### PR TITLE
(bugfix) tag: disable tag outside regular smash

### DIFF
--- a/utils/src/game_modes.rs
+++ b/utils/src/game_modes.rs
@@ -85,6 +85,12 @@ unsafe fn on_rule_select_hook(_: &skyline::hooks::InlineCtx) {
 
 #[skyline::hook(offset = offsets::once_per_game_frame())]
 unsafe fn once_per_game_frame(game_state_ptr: u64) {
+
+    // check if current match mode is not regular smash, if so sub out the custom mode
+    if utils_dyn::util::get_match_mode().0 != 1 {
+        CURRENT_CUSTOM_MODE = None;
+    }
+
     if detect_new_game(game_state_ptr) {
         match get_custom_mode() {
             Some(CustomMode::SmashballTag) => tag::clear(),

--- a/utils/src/offsets.rs
+++ b/utils/src/offsets.rs
@@ -412,7 +412,6 @@ mod offsets_impl {
             offsets.get_match_mode = {
                 let offset = byte_search(GET_MATCH_MODE_SEARCH_CODE).expect("Unable to find get_match_mode!") - GET_MATCH_MODE_OFFSET_TO_START;
                 let bl_offset = offset_from_bl(offset);
-                println!("OFFSET: {:#X} BL_OFFSET: {:#X}", offset, bl_offset);
                 offset + bl_offset
             };
             offsets.kill_zoom_regular = byte_search(KILL_ZOOM_REGULAR_SEARCH_CODE).expect("Unable to find the regular kill zoom function!") - KILL_ZOOM_REGULAR_OFFSET_TO_START;

--- a/utils/src/offsets.rs
+++ b/utils/src/offsets.rs
@@ -358,7 +358,7 @@ mod offsets_impl {
         unsafe {
             let bl = *offset_to_addr::<u32>(bl_offset);
             let imm = bl & 0b0_00000_11111111111111111111111111;
-            bl as usize
+            (imm * 4) as usize
         }
     }
 
@@ -412,6 +412,7 @@ mod offsets_impl {
             offsets.get_match_mode = {
                 let offset = byte_search(GET_MATCH_MODE_SEARCH_CODE).expect("Unable to find get_match_mode!") - GET_MATCH_MODE_OFFSET_TO_START;
                 let bl_offset = offset_from_bl(offset);
+                println!("OFFSET: {:#X} BL_OFFSET: {:#X}", offset, bl_offset);
                 offset + bl_offset
             };
             offsets.kill_zoom_regular = byte_search(KILL_ZOOM_REGULAR_SEARCH_CODE).expect("Unable to find the regular kill zoom function!") - KILL_ZOOM_REGULAR_OFFSET_TO_START;


### PR DESCRIPTION
Resolves #229 

Disables the custom gamemodes outside of any mode that is not match kind 1 (regular smash)