### PR TITLE
Automatic Nightly/Beta Updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
     # build the project
     - run: |
-        PATH=$PATH:/root/.cargo/bin && export HDR_VERSION="${{ steps.version.outputs.version_string }}" && cd scripts && python3 make_dist.py release && cd ..
+        PATH=$PATH:/root/.cargo/bin && export HDR_VERSION="${{ steps.version.outputs.version_string }}" && cd scripts && python3 make_dist.py publish && cd ..
       env:
         HOME: /root
     - name: Upload hdr-switch artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
     # build the project
     - run: |
-        export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin && export HDR_VERSION="${{ steps.version.outputs.version_string }}" && cd scripts && python3 make_dist.py release && cd ..
+        export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin && export HDR_VERSION="${{ steps.version.outputs.version_string }}" && cd scripts && python3 make_dist.py publish && cd ..
       env:
         HOME: /root
     - name: Upload hdr-switch artifact

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -15,6 +15,14 @@ skyline = { git = "https://github.com/ultimate-research/skyline-rs.git" }
 smashline = { git = "https://github.com/blu-dev/smashline" }
 utils = { path = "../utils" }
 fighters = { path = "../fighters" }
+semver = "1"
+zip = { version = "0.5", default-features = false, features = ["deflate"] }
+gh-updater = { git = "https://github.com/blu-dev/gh-updater" }
+skyline-web = { git = "https://github.com/skyline-rs/skyline-web" }
+
+[patch.crates-io]
+ring = { git = "https://github.com/skyline-rs/ring", branch = "0.16.20" }
+webpki = { git = "https://github.com/skyline-rs/webpki" }
 
 [features]
 default = ["pitb","eflame","pfushigisou","purin","younglink","plizardon","shulk","chrom","miifighter","gamewatch","krool","samusd","ryu","rosetta","yoshi","lucas","link","lucario","zelda","kamui","wolf","nana","tantan","koopag","ridley","gekkouga","ike","roy","rockman","peach","elight","gaogaen","falco","ness","kirby","pikachu","daisy","sheik","mariod","luigi","captain","mario","jack","palutena","dolly","pickel","wiifit","pzenigame","pichu","pit","ken","brave","richter","miiswordsman","robin","master","robot","szerosuit","ganon","wario","diddy","shizue","littlemac","pacman","edge","marth","trail","mewtwo","metaknight","toonlink","koopajr","sonic","donkey","inkling","packun","miigunner","buddy","pikmin","cloud","fox","duckhunt","lucina","murabito","bayonetta","samus","koopa","simon","popo","dedede","snake","demon"]

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -15,10 +15,10 @@ skyline = { git = "https://github.com/ultimate-research/skyline-rs.git" }
 smashline = { git = "https://github.com/blu-dev/smashline" }
 utils = { path = "../utils" }
 fighters = { path = "../fighters" }
-semver = "1"
-zip = { version = "0.5", default-features = false, features = ["deflate"] }
-gh-updater = { git = "https://github.com/blu-dev/gh-updater" }
-skyline-web = { git = "https://github.com/skyline-rs/skyline-web" }
+semver = { version = "1", optional = true }
+zip = { version = "0.5", default-features = false, features = ["deflate"], optional = true }
+gh-updater = { git = "https://github.com/blu-dev/gh-updater", optional = true }
+skyline-web = { git = "https://github.com/skyline-rs/skyline-web", optional = true }
 
 [patch.crates-io]
 ring = { git = "https://github.com/skyline-rs/ring", branch = "0.16.20" }
@@ -28,6 +28,7 @@ webpki = { git = "https://github.com/skyline-rs/webpki" }
 default = ["pitb","eflame","pfushigisou","purin","younglink","plizardon","shulk","chrom","miifighter","gamewatch","krool","samusd","ryu","rosetta","yoshi","lucas","link","lucario","zelda","kamui","wolf","nana","tantan","koopag","ridley","gekkouga","ike","roy","rockman","peach","elight","gaogaen","falco","ness","kirby","pikachu","daisy","sheik","mariod","luigi","captain","mario","jack","palutena","dolly","pickel","wiifit","pzenigame","pichu","pit","ken","brave","richter","miiswordsman","robin","master","robot","szerosuit","ganon","wario","diddy","shizue","littlemac","pacman","edge","marth","trail","mewtwo","metaknight","toonlink","koopajr","sonic","donkey","inkling","packun","miigunner","buddy","pikmin","cloud","fox","duckhunt","lucina","murabito","bayonetta","samus","koopa","simon","popo","dedede","snake","demon"]
 dev = ["utils/no-offset-search"]
 runtime = ["fighters/ignore-common", "fighters/runtime"]
