### PR TITLE
fix help message in script & fix invalid param name (#32)

### DIFF
--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -190,7 +190,7 @@ unsafe fn run_squat(boma: &mut BattleObjectModuleAccessor, status_kind: i32, sti
 unsafe fn glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, facing: f32) {
     if boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_F, *FIGHTER_STATUS_KIND_ESCAPE_B])
     {
-        let max_ditcit_frame = ParamModule::get_float(boma.object(), ParamType::Common, "ditcit_frame");
+        let max_ditcit_frame = ParamModule::get_float(boma.object(), ParamType::Common, "glide_toss_cancel_frame");
         VarModule::set_flag(boma.object(), vars::common::CAN_GLIDE_TOSS, MotionModule::frame(boma) <= max_ditcit_frame);
         return;
     }

--- a/scripts/new_fighter_param.py
+++ b/scripts/new_fighter_param.py
@@ -10,7 +10,7 @@ path = pathlib.Path(__file__).parent.parent.resolve()
 romfs_src_path = path.joinpath("romfs/source")
 
 if len(sys.argv) < 2:
-    print('new_fighter_param.py <param_name> -t <param_type> -d <default_value> <param_name>')
+    print('new_fighter_param.py -t <param_type> -d <default_value> <param_name>')
     sys.exit(2)
 
 try:


### PR DESCRIPTION
Resolves the invalid usage of param name `ditcit_frame` instead of `glide_toss_cancel_frame`. Resolves #32 