### PR TITLE
Green Missile Rework

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -223,6 +223,24 @@ pub mod vars {
         pub use super::shotos::*;
     }
 
+    pub mod luigi {
+        // flag
+        /// This flag stores whether or not Luigi currently has a misfire stored.
+        pub const IS_MISFIRE_STORED: i32 = 0x1000;
+        
+        // int
+        /// This int stores the number of remaining green missile's luigi must do before getting a misfire
+        pub const REMAINING_SPECIAL_S_UNTIL_MISFIRE: i32 = 0x1000;
+        /// This int stores the handle of the charge smoke effect for killing it if we store misfire
+        pub const CHARGE_SMOKE_EFFECT_HANDLE: i32 = 0x1001;
+        /// This int stores the handle of the pulsing effect for killing it if we store misfire
+        pub const CHARGE_PULSE_EFFECT_HANDLE: i32 = 0x1002;
+
+        // float
+        /// This float holds the current multiplier on damage for misfire
+        pub const MISFIRE_DAMAGE_MULTIPLIER: i32 = 0x1000;
+    }
+
     pub mod mario {
         // flags
         pub const FIREBRAND_SPAWNED: i32 = 0x1000;

--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -107,7 +107,8 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
         */
 
         //Sword trails
-        if VarModule::is_flag(boma.object(), vars::roy::TRAIL_EFFECT) {
+        if (boma.kind() == *FIGHTER_KIND_ROY || boma.kind() == *FIGHTER_KIND_CHROM) 
+        && VarModule::is_flag(boma.object(), vars::roy::TRAIL_EFFECT) {
             EffectModule::kill_joint_id(boma, Hash40::new("sword1"), false, false);
             if fighter_kind == *FIGHTER_KIND_ROY {
                 EffectModule::req_follow(boma, Hash40::new("roy_fire_small"), Hash40::new("sword1"), &Vector3f{x: 0.0, y: 0.0, z: 0.0}, &Vector3f{x: 0.0, y: 0.0, z: 0.0}, 1.0, false, 0, 0, 0, 0, 0, false, false);

--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -176,7 +176,7 @@ unsafe fn effect_specialshold(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
         let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
-        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
+        VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
             LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.8, 0.0);
         }
@@ -185,7 +185,7 @@ unsafe fn effect_specialshold(fighter: &mut L2CAgentBase) {
         if is_excute(fighter) {
             FOOT_EFFECT(fighter, Hash40::new("sys_dash_smoke"), Hash40::new("top"), -5, 0, 0, 0, 0, 0, 1, 10, 00, 4, 0, 0, 0, false);
             let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
-            VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, handle as i32);
+            VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_SMOKE_EFFECT_HANDLE, handle as i32);
             if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
                 LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.7, 0.3);
             }
@@ -201,7 +201,7 @@ unsafe fn effect_specialairshold(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
         let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
-        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
+        VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
             LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.8, 0.0);
         }
