### PR TITLE
Skip gimmick flash in results screen

### DIFF
--- a/fighters/common/src/opff/gimmick.rs
+++ b/fighters/common/src/opff/gimmick.rs
@@ -3,7 +3,10 @@ use utils::{
     ext::*,
     consts::*
 };
-use smash::app::BattleObjectModuleAccessor;
+use smash::app::{
+	self,
+	BattleObjectModuleAccessor,
+};
 use smash::phx::{Vector2f, Vector3f, Vector4f};
 use smash::app::lua_bind::*;
 use smash::lib::lua_const::*;
@@ -11,6 +14,10 @@ use smash::hash40;
 
 #[no_mangle]
 pub unsafe extern "Rust" fn gimmick_flash(boma: &mut BattleObjectModuleAccessor) {
+	if !app::sv_information::is_ready_go() {
+		return
+	}
+	
     let cbm_vec1 = Vector4f{x: 1.0, y: 0.8, z: 0.35, w: 0.25};
     let cbm_vec2 = Vector4f{x: 1.0, y: 0.8, z: 0.35, w: 0.00};
     ColorBlendModule::set_main_color(boma, &cbm_vec1, &cbm_vec2, 0.5, 0.5, 5, true);


### PR DESCRIPTION
Fixes #225. Issue also repros for Mario, Sheik, and Young Link gimmicks. This fixes those as well.