### PR TITLE
Resolve import issues for shotos, dark samus, bayonetta, icies, peach

### DIFF
--- a/fighters/common/src/djc.rs
+++ b/fighters/common/src/djc.rs
@@ -4,8 +4,8 @@ use globals::*;
 
 pub fn install() {
     smashline::install_hooks!(
-        sub_attack_air_inherit_jump_aerial_motion_uniq_process_init,
-        sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec
+        sub_attack_air_inherit_jump_aerial_motion_uniq_process_init_impl,
+        sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec_impl
     );
 }
 
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn attack_air_main_status_loop(fighter: &mut L2CFighterCom
 // TAGS: DJC, Double Jump Cancel, FIGHTER_STATUS_KIND_ATTACK_AIR
 /// Inherits the double jump animation movement when doing an aerial (init)
 #[smashline::hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon59sub_attack_air_inherit_jump_aerial_motion_uniq_process_initEv")]
-pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_init_impl(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
         call_original!(fighter)
     } else {
@@ -71,10 +71,17 @@ pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_
     }
 }
 
+#[utils::export(common::djc)]
+fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    unsafe {
+        sub_attack_air_inherit_jump_aerial_motion_uniq_process_init_impl(fighter) 
+    }
+}
+
 // TAGS: DJC, Double Jump Cancel, FIGHTER_STATUS_KIND_ATTACK_AIR
 /// Inherits the double jump animation movement when doing an aerial (exec)
 #[smashline::hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon59sub_attack_air_inherit_jump_aerial_motion_uniq_process_execEv")]
-pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
+pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec_impl(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_AERIAL
     && fighter.global_table[FIGHTER_KIND] != FIGHTER_KIND_DEMON
     && fighter.global_table[CURRENT_FRAME].get_i32() <= dbg!(ParamModule::get_int(fighter.battle_object, ParamType::Common, "djc_leniency_frame"))
@@ -82,4 +89,11 @@ pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
     }
     call_original!(fighter)
+}
+
+#[utils::export(common::djc)]
+fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
+    unsafe {
+        sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec_impl(fighter)
+    }
 }

--- a/fighters/common/src/general_statuses/attack.rs
+++ b/fighters/common/src/general_statuses/attack.rs
@@ -20,7 +20,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 }
 
 
-
+#[no_mangle]
 pub unsafe extern "Rust" fn only_jabs(fighter: &mut L2CFighterCommon) -> bool {
     return !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON)
     && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CATCH)

--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -23,6 +23,7 @@ pub mod opff;
 pub mod misc;
 pub mod general_statuses;
 pub mod function_hooks;