@@ -211,8 +211,8 @@ unsafe fn effect_specialairshold(fighter: &mut L2CAgentBase) {
 #[acmd_script(agent = "luigi", script = "game_specialsdischarge", category = ACMD_GAME)]
 unsafe fn game_specialsdischarge(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
-    let misfire_multiplier = VarModule::get_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO);
-    VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, 1.0);
+    let misfire_multiplier = VarModule::get_float(fighter.battle_object, vars::luigi::MISFIRE_DAMAGE_MULTIPLIER);
+    VarModule::set_float(fighter.battle_object, vars::luigi::MISFIRE_DAMAGE_MULTIPLIER, 1.0);
     frame(lua_state, 4.0);
     if is_excute(fighter) {
         SA_SET(fighter, *SITUATION_KIND_AIR);

--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -169,12 +169,111 @@ unsafe fn game_specialairlw(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script(agent = "luigi", script = "effect_specialshold", category = ACMD_EFFECT)]
+unsafe fn effect_specialshold(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
+        let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
+        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
+            LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.8, 0.0);
+        }
+    }
+    for _ in 0..100 {
+        if is_excute(fighter) {
+            FOOT_EFFECT(fighter, Hash40::new("sys_dash_smoke"), Hash40::new("top"), -5, 0, 0, 0, 0, 0, 1, 10, 00, 4, 0, 0, 0, false);
+            let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
+            VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, handle as i32);
+            if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
+                LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.7, 0.3);
+            }
+        }
+        wait(lua_state, 10.0);
+    }
+}
+
+#[acmd_script(agent = "luigi", script = "effect_specialairshold", category = ACMD_EFFECT)]
+unsafe fn effect_specialairshold(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
+        let handle = EffectModule::get_last_handle(fighter.module_accessor) as u32;
+        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, handle as i32);
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE) {
+            LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.8, 0.0);
+        }
+    }
+}
+
+#[acmd_script(agent = "luigi", script = "game_specialsdischarge", category = ACMD_GAME)]
+unsafe fn game_specialsdischarge(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let misfire_multiplier = VarModule::get_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO);
+    VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, 1.0);
+    frame(lua_state, 4.0);
+    if is_excute(fighter) {
+        SA_SET(fighter, *SITUATION_KIND_AIR);
+        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_LUIGI_SPECIAL_S_RAM);
+        CORRECT(fighter, *GROUND_CORRECT_KIND_AIR);
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("neck"), 25.0 * misfire_multiplier, 361, 100, 0, 20, 5.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 4, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_HEAD);
+        AttackModule::set_attack_keep_rumble(fighter.module_accessor, 0, true);
+        JostleModule::set_status(fighter.module_accessor, false);
+    }
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_RAM_FLAG_GROUND_CHECK);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("neck"), 25.0 * misfire_multiplier, 361, 100, 0, 20, 5.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 4, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_HEAD);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_RAM_TRANSITION_TERM_ID_GROUND);
+    }
+    frame(lua_state, 29.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_RAM_FLAG_BRAKE);
+    }
+}
+
+#[acmd_script(agent = "luigi", script = "effect_specialsdischarge", category = ACMD_EFFECT)]
+unsafe fn effect_specialsdischarge(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("luigi_rocket_bomb"), Hash40::new("top"), 0, 4, 0, 0, 0, 0, 1.2, 0, 0, 0, 0, 0, 0, true);
+        LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.8, 0.0);
+    }
+
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_dash_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("luigi_rocket_jet2"), Hash40::new("top"), 0, 4, 4, 0, 0, 0, 1, true);
+        LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.7, 0.3);
+        EffectModule::enable_sync_init_pos_last(fighter.module_accessor);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         game_specialn,
         game_specialairn,
         game_speciallw,
         game_specialairlw,
+        game_specialsdischarge,
+
+        effect_specialshold,
+        effect_specialairshold,
+        effect_specialsdischarge
     );
 }
 

--- a/fighters/luigi/src/lib.rs
+++ b/fighters/luigi/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -20,7 +20,9 @@ use smash::{
         lua_bind::*
     },
     hash40,
-    lib::lua_const::*,
+    lib::{
+        lua_const::*
+    },
     lua2cpp::*,
     phx::*
 };
@@ -36,8 +38,37 @@ use utils::{
 };
 use smashline::*;
 
+pub const REMAINING_SPECIAL_S_UNTIL_MISFIRE: i32 = 0x1000;
+pub const CHARGE_SMOKE_EFFECT_HANDLE: i32 = 0x1001;
+pub const CHARGE_PULSE_EFFECT_HANDLE: i32 = 0x1002;
+
+pub const IS_MISFIRE_STORED: i32 = 0x1000;
+pub const MISFIRE_DAMAGE_RATIO: i32 = 0x1000;
+
+#[smashline::fighter_reset]
+fn luigi_reset(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        if fighter.kind() != *FIGHTER_KIND_LUIGI {
+            return;
+        }
+    
+        VarModule::off_flag(fighter.battle_object, IS_MISFIRE_STORED);
+        VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, 1.0);
+        VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1);
+        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+        calculate_misfire_number(fighter);
+    }
+}
+
+pub fn calculate_misfire_number(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        VarModule::set_int(fighter.battle_object, REMAINING_SPECIAL_S_UNTIL_MISFIRE, app::sv_math::rand(hash40("fighter"), 8))
+    }
+}
+
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
+    smashline::install_agent_resets!(luigi_reset);
 }

--- a/fighters/luigi/src/lib.rs
+++ b/fighters/luigi/src/lib.rs
@@ -38,13 +38,6 @@ use utils::{
 };
 use smashline::*;
 
