### PR TITLE
PR builds and dev builds packaged separately

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -70,7 +70,7 @@ jobs:
     # build the project
     - run: |
         export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin && export HDR_VERSION="${{ needs.version_and_changelog.outputs.version }}-nightly" \
-        && cd scripts && python3 make_dist.py build && cd ..
+        && cd scripts && python3 make_dist.py build name=hdr && cd ..
       env:
         HOME: /root
 

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -64,7 +64,7 @@ jobs:
     # build the project
     - run: |
         export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin && export HDR_VERSION="${{ needs.version_and_changelog.outputs.version }}-nightly" \
-        && cd scripts && python3 make_dist.py publish && cd ..
+        && cd scripts && python3 make_dist.py publish name=hdr && cd ..
       env:
         HOME: /root
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -23,7 +23,7 @@ jobs:
     # build the project
     - run: |
         export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin && export HDR_VERSION="1.69.420-pr" \
-        && cd scripts && python3 make_dist.py build && cd ..
+        && cd scripts && python3 make_dist.py build name=hdr-pr && cd ..
       env:
         HOME: /root
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -4,10 +4,11 @@ import shutil, os, sys, pkgutil, characters
 if "help" in sys.argv or "--help" in sys.argv or "-h" in sys.argv:
   print("no arguments required for simple build. To build parts of the project"
     + " as a development reloadable plugin, use argument 'dev=mario,luigi,captain'"
-    + " to specify which character crates to build into the reloadable dev plugin.")
+    + " to specify which character crates to build into the reloadable dev plugin."
+    + " to specify what mod folder name to build as, use 'name=hdr-pr' or 'name=hdr', etc.")
   print("For example:")
   print("\t./build.py debug dev=mario,luigi,captain\n")
-  print("\t./build.py release dev=captain\n")
+  print("\t./build.py release dev=captain name=hdr-dev\n")
   exit(0)
 
 # handle fallback exe on windows
@@ -64,6 +65,12 @@ if is_publish:
 if "build" in os.listdir('.'):
   shutil.rmtree('build')
 os.mkdir('build')
+
+# search for mod name plugin args
+mod_name = "hdr-dev"
+for arg in sys.argv:
+  if "name=" in arg:
+    mod_name = arg.split('=')[1]
 
 
 # search for dev plugin args
@@ -144,7 +151,7 @@ if (is_dev_build and not is_publish):
     build_type, "libhdr.nro", "standalone")
 
     # collect switch romfs
-  pkgutil.collect_romfs("hdr-switch", "")
+  pkgutil.collect_romfs("hdr-switch", "", mod_name)
 
   # collect ryujinx plugin
   pkgutil.collect_plugin("hdr-ryujinx", 
@@ -152,7 +159,7 @@ if (is_dev_build and not is_publish):
     build_type, "libhdr.nro", "standalone")
   
   # collect ryujinx romfs
-  pkgutil.collect_romfs("hdr-ryujinx", "sdcard")
+  pkgutil.collect_romfs("hdr-ryujinx", "sdcard", mod_name)
 
 
 else:
@@ -168,7 +175,7 @@ else:
     build_type, "libhdr.nro")
 
   # collect switch romfs
-  pkgutil.collect_romfs("hdr-switch", "")
+  pkgutil.collect_romfs("hdr-switch", "", mod_name)
 
 
   # collect ryujinx plugin
@@ -177,7 +184,7 @@ else:
     build_type, "libhdr.nro")
   
   # collect ryujinx romfs
-  pkgutil.collect_romfs("hdr-ryujinx", "sdcard")
+  pkgutil.collect_romfs("hdr-ryujinx", "sdcard", mod_name)
 
 os.chdir(current_dir)
 

--- a/scripts/pkgutil.py
+++ b/scripts/pkgutil.py
@@ -22,10 +22,10 @@ def collect_plugin(package_name: str, package_path: str, build_type: str, plugin
   
   return
 
-def collect_romfs(package_name: str, context_path: str):
+def collect_romfs(package_name: str, context_path: str, mod_name: str):
   print("COLLECTING " + package_name + " romfs!")
   romfs_source = os.path.join("romfs/build")
-  romfs_destination = os.path.join("build", package_name, context_path, "ultimate/mods/hdr")
+  romfs_destination = os.path.join("build", package_name, context_path, "ultimate/mods", mod_name)
   shutil.copytree(
     os.path.join(romfs_source), 
     os.path.join(romfs_destination))


### PR DESCRIPTION
PR builds, dev builds, and regular builds (nightly, beta) will be packaged in different folder names. PR builds will be ultimate/mods/hdr-pr, dev builds (which is the default for build.py) will be /ultimate/mods/hdr-dev. This will allow us to easily toggle pr builds and dev builds compared to regular nightlies or betas using the arcropolis ui.

resolves #267