### PR TITLE
(bugfix) fix inputing salty runback leaving pause/training menu up

### DIFF
--- a/dynamic/src/game_modes.rs
+++ b/dynamic/src/game_modes.rs
@@ -6,10 +6,28 @@ pub enum CustomMode {
 extern "Rust" {
     #[link_name = "hdr__game_modes__is_custom_mode"]
     fn _is_custom_mode() -> bool;
+
+    #[link_name = "hdr__game_modes__get_custom_mode"]
+    fn _get_custom_mode() -> Option<CustomMode>;
+
+    #[link_name = "hdr__game_modes__signal_new_game"]
+    fn _signal_new_game();
 }
 
 pub fn is_custom_mode() -> bool {
     unsafe {
         _is_custom_mode()
+    }
+}
+
+pub fn get_custom_mode() -> Option<CustomMode> {
+    unsafe {
+        _get_custom_mode()
+    }
+}
+
+pub fn signal_new_game() {
+    unsafe {
+        _signal_new_game()
     }
 }

--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -4,7 +4,7 @@ use utils::ext::*;
 #[repr(C)]
 struct SomeControllerStruct {
     padding: [u8; 0x10],
-    controller: &'static Controller
+    controller: &'static mut Controller
 }
 
 #[skyline::hook(offset = offsets::map_controls())]
@@ -12,11 +12,11 @@ unsafe fn map_controls_hook(
     mappings: *mut ControllerMapping,
     player_idx: i32,
     out: *mut MappedInputs,
-    controller_struct: &SomeControllerStruct,
+    controller_struct: &mut SomeControllerStruct,
     arg: bool
 ) {
-    let controller = controller_struct.controller;
     let ret = original!()(mappings, player_idx, out, controller_struct, arg);
+    let controller = &mut controller_struct.controller;
 
     // Check if the button combos are being pressed and then force Stock Share + AttackRaw/SpecialRaw depending on input
 
@@ -25,10 +25,20 @@ unsafe fn map_controls_hook(
     && controller.current_buttons.a()
     && (controller.current_buttons.minus() || controller.current_buttons.plus())
     {
+        controller.current_buttons.set_plus(false);
+        controller.current_buttons.set_minus(false);
+        controller.just_down.set_plus(false);
+        controller.just_down.set_minus(false);
+
         if controller.current_buttons.y() {
             (*out).buttons = Buttons::StockShare | Buttons::AttackRaw;
         } else if controller.current_buttons.x() {
             (*out).buttons = Buttons::StockShare | Buttons::SpecialRaw;
+        } else {
+            controller.current_buttons.set_plus(true);
+            controller.current_buttons.set_minus(true);
+            controller.just_down.set_plus(true);
+            controller.just_down.set_minus(true);
         }
     }
 }

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -64,6 +64,7 @@ unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
     if fighter.is_button_on(Buttons::StockShare) {
         if fighter.is_button_on(Buttons::AttackRaw) && !fighter.is_button_on(!(Buttons::AttackRaw | Buttons::StockShare)) {
             utils::util::trigger_match_reset();
+            utils::game_modes::signal_new_game();
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
             utils::util::trigger_match_exit();


### PR DESCRIPTION
Addresses part of #155 and resolves #149