-pub const REMAINING_SPECIAL_S_UNTIL_MISFIRE: i32 = 0x1000;
-pub const CHARGE_SMOKE_EFFECT_HANDLE: i32 = 0x1001;
-pub const CHARGE_PULSE_EFFECT_HANDLE: i32 = 0x1002;
-
-pub const IS_MISFIRE_STORED: i32 = 0x1000;
-pub const MISFIRE_DAMAGE_RATIO: i32 = 0x1000;
-
 #[smashline::fighter_reset]
 fn luigi_reset(fighter: &mut L2CFighterCommon) {
     unsafe {
@@ -52,17 +45,17 @@ fn luigi_reset(fighter: &mut L2CFighterCommon) {
             return;
         }
     
-        VarModule::off_flag(fighter.battle_object, IS_MISFIRE_STORED);
-        VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, 1.0);
-        VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1);
-        VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+        VarModule::off_flag(fighter.battle_object, vars::luigi::IS_MISFIRE_STORED);
+        VarModule::set_float(fighter.battle_object, vars::luigi::MISFIRE_DAMAGE_MULTIPLIER, 1.0);
+        VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_SMOKE_EFFECT_HANDLE, -1);
+        VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE, -1);
         calculate_misfire_number(fighter);
     }
 }
 
 pub fn calculate_misfire_number(fighter: &mut L2CFighterCommon) {
     unsafe {
-        VarModule::set_int(fighter.battle_object, REMAINING_SPECIAL_S_UNTIL_MISFIRE, app::sv_math::rand(hash40("fighter"), 8))
+        VarModule::set_int(fighter.battle_object, vars::luigi::REMAINING_SPECIAL_S_UNTIL_MISFIRE, app::sv_math::rand(hash40("fighter"), 8))
     }
 }
 

--- a/fighters/luigi/src/opff.rs
+++ b/fighters/luigi/src/opff.rs
@@ -21,7 +21,7 @@ pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i3
 pub fn luigi_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
-		luigi_frame(fighter)
+		luigi_frame(fighter);
     }
 }
 

--- a/fighters/luigi/src/status.rs
+++ b/fighters/luigi/src/status.rs
@@ -3,10 +3,10 @@ use super::*;
 #[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
 unsafe fn special_s_charge_init(fighter: &mut L2CFighterCommon) -> L2CValue {
     if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_INSTANCE_WORK_ID_FLAG_SPECIAL_S_CHARGE_MELEE_NO_RANDOM) {
-        let should_do_effect = if VarModule::is_flag(fighter.battle_object, IS_MISFIRE_STORED) {
-            VarModule::off_flag(fighter.battle_object, IS_MISFIRE_STORED);
+        let should_do_effect = if VarModule::is_flag(fighter.battle_object, vars::luigi::IS_MISFIRE_STORED) {
+            VarModule::off_flag(fighter.battle_object, vars::luigi::IS_MISFIRE_STORED);
             true
-        } else if VarModule::countdown_int(fighter.battle_object, REMAINING_SPECIAL_S_UNTIL_MISFIRE, 0) {
+        } else if VarModule::countdown_int(fighter.battle_object, vars::luigi::REMAINING_SPECIAL_S_UNTIL_MISFIRE, 0) {
             super::calculate_misfire_number(fighter);
             true
         } else {
@@ -76,19 +76,19 @@ unsafe extern "C" fn special_s_charge_main_loop(fighter: &mut L2CFighterCommon) 
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE)
         && fighter.global_table[globals::CURRENT_FRAME].get_i32() >= 3
         && fighter.is_button_on(Buttons::Guard | Buttons::GuardHold) {
-            VarModule::on_flag(fighter.battle_object, IS_MISFIRE_STORED);
-            let mult = VarModule::get_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO);
-            VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, (mult * 0.95).max(0.8));
+            VarModule::on_flag(fighter.battle_object, vars::luigi::IS_MISFIRE_STORED);
+            let mult = VarModule::get_float(fighter.battle_object, vars::luigi::MISFIRE_DAMAGE_MULTIPLIER);
+            VarModule::set_float(fighter.battle_object, vars::luigi::MISFIRE_DAMAGE_MULTIPLIER, (mult * 0.95).max(0.8));
             WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE);
