### PR TITLE
add dacus params and fix dacus

### DIFF
--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -24,5 +24,8 @@
     <float hash="waveland_pass_neutral_sens">-0.3</float>
     <int hash="air_escape_snap_frame">5</int>
     <float hash="waveland_distance_threshold">6</float>
-    
+    <struct hash="dacus_enable">
+        <int hash="start_frame">3</int>
+        <int hash="end_frame">10</int>
+    </struct>
 </struct>


### PR DESCRIPTION
Resolves #59 

Adds a new param struct and two new params:
```xml
<struct hash="dacus_enable">
    <int hash="start_frame">3</int>
    <int hash="end_frame">10</int>
</struct>
```

Dacus is based off of these params now and the ints are status frames