+pub mod shoto_status;
 
 pub fn install() {
     djc::install();

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -19,7 +19,7 @@ pub mod cancels;
 pub mod var_resets;
 pub mod gentleman;
 pub mod momentum_transfer_line;
-//pub mod shotos;
+pub mod shotos;
 //pub mod magic;
 pub mod gimmick;
 pub mod floats;

--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -1,8 +1,5 @@
-use utils::{
-    *,
-    ext::*,
-    consts::*
-};
+use super::*;
+use smash::app::BattleObjectModuleAccessor;
 
 // Dtilt and Utilt repeat increment
 unsafe fn dtilt_utilt_repeat_increment(boma: &mut BattleObjectModuleAccessor) {

--- a/fighters/common/src/shoto_status.rs
+++ b/fighters/common/src/shoto_status.rs
@@ -20,7 +20,7 @@ use globals::*;
 
 // FIGHTER_RYU_STATUS_KIND_DASH_BACK (it's the same for theo ther fgc char statuses) //
 
-#[utils::export(shoto_status::fgc_pre_dashback)]
+#[utils::export(common::shoto_status)]
 pub unsafe fn fgc_pre_dashback(fighter: &mut L2CFighterCommon) {
     let ground_brake = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
 	let mut initial_speed = VarModule::get_float(fighter.battle_object, vars::common::CURR_DASH_SPEED);
@@ -39,7 +39,7 @@ pub unsafe fn fgc_pre_dashback(fighter: &mut L2CFighterCommon) {
     VarModule::set_float(fighter.battle_object, vars::common::CURR_DASH_SPEED, initial_speed);
 }
 
-
+#[no_mangle]
 pub unsafe extern "Rust" fn fgc_dashback_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     MotionModule::change_motion(fighter.module_accessor, Hash40::new("dash_b"), 0.0, 1.0, false, 0.0, false, false);
     fighter.status_DashCommon();
@@ -376,7 +376,7 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
     // 0.into()
 }
 
-#[utils::export(shoto_status::fgc_end_dashback)]
+#[utils::export(common::shoto_status)]
 pub unsafe fn fgc_end_dashback(fighter: &mut L2CFighterCommon) {
     let ground_brake = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
 	let mut initial_speed = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN);
@@ -448,6 +448,7 @@ pub unsafe fn fgc_end_dashback(fighter: &mut L2CFighterCommon) {
 	// println!("end dash total speed: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL));
 }
 
+#[no_mangle]
 pub unsafe extern "Rust" fn ryu_attack_main_uniq_chk(fighter: &mut L2CFighterCommon) -> L2CValue {
     if !StatusModule::is_changing(fighter.module_accessor) {
         let combo_count = ComboModule::count(fighter.module_accessor) as i32;
@@ -466,6 +467,7 @@ pub unsafe extern "Rust" fn ryu_attack_main_uniq_chk(fighter: &mut L2CFighterCom
 }
 
 
+#[no_mangle]
 pub unsafe extern "C" fn ryu_attack_main_uniq_chk2(fighter: &mut L2CFighterCommon, mot1: L2CValue, mot2: L2CValue) {
     ryu_attack_main_uniq_chk3(fighter);
     fighter.attack_mtrans_pre_process();
@@ -489,7 +491,7 @@ pub unsafe extern "C" fn ryu_attack_main_uniq_chk2(fighter: &mut L2CFighterCommo
     }
 }
 
-#[utils::export(shoto_status::ryu_attack_main_uniq_chk3)]
+#[utils::export(common::shoto_status)]
 unsafe extern "C" fn ryu_attack_main_uniq_chk3(fighter: &mut L2CFighterCommon) {
     WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_RYU_STATUS_ATTACK_INT_BUTTON_ON_FRAME);
     WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_RYU_STATUS_ATTACK_INT_FRAME);
@@ -664,6 +666,7 @@ pub unsafe extern "Rust" fn ryu_hit_cancel(fighter: &mut L2CFighterCommon, situa
     val.into()
 }
 
+#[no_mangle]
 pub unsafe extern "Rust" fn ryu_kara_cancel(fighter: &mut L2CFighterCommon) -> L2CValue {
     let val;
     let special_n_command = WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
@@ -704,7 +707,7 @@ pub unsafe extern "Rust" fn ryu_kara_cancel(fighter: &mut L2CFighterCommon) -> L
 //     }
 // }
 
-#[utils::export(shoto_status::ryu_idkwhatthisis2)]
+#[utils::export(common::shoto_status)]
 pub unsafe extern "C" fn ryu_idkwhatthisis2(fighter: &mut L2CFighterCommon) {
     if !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_ATTACK) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_RYU_STATUS_ATTACK_FLAG_RELEASE_BUTTON);

--- a/fighters/popo/src/status.rs
+++ b/fighters/popo/src/status.rs
@@ -8,7 +8,7 @@ pub fn install() {
     );
 }
 
-#[utils::export(popo::ics_dash)]
+#[utils::export(popo)]
 pub unsafe fn ics_dash(fighter: &mut L2CFighterCommon) -> L2CValue {
     fighter.status_Dash_Sub();
     fighter.sub_shift_status_main(L2CValue::Ptr(ics_dash_main as *const () as _))

--- a/fighters/samusd/src/opff.rs
+++ b/fighters/samusd/src/opff.rs
@@ -26,7 +26,7 @@ unsafe fn frame_data(boma: &mut BattleObjectModuleAccessor, status_kind: i32, mo
 
 // symbol-based call for the samus' common opff
 extern "Rust" {
-    fn samus_common(fighter: &mut smash::lua2cpp::L2CFighterCommon);
+    fn common_samus(fighter: &mut smash::lua2cpp::L2CFighterCommon);
 }
 
 
@@ -35,7 +35,7 @@ pub fn samusd_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
 		samusd_frame(fighter);
-        samus_common(fighter);
+        common_samus(fighter);
     }
 }
 


### PR DESCRIPTION
Shotos needed to import the `common::shotos_status` exports and `only_jab`, Bayonetta needed `only_jab`, and Dark Samus needed the import renamed from `samus_common` to `common_samus`.

This resolves issues #52 #51 #47 