-            let smoke_eff = VarModule::get_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE);
-            let pulse_eff = VarModule::get_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE);
+            let smoke_eff = VarModule::get_int(fighter.battle_object, vars::luigi::CHARGE_SMOKE_EFFECT_HANDLE);
+            let pulse_eff = VarModule::get_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE);
             if smoke_eff != -1 {
                 EffectModule::kill(fighter.module_accessor, smoke_eff as u32, true, true);
-                VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1);
+                VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_SMOKE_EFFECT_HANDLE, -1);
             }
             if pulse_eff != -1 {
                 EffectModule::kill(fighter.module_accessor, pulse_eff as u32, true, true);
-                VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+                VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE, -1);
                 EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
             }
         }
@@ -100,8 +100,8 @@ unsafe extern "C" fn special_s_charge_main_loop(fighter: &mut L2CFighterCommon) 
 
 #[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe fn special_s_charge_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1); 
-    VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+    VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_SMOKE_EFFECT_HANDLE, -1); 
+    VarModule::set_int(fighter.battle_object, vars::luigi::CHARGE_PULSE_EFFECT_HANDLE, -1);
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_BONUS) {
         WorkModule::set_float(fighter.module_accessor, WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_bonus")), *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
     } else {

--- a/fighters/luigi/src/status.rs
+++ b/fighters/luigi/src/status.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+#[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+unsafe fn special_s_charge_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_INSTANCE_WORK_ID_FLAG_SPECIAL_S_CHARGE_MELEE_NO_RANDOM) {
+        let should_do_effect = if VarModule::is_flag(fighter.battle_object, IS_MISFIRE_STORED) {
+            VarModule::off_flag(fighter.battle_object, IS_MISFIRE_STORED);
+            true
+        } else if VarModule::countdown_int(fighter.battle_object, REMAINING_SPECIAL_S_UNTIL_MISFIRE, 0) {
+            super::calculate_misfire_number(fighter);
+            true
+        } else {
+            false
+        };
+        if should_do_effect {
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE);
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FLASHING);
+            EffectModule::req_common(fighter.module_accessor, Hash40::new("charge_max"), 0.0) as u32;
+        }
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_s_charge_uniq_process(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let charge = WorkModule::get_float(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+    let charge_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_frame"));
+
+    if charge_frame <= charge {
+        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FLASHING) {
+            EffectModule::req_common(fighter.module_accessor, Hash40::new("charge_max"), 0.0);
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FLASHING);
+        }
+        MotionModule::set_rate(fighter.module_accessor, 0.0);
+    }
+
+    WorkModule::add_float(fighter.module_accessor, WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_speed_mul")), *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+    0.into()
+}
+
+unsafe fn special_s_charge_motion_check(fighter: &mut L2CFighterCommon) {
+    let (kinetic, gc_kind, motion, mtrans) = if fighter.global_table[globals::SITUATION_KIND] == SITUATION_KIND_GROUND {
+        (*FIGHTER_KINETIC_TYPE_GROUND_STOP, app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP_ATTACK), Hash40::new("special_s_hold"), *SITUATION_KIND_AIR)
+    } else {
+        (*FIGHTER_KINETIC_TYPE_AIR_STOP, app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR), Hash40::new("special_air_s_hold"), *SITUATION_KIND_GROUND)
+    };
+    KineticModule::change_kinetic(fighter.module_accessor, kinetic);
+    GroundModule::correct(fighter.module_accessor, gc_kind);
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FIRST) {
+        MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
+    } else {
+        MotionModule::change_motion(fighter.module_accessor, motion, 0.0, 1.0, false, 0.0, false, false);
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FIRST);
+    }
+    let charge = WorkModule::get_float(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+    let charge_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_frame"));
+    if charge_frame <= charge {
+        MotionModule::set_rate(fighter.module_accessor, 0.0);
+    }
+    WorkModule::set_int(fighter.module_accessor, mtrans, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_INT_MTRANS);
+}
+
+unsafe extern "C" fn special_s_charge_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !fighter.is_button_off(Buttons::Special) {
+        let charge = WorkModule::get_float(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+        let charge_frame_max = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_frame_max"));
+        if charge_frame_max <= charge && fighter.is_situation(*SITUATION_KIND_GROUND) {
+            fighter.change_status(FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_BREATH.into(), false.into());
+            return 0.into();
+        }
+        if !StatusModule::is_changing(fighter.module_accessor) {
+            let mtrans = WorkModule::get_int(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_INT_MTRANS);
+            if mtrans != fighter.global_table[globals::PREV_SITUATION_KIND].get_i32() && mtrans == fighter.global_table[globals::SITUATION_KIND].get_i32() {
+                special_s_charge_motion_check(fighter);
+            }
+        }
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE)
+        && fighter.global_table[globals::CURRENT_FRAME].get_i32() >= 3
+        && fighter.is_button_on(Buttons::Guard | Buttons::GuardHold) {
+            VarModule::on_flag(fighter.battle_object, IS_MISFIRE_STORED);
+            let mult = VarModule::get_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO);
+            VarModule::set_float(fighter.battle_object, MISFIRE_DAMAGE_RATIO, (mult * 0.95).max(0.8));
+            WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_DISCHARGE);
+            let smoke_eff = VarModule::get_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE);
+            let pulse_eff = VarModule::get_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE);
+            if smoke_eff != -1 {
+                EffectModule::kill(fighter.module_accessor, smoke_eff as u32, true, true);
+                VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1);
+            }
+            if pulse_eff != -1 {
+                EffectModule::kill(fighter.module_accessor, pulse_eff as u32, true, true);
+                VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+                EFFECT_FOLLOW(fighter, Hash40::new("luigi_rocket_hold"), Hash40::new("top"), 0, 6, 0,  0, 1, 0, 1, true);
+            }
+        }
+    } else {
+        fighter.change_status(FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_RAM.into(), true.into());
+    }
+    0.into()
+}
+
+#[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn special_s_charge_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::set_int(fighter.battle_object, CHARGE_SMOKE_EFFECT_HANDLE, -1); 
+    VarModule::set_int(fighter.battle_object, CHARGE_PULSE_EFFECT_HANDLE, -1);
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_BONUS) {
+        WorkModule::set_float(fighter.module_accessor, WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("charge_bonus")), *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+    } else {
+        WorkModule::set_float(fighter.module_accessor, 0.0, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_WORK_FLOAT_CHARGE);
+    }
+
+    if !StopModule::is_stop(fighter.module_accessor) {
+        special_s_charge_uniq_process(fighter);
+    }
+    special_s_charge_motion_check(fighter);
+    fighter.global_table[globals::SUB_STATUS2].assign(&L2CValue::Ptr(special_s_charge_uniq_process as *const () as _));
+    fighter.main_shift(special_s_charge_main_loop)
+}
+
+#[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn special_s_charge_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    EffectModule::remove_common(fighter.module_accessor, Hash40::new("charge_max"));
+    0.into()
+}
+
+#[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+unsafe fn special_s_charge_exit(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_CHARGE_FLAG_FLASHING);
+    0.into()
+}
+
+pub fn install() {
+    smashline::install_status_scripts!(
+        special_s_charge_init,
+        special_s_charge_main,
+        special_s_charge_end,
+        special_s_charge_exit
+    );
+}


