### PR TITLE
remove ignoring of files for CI builds, since CI builds are always required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,9 @@ name: rust build
 on:
   push:
     branches: [ dev, stable ] # CHANGE "master" TO "main" IF THAT IS THE NAME OF YOUR MAIN BRANCH!
-    paths-ignore:
-      - '**/README.md'
-      - '**/.gitignore'
-      - 'scripts/**'
   pull_request:
     branches: [ dev, stable ]
-    paths-ignore:
-      - '**/README.md'
-      - '**/.gitignore'
-      - 'scripts/**'
       
-
 jobs:
   # build the plugin
   plugin_build:


### PR DESCRIPTION
removed yml that ignores certain directories on prs since successful builds are required on all PRs.
This fixes the issue with prs being unmergeable because their required workflow is not triggered because the change was only scripts, for example.