### PR TITLE
delete old tags when new releases are made

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       uses: dev-drprasad/delete-older-releases@v0.2.0
       with:
         keep_latest: 0
-        #delete_tags: true
+        delete_tags: true
         delete_tag_pattern: nightly # defaults to ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
       uses: dev-drprasad/delete-older-releases@v0.2.0
       with:
         keep_latest: 0
-        #delete_tags: true
+        delete_tags: true
         delete_tag_pattern: beta # defaults to ""
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/make_changelog.py
+++ b/scripts/make_changelog.py
@@ -27,7 +27,7 @@ print(log_output)
 all_lines = log_output.split("\n")
 cleaned_lines = set()
 for line in all_lines:
-    if line != "" and "Merge pull" in line and not "Merge branch 'dev'" in line and not "from HDR-Development/dev" in line:
+    if line != "" and "Merge pull" in line and not "Merge branch 'dev'" in line:# and not "from HDR-Development/devkit" in line:
         cleaned_lines.add(line.strip())
 
 


### PR DESCRIPTION
changes the build.yml to delete old nightly and beta tags to avoid cluttering the releases page with outdated tags that dont have artifacts.