### PR DESCRIPTION
This resolves #56 and resolves #57 

Basically, gives Luigi a better/more predictable misfire and misfire storage.

Currently, Luigi's misfire is calculated at the end of the charge, before the launch, with a probability of 1/8.

However, you were not guaranteed to get a misfire once out of every 8 usages. Now, the misfire has the following behavior:
* At the beginning of a match (or a training mode reset), a random number in the range [0, 7] (inclusive) is generated. This number designates how many more Green Missiles he must perform before getting a misfire. Misfires that go past their time limit and result in Luigi panting also count towards this number.
* When Luigi is going to perform a misfire, the charge effects will be green, as shown:
![image](https://user-images.githubusercontent.com/42755519/151686730-42454da0-a8a4-46bd-b4ec-b5818efd1c53.png)
* During a misfire charge, if you press either guard (shield), or guard hold (shield lock), the misfire will be stored and the effects will be replaced by regular charge effects. Every time you store a misfire, the damage multiplier for misfire is decreased by the following formula: `max_damage = 25.0 * max(0.95^x, 0.8)`, where `x` is the number of times you have stored the same misfire, and `0.8` is the lower bound, meaning you can never go below `80%` of the max damage (25.0). This is also scaled later on by how long you held the misfire for.
* Misfire storage lasts across deaths.
* Misfire has green effects for all of the missile part of the move, including green smoke trail
* The green effects will show for a minimum of 3 frames. After the third frame, if you are pressing shield then it will be stored. This cannot be accidentally tap buffered, it checks the raw button input after the third frame.
* Here is a video in action:



https://user-images.githubusercontent.com/42755519/151686799-6c46ea66-e3ba-4936-818c-ecb60da5c24b.mp4

