### PR TITLE
small fix for beta releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,6 @@ jobs:
         allow_override: true
         gzip: false
         tag: beta-${{ needs.plugin_build.outputs.version_string }}
-        commitish: ${{ needs.plugin_build.outputs.commit_hash }}
         name: beta ${{ needs.plugin_build.outputs.version_string }}
         body: >
           Beta built off of the latest code in the repository. 


### PR DESCRIPTION
beta releases were not created correctly after PR merge because commitish is not a valid option for this action.