+updater = ["semver", "zip", "gh-updater", "skyline-web"]
 pitb = ["fighters/include-pitb"]
 eflame = ["fighters/include-eflame"]
 pfushigisou = ["fighters/include-pfushigisou"]

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -3,6 +3,8 @@
 
 use skyline::libc::c_char;
 
+mod updater;
+
 #[smashline::installer]
 pub fn install() {
     fighters::install();
@@ -33,6 +35,14 @@ pub fn main() {
     #[cfg(not(feature = "runtime"))]
     { utils::init(); }
     fighters::install();
+
+    std::thread::Builder::new()
+        .stack_size(0x40_0000)
+        .spawn(|| {
+            updater::check_for_updates();
+        })
+        .unwrap()
+        .join();
 
     skyline::install_hook!(change_version_string_hook);
 }

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -3,6 +3,7 @@
 
 use skyline::libc::c_char;
 
+#[cfg(feature = "updater")]
 mod updater;
 
 #[smashline::installer]
@@ -36,13 +37,16 @@ pub fn main() {
     { utils::init(); }
     fighters::install();
 
-    std::thread::Builder::new()
-        .stack_size(0x40_0000)
-        .spawn(|| {
-            updater::check_for_updates();
-        })
-        .unwrap()
-        .join();
+    #[cfg(feature = "updater")]
+    {
+        std::thread::Builder::new()
+            .stack_size(0x40_0000)
+            .spawn(|| {
+                updater::check_for_updates();
+            })
+            .unwrap()
+            .join();
+    }
 
     skyline::install_hook!(change_version_string_hook);
 }

--- a/plugin/src/updater.rs
+++ b/plugin/src/updater.rs
@@ -1,0 +1,124 @@
+use std::{path::Path, io::Cursor};
+
+use gh_updater::ReleaseFinderConfig;
+use semver::Version;
+use zip::ZipArchive;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum WhichVersion {
+    Current,
+    Release,
+    Prerelease
+}
+
+fn get_version(current: &Version, release: Option<&Version>, prerelease: Option<&Version>) -> WhichVersion {
+    if !current.pre.is_empty() {
+        if let Some(prerelease) = prerelease {
+            if current != prerelease {
+                WhichVersion::Prerelease
+            } else {
+                WhichVersion::Current
+            }
+        } else {
+            WhichVersion::Current
+        }
+    } else {
+        if let Some(release) = release {
+            if current != release {
+                WhichVersion::Release
+            } else {
+                WhichVersion::Current
+            }
+        } else {
+            WhichVersion::Current
+        }
+    }
+}
+
+pub fn check_for_updates() {
+    if Path::new("sd:/ryujinx.txt").exists() {
+        println!("Auto updater exiting as Ryujinx was encountered.");
+        return;
+    }
+
+    let release = ReleaseFinderConfig::new("HewDraw-Remix")
+        .with_author("HDR-Development")
+        .with_repository("HewDraw-Remix")
+        .with_prereleases(true)
+        .find_release();
+    
+    let (release, prerelease) = match release {
+        Ok(r) => r,
+        Err(e) => {
+            println!("HDR failed to check for updates: {:?}", e);
+            return;
+        }
+    };
+
+    // Get the current version
+    let current_version = Version::parse(env!("CARGO_PKG_VERSION").trim_start_matches("v")).unwrap();
+
+    // Get the release version after getting rid of everything before the "v" (SemVer comes after "v")
+    let release_version = release
+        .as_ref()
+        .map(|x| x.get_release_tag().split("v").last())
+        .flatten()
+        .map(|x| Version::parse(x).ok())
+        .flatten();
+
+    // Get the prerelease version after getting rid of everything before the "v" (SemVer comes after "v")
+    let prerelease_version = prerelease
+        .as_ref()
+        .map(|x| x.get_release_tag().split("v").last())
+        .flatten()
+        .map(|x| Version::parse(x).ok())
+        .flatten();
+
+    // Don't bother updating if we are a dev build because it's in development
+    if current_version.pre.as_str() == "dev" {
+        return;
+    }
+    
+    // get which version to update to and get the asset
+    let ver = get_version(&current_version, release_version.as_ref(), prerelease_version.as_ref());
+
+    // prompt user if they want to update
+    let should_update = match ver {
+        WhichVersion::Prerelease => skyline_web::Dialog::yes_no("A new version of HDR (nightly) was encountered.<br>Do you want to install it?"),
+        WhichVersion::Release => skyline_web::Dialog::yes_no("A new version of HDR was encountered.<br>Do you want to install it?"),
+        WhichVersion::Current => return,
+    };
+
+    if !should_update {
+        return;
+    }
+
+    let asset = match ver {
+        WhichVersion::Prerelease => prerelease.unwrap().get_asset_by_name("hdr-switch.zip"),
+        WhichVersion::Release => release.unwrap().get_asset_by_name("hdr-switch.zip"),
+        WhichVersion::Current => unreachable!(),
+    };
+
+    // get the zip reader on the zip archive to extract to SD root
+    let mut zip = match asset {
+        Some(asset) => match ZipArchive::new(Cursor::new(asset)) {
+            Ok(zip) => zip,
+            Err(e) => {
+                println!("HDR failed to parse zip data: {:?}", e);
+                return;
+            }
+        },
+        None => return
+    };
+
+    // try to extract the zip to the SD root and restart the application
+    match zip.extract("sd:/") {
+        Ok(_) => unsafe { 
+            skyline_web::DialogOk::ok("The applicatio will now restart.");
+            skyline::nn::oe::RequestToRelaunchApplication();
+        },
+        Err(e) => {
+            panic!("HDR failed to extract update ZIP. Reason: {:?}", e);
+        }
+    }
+}

--- a/plugin/src/updater.rs
+++ b/plugin/src/updater.rs
@@ -36,9 +36,12 @@ fn get_version(current: &Version, release: Option<&Version>, prerelease: Option<
 }
 
 pub fn check_for_updates() {
-    if Path::new("sd:/ryujinx.txt").exists() {
-        println!("Auto updater exiting as Ryujinx was encountered.");
-        return;
+    unsafe { // Ryujinx skip based on text addr
+        let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
+        if text_addr == 0x8400000 {
+            println!("HDR cannot auto-update on Ryujinx");
+            return;
+        }
     }
 
     let release = ReleaseFinderConfig::new("HewDraw-Remix")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -29,10 +29,17 @@ if "nodev" in sys.argv:
 
 release_arg = ""
 build_type = "debug"
+is_publish = False
 if "release" in sys.argv or "--release" in sys.argv:
   release_arg = "--release"
   build_type = "release"
+elif "publish" in sys.argv or "--publish" in sys.argv:
+  release_arg = "--release"
+  build_type = "release"
+  is_publish = True
 
+if is_publish:
+  allow_dev_build = False
 
 # if staging folder exists, delete it
 if "build" in os.listdir('.'):
@@ -60,7 +67,7 @@ for arg in sys.argv:
     for char in char_list:
       dev_characters.add(char)
 
-if (is_dev_build):
+if (is_dev_build and not is_publish):
     
   # special build commands for regular vs development plugins
   dev_args = ""
@@ -124,7 +131,10 @@ if (is_dev_build):
 
 else:
   # simple build
-  pkgutil.build(release_arg, "")
+  if is_publish:
+    pkgutil.build(release_arg, "--features updater")
+  else:
+    pkgutil.build(release_arg, "")
 
   # collect switch package
   pkgutil.collect_plugin("hdr-switch", 


### PR DESCRIPTION
This PR works towards resolving #17 for on-console updaters. For Ryujinx players, there will likely be no update prompts at all because we auto-detect and skip.

![image](https://user-images.githubusercontent.com/42755519/151737078-0b88a001-dc2e-4dff-8d74-5d49c48db23f.png)

Afterwards, it will prompt a relaunch of the application where you have to re-select the user

Note: This creates a dependency on devkitpro being installed and added to your path in order to build HDR