### PR TITLE
approved duckhunt changes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -206,6 +206,11 @@ pub mod vars {
         pub const UNABLE_CANCEL_S3_DASH: i32 = 0x1051;
     }
 
+    pub mod duckhunt {
+        // int
+        pub const GUNMAN_TIMER: i32 = 0x1000;
+    }
+
     pub mod gaogaen {
         // floats
         pub const ANGLE_GRAB_STICK_Y: i32 = 0x1000;

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -367,6 +367,7 @@ pub trait BomaExt {
     unsafe fn get_jump_count(&mut self) -> i32;
     unsafe fn get_jump_count_max(&mut self) -> i32;
     unsafe fn motion_frame(&mut self) -> f32;
+    unsafe fn set_rate(&mut self, motion_rate: f32);
     unsafe fn is_in_hitlag(&mut self) -> bool;
 
 
@@ -538,6 +539,10 @@ impl BomaExt for BattleObjectModuleAccessor {
 
     unsafe fn is_motion(&mut self, kind: Hash40) -> bool {
         return MotionModule::motion_kind(self) == kind.hash;
+    }
+
+    unsafe fn set_rate(&mut self, motion_rate: f32) {
+        MotionModule::set_rate(self, motion_rate);
     }
 
     unsafe fn is_motion_one_of(&mut self, kinds: &[Hash40]) -> bool {

--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -165,7 +165,6 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
             && flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW {
                     return false
             }
-            println!("TIMER: {}", VarModule::get_int(boma.object(), vars::duckhunt::GUNMAN_TIMER));
         }
     }   
     original!()(boma, flag)

--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -159,13 +159,15 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
             }
         }
 
-        //Disable Duck Hunt Gunman if Gunman is present
-        if boma.kind() == *FIGHTER_KIND_DUCKHUNT 
-        && WorkModule::is_flag(boma, *FIGHTER_DUCKHUNT_INSTANCE_WORK_ID_FLAG_GUNMAN_OK) 
-        && flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW {
-            return false;
-        }       
-    }
+        //Disable Duck Hunt Down Special on a timer
+        if boma.kind() == *FIGHTER_KIND_DUCKHUNT  {
+            if VarModule::get_int(boma.object(), vars::duckhunt::GUNMAN_TIMER) != 0 
+            && flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW {
+                    return false
+            }
+            println!("TIMER: {}", VarModule::get_int(boma.object(), vars::duckhunt::GUNMAN_TIMER));
+        }
+    }   
     original!()(boma, flag)
 }
 

--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -158,6 +158,13 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
                 }
             }
         }
+
+        //Disable Duck Hunt Gunman if Gunman is present
+        if boma.kind() == *FIGHTER_KIND_DUCKHUNT 
+        && WorkModule::is_flag(boma, *FIGHTER_DUCKHUNT_INSTANCE_WORK_ID_FLAG_GUNMAN_OK) 
+        && flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW {
+            return false;
+        }       
     }
     original!()(boma, flag)
 }

--- a/fighters/duckhunt/src/acmd/aerials.rs
+++ b/fighters/duckhunt/src/acmd/aerials.rs
@@ -175,7 +175,7 @@ unsafe fn duckhunt_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 20.0);
     if is_excute(fighter) {
         // Air-only
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 270, 80, 0, 10, 6.5, 0.0, -8.0, 0.0, Some(0.0), Some(-5.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 270, 60, 0, 30, 6.5, 0.0, -8.0, 0.0, Some(0.0), Some(-5.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
         // Ground-only
         ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 270, 95, 0, 60, 6.5, 0.0, -8.0, 0.0, Some(0.0), Some(-5.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
     }

--- a/fighters/duckhunt/src/acmd/ground.rs
+++ b/fighters/duckhunt/src/acmd/ground.rs
@@ -10,7 +10,7 @@ unsafe fn duckhunt_attackdash_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 13.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 105, 40, 0, 90, 3.5, 0.0, 7.0, 9.0, Some(0.0), Some(7.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_sting"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 105, 40, 0, 90, 3.5, 0.0, 7.0, 9.0, Some(0.0), Some(7.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_sting"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
     }
     frame(lua_state, 23.0);
     if is_excute(fighter) {

--- a/fighters/duckhunt/src/acmd/ground.rs
+++ b/fighters/duckhunt/src/acmd/ground.rs
@@ -1,7 +1,7 @@
 
 use super::*;
 #[acmd_script( agent = "duckhunt", script = "game_attackdash" , category = ACMD_GAME , low_priority)]
-unsafe fn duckhunt_attack_dash_game(fighter: &mut L2CAgentBase) {
+unsafe fn duckhunt_attackdash_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 10.0);
@@ -19,10 +19,31 @@ unsafe fn duckhunt_attack_dash_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "duckhunt", script = "game_attack12" , category = ACMD_GAME , low_priority)]
+unsafe fn duckhunt_attack12_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        ATTACK(fighter,  0,  0,  Hash40::new("top"),  1.5,  70,  30,  0,  30,  3.0,  0.0,  3.5,  2.0,  None,  None,  None,  1.2,  1.0,  *ATTACK_SETOFF_KIND_ON,  *ATTACK_LR_CHECK_F,  false,  0,  0.0,  0,  false,  false,  false,  false,  true,  *COLLISION_SITUATION_MASK_GA,  *COLLISION_CATEGORY_MASK_ALL,  *COLLISION_PART_MASK_ALL,  false,  Hash40::new("collision_attr_normal"),  *ATTACK_SOUND_LEVEL_S,  *COLLISION_SOUND_ATTR_PUNCH,  *ATTACK_REGION_HEAD);
+        ATTACK(fighter,  1,  0,  Hash40::new("top"),  1.5,  70,  25,  0,  25,  5.0,  0.0,  7.5,  5.5,  None,  None,  None,  1.2,  1.0,  *ATTACK_SETOFF_KIND_ON,  *ATTACK_LR_CHECK_F,  false,  0,  0.0,  0,  false,  false,  false,  false,  true,  *COLLISION_SITUATION_MASK_GA,  *COLLISION_CATEGORY_MASK_ALL,  *COLLISION_PART_MASK_ALL,  false,  Hash40::new("collision_attr_normal"),  *ATTACK_SOUND_LEVEL_S,  *COLLISION_SOUND_ATTR_PUNCH,  *ATTACK_REGION_HEAD);
+    }
+    wait(lua_state, 2.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_100);
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_100);
+    }
+}
 
 pub fn install() {
     install_acmd_scripts!(
-        duckhunt_attack_dash_game,
+        duckhunt_attackdash_game,
+        duckhunt_attack12_game,
     );
 }
 

--- a/fighters/duckhunt/src/acmd/other.rs
+++ b/fighters/duckhunt/src/acmd/other.rs
@@ -89,6 +89,38 @@ unsafe fn duckhunt_can_explode_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "duckhunt_clay" , script = "game_fly" , category = ACMD_GAME , low_priority)]
+unsafe fn duckhunt_clay_fly_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK(fighter,  0,  0,  Hash40::new("top"),  2.0,  75,  50,  0,  20,  1.0,  0.0,  0.0,  0.0,  None,  None,  None,  5.0,  0.0,  *ATTACK_SETOFF_KIND_THRU,  *ATTACK_LR_CHECK_F,  false,  -1,  0.0,  0,  true,  false,  false,  false,  false,  *COLLISION_SITUATION_MASK_GA,  *COLLISION_CATEGORY_MASK_ALL,  *COLLISION_PART_MASK_ALL,  false,  Hash40::new("collision_attr_normal"),  *ATTACK_SOUND_LEVEL_L,  *COLLISION_SOUND_ATTR_PUNCH,  *ATTACK_REGION_OBJECT);
+        AttackModule::enable_safe_pos(boma);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *WEAPON_DUCKHUNT_CLAY_INSTANCE_WORK_ID_FLAG_IS_ADD_ACCEL_Y);
+    }
+}
+
+#[acmd_script( agent = "duckhunt_gunman" , scripts = ["sound_readyr", "sound_readyl"] , category = ACMD_SOUND , low_priority)]
+unsafe fn duckhunt_gunman_ready_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_duckhunt_special_l02"));
+    }
+    frame(lua_state, 280.0);
+    if is_excute(fighter) {
+        PLAY_STATUS(fighter, Hash40::new("se_duckhunt_special_l09"));
+    } 
+}
+
+#[acmd_script( agent = "duckhunt_gunman" , scripts = ["effect_readyr" , "effect_readyl"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn duckhunt_gunman_ready_effect(fighter: &mut L2CAgentBase) {
+    
+}
+
 pub fn install() {
     install_acmd_scripts!(
         duckhunt_catch_game,
@@ -96,6 +128,9 @@ pub fn install() {
         dash_effect,
         turn_dash_game,
         duckhunt_can_explode_game,
+        duckhunt_clay_fly_game,
+        duckhunt_gunman_ready_effect,
+        duckhunt_gunman_ready_sound,
     );
 }
 

--- a/fighters/duckhunt/src/acmd/other.rs
+++ b/fighters/duckhunt/src/acmd/other.rs
@@ -110,15 +110,78 @@ unsafe fn duckhunt_gunman_ready_sound(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_duckhunt_special_l02"));
     }
-    frame(lua_state, 280.0);
+    frame(lua_state, 275.0);
     if is_excute(fighter) {
         PLAY_STATUS(fighter, Hash40::new("se_duckhunt_special_l09"));
     } 
 }
 
-#[acmd_script( agent = "duckhunt_gunman" , scripts = ["effect_readyr" , "effect_readyl"] , category = ACMD_EFFECT , low_priority)]
-unsafe fn duckhunt_gunman_ready_effect(fighter: &mut L2CAgentBase) {
-    
+#[acmd_script( agent = "duckhunt_gunman" , script = "effect_readyl" , category = ACMD_EFFECT , low_priority)]
+unsafe fn duckhunt_gunman_ready_effectl(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 275.0);
+    let gunman_kind = WorkModule::get_int(fighter.boma(), *WEAPON_DUCKHUNT_GUNMAN_INSTANCE_WORK_ID_KIND);
+    if is_excute(fighter) {
+        match gunman_kind {
+            0 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, 0.74, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, -0.78, 0, 0, 0, 1, true);
+            }
+            1 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, 0.42, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, -0.5, 0, 0, 0, 1, true);
+            }
+            2 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, 0.26, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, -1.29, 0, 0, 0, 1, true);
+            }
+            3 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, 0.85, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, -0.64, 0, 0, 0, 1, true);
+            }
+            4 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.17, 0.4, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.16, -1.36, 0, 0, 0, 1, true);
+            }
+            _ => {
+                return
+            }
+        }
+    }
+}
+
+#[acmd_script( agent = "duckhunt_gunman" , script = "effect_readyr" , category = ACMD_EFFECT , low_priority)]
+unsafe fn duckhunt_gunman_ready_effectr(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 275.0);
+    let gunman_kind = WorkModule::get_int(fighter.boma(), *WEAPON_DUCKHUNT_GUNMAN_INSTANCE_WORK_ID_KIND);
+    if is_excute(fighter) {
+        match gunman_kind {    
+            0 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, 0.74, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, -0.78, 0, 0, 0, 1, true);
+            }
+            1 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, 0.42, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, -0.5, 0, 0, 0, 1, true);
+            }
+            2 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, 0.26, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, -1.29, 0, 0, 0, 1, true);
+            }
+            3 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, 0.85, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, -0.64, 0, 0, 0, 1, true);
+            }
+            4 => {
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.17, 0.4, 0, 0, 0, 1, true);
+                EFFECT_FOLLOW(fighter, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.16, -1.36, 0, 0, 0, 1, true);
+            }
+            _ => {
+                return
+            }
+        }
+    }
 }
 
 pub fn install() {
@@ -129,7 +192,8 @@ pub fn install() {
         turn_dash_game,
         duckhunt_can_explode_game,
         duckhunt_clay_fly_game,
-        duckhunt_gunman_ready_effect,
+        duckhunt_gunman_ready_effectr,
+        duckhunt_gunman_ready_effectl,
         duckhunt_gunman_ready_sound,
     );
 }

--- a/fighters/duckhunt/src/acmd/smashes.rs
+++ b/fighters/duckhunt/src/acmd/smashes.rs
@@ -1,7 +1,35 @@
 
 use super::*;
 
-#[acmd_script( agent = "duckhunt", script = "game_attacks4" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "duckhunt" , script = "game_attackhi4" , category = ACMD_GAME , low_priority)]
+unsafe fn duckhunt_attack_hi4_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma,  *FIGHTER_STATUS_ATTACK_FLAG_START_SMASH_HOLD);
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        WorkModule::set_int(boma, 5, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_DELAY_FRAME);
+        WorkModule::set_int(boma, 6, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_RETICLE_DISPLAY_FRAME);
+        ATTACK(fighter, /*ID*/ 0, /*Part*/ 0, /*Bone*/ Hash40::new("top"), /*Damage*/ 2.5, /*Angle*/ 368, /*KBG*/ 100, /*FKB*/ 0, /*BKB*/ 0, /*Size*/ 5.3, /*X*/ 0.0, /*Y*/ 11.0, /*Z*/ 9.0, /*X2*/ None, /*Y2*/ None, /*Z2*/ None, /*Hitlag*/ 1.0, /*SDI*/ 1.0, /*Clang_Rebound*/ *ATTACK_SETOFF_KIND_THRU, /*FacingRestrict*/ *ATTACK_LR_CHECK_POS, /*SetWeight*/ false, /*ShieldDamage*/ 0, /*Trip*/ 0.0, /*Rehit*/ 0, /*Reflectable*/ false, /*Absorbable*/ false, /*Flinchless*/ false, /*DisableHitlag*/ false, /*Direct_Hitbox*/ true, /*Ground_or_Air*/ *COLLISION_SITUATION_MASK_GA, /*Hitbits*/ *COLLISION_CATEGORY_MASK_ALL, /*CollisionPart*/ *COLLISION_PART_MASK_ALL, /*FriendlyFire*/ false, /*Effect*/ Hash40::new("collision_attr_fire"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_M, /*SFXType*/ *COLLISION_SOUND_ATTR_PUNCH, /*Type*/ *ATTACK_REGION_NONE);
+        let hit1 = smash::phx::Vector2f { x: -7.0, y: 10.0 };
+        AttackModule::set_vec_target_pos(boma, 0, Hash40::new("top"), &hit1, 8, false);
+    }
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, /*ID*/ 1, /*Part*/ 0, /*Bone*/ Hash40::new("top"), /*Damage*/ 2.5, /*Angle*/ 368, /*KBG*/ 100, /*FKB*/ 0, /*BKB*/ 0, /*Size*/ 6.3, /*X*/ 0.0, /*Y*/ 15.0, /*Z*/ -8.0, /*X2*/ None, /*Y2*/ None, /*Z2*/ None, /*Hitlag*/ 1.0, /*SDI*/ 1.0, /*Clang_Rebound*/ *ATTACK_SETOFF_KIND_THRU, /*FacingRestrict*/ *ATTACK_LR_CHECK_POS, /*SetWeight*/ false, /*ShieldDamage*/ 0, /*Trip*/ 0.0, /*Rehit*/ 0, /*Reflectable*/ false, /*Absorbable*/ false, /*Flinchless*/ false, /*DisableHitlag*/ false, /*Direct_Hitbox*/ true, /*Ground_or_Air*/ *COLLISION_SITUATION_MASK_GA, /*Hitbits*/ *COLLISION_CATEGORY_MASK_ALL, /*CollisionPart*/ *COLLISION_PART_MASK_ALL, /*FriendlyFire*/ false, /*Effect*/ Hash40::new("collision_attr_fire"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_M, /*SFXType*/ *COLLISION_SOUND_ATTR_PUNCH, /*Type*/ *ATTACK_REGION_NONE);
+        let hit2 = smash::phx::Vector2f { x: 0.0, y: 17.0 };
+        AttackModule::set_vec_target_pos(boma, 1, Hash40::new("top"), &hit2, 8, false);
+    }
+    frame(lua_state, 23.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, /*ID*/ 2, /*Part*/ 0, /*Bone*/ Hash40::new("top"), /*Damage*/ 10.0, /*Angle*/ 85, /*KBG*/ 120, /*FKB*/ 0, /*BKB*/ 45, /*Size*/ 7.8, /*X*/ 0.0, /*Y*/ 21.0, /*Z*/ 0.0, /*X2*/ None, /*Y2*/ None, /*Z2*/ None, /*Hitlag*/ 1.0, /*SDI*/ 1.0, /*Clang_Rebound*/ *ATTACK_SETOFF_KIND_THRU, /*FacingRestrict*/ *ATTACK_LR_CHECK_POS, /*SetWeight*/ false, /*ShieldDamage*/ 0, /*Trip*/ 0.0, /*Rehit*/ 0, /*Reflectable*/ false, /*Absorbable*/ false, /*Flinchless*/ false, /*DisableHitlag*/ false, /*Direct_Hitbox*/ true, /*Ground_or_Air*/ *COLLISION_SITUATION_MASK_GA, /*Hitbits*/ *COLLISION_CATEGORY_MASK_ALL, /*CollisionPart*/ *COLLISION_PART_MASK_ALL, /*FriendlyFire*/ false, /*Effect*/ Hash40::new("collision_attr_fire"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_L, /*SFXType*/ *COLLISION_SOUND_ATTR_KICK, /*Type*/ *ATTACK_REGION_NONE);
+    }
+}
+
+#[acmd_script( agent = "duckhunt" , script = "game_attacks4" , category = ACMD_GAME , low_priority)]
 unsafe fn duckhunt_attack_s4_s_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -13,20 +41,20 @@ unsafe fn duckhunt_attack_s4_s_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         WorkModule::set_int(boma, 5, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_DELAY_FRAME);
         WorkModule::set_int(boma, 6, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_RETICLE_DISPLAY_FRAME);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 45, 100, 66, 0, 6.0, 0.0, 6.0, 10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 45, 100, 66, 0, 6.0, 0.0, 6.0, 10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
     }
     frame(lua_state, 18.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 4.0, 45, 100, 70, 0, 7.0, 0.0, 6.0, 18.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 4.0, 45, 100, 70, 0, 7.0, 0.0, 6.0, 18.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
     }
     frame(lua_state, 24.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 2, 0, Hash40::new("top"), 9.0, 361, 131, 0, 50, 9.0, 0.0, 6.0, 26.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 9.0, 361, 131, 0, 50, 9.0, 0.0, 6.0, 26.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
     }
     
 }
 
-#[acmd_script( agent = "duckhunt", script = "game_attacklw4" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "duckhunt" , script = "game_attacklw4" , category = ACMD_GAME , low_priority)]
 unsafe fn duckhunt_attack_lw4_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -38,25 +66,26 @@ unsafe fn duckhunt_attack_lw4_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         WorkModule::set_int(boma, 5, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_DELAY_FRAME);
         WorkModule::set_int(boma, 6, *FIGHTER_DUCKHUNT_STATUS_ATTACK_INT_SMASH_RETICLE_DISPLAY_FRAME);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 368, 100, 0, 0, 6.0, 0.0, 4.0, 10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 368, 100, 0, 0, 6.0, 0.0, 4.0, 10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
         let hit1 = smash::phx::Vector2f { x: -9.0, y: 2.0 };
         AttackModule::set_vec_target_pos(boma, 0, smash::phx::Hash40::new("top"), &hit1, 8, false);
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 368, 100, 0, 0, 7.0, 0.0, 5.0, -10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 368, 100, 0, 0, 7.0, 0.0, 5.0, -10.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_NONE);
         let hit2 = smash::phx::Vector2f { x: 12.0, y: 3.0 };
         AttackModule::set_vec_target_pos(boma, 1, smash::phx::Hash40::new("top"), &hit2, 8, false);
     }
     frame(lua_state, 24.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 2, 0, Hash40::new("top"), 6.0, 150, 160, 0, 37, 9.0, 0.0, 7.0, 14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 6.0, 150, 160, 0, 37, 9.0, 0.0, 7.0, 14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
     }
     
 }
 
 pub fn install() {
     install_acmd_scripts!(
+        duckhunt_attack_hi4_game,
         duckhunt_attack_s4_s_game,
         duckhunt_attack_lw4_game,
     );

--- a/fighters/duckhunt/src/acmd/specials.rs
+++ b/fighters/duckhunt/src/acmd/specials.rs
@@ -12,9 +12,40 @@ unsafe fn duckhunt_special_hi_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "duckhunt" , scripts = ["game_specialairlw", "game_speciallw"], category = ACMD_GAME , low_priority)]
+unsafe fn duckhunt_special_airlw_game(fighter: &mut L2CAgentBase) {
+    let lua_state: u64 = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 4.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_DUCKHUNT_STATUS_SPECIAL_LW_FLAG_CALL_TRIGGER);
+    }
+}
+
+#[acmd_script( agent = "duckhunt_gunman" , scripts = ["sound_readyr", "sound_readyl"] , category = ACMD_SOUND , low_priority)]
+unsafe fn gunman_downb_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_duckhunt_special_l02"));
+    }
+    frame(lua_state, 280.0);
+    if is_excute(fighter) {
+        PLAY_STATUS(fighter, Hash40::new("se_duckhunt_special_l09"));
+    } 
+}
+
+#[acmd_script( agent = "duckhunt_gunman" , scripts = ["effect_readyr" , "effect_readyl"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn gunman_downb_effect_stub(fighter: &mut L2CAgentBase) {
+    
+}
+
 pub fn install() {
     install_acmd_scripts!(
         duckhunt_special_hi_game,
+        duckhunt_special_airlw_game,
+        gunman_downb_sound,
+        //gunman_downb_effect_stub,
     );
 }
 

--- a/fighters/duckhunt/src/acmd/specials.rs
+++ b/fighters/duckhunt/src/acmd/specials.rs
@@ -13,7 +13,7 @@ unsafe fn duckhunt_special_hi_game(fighter: &mut L2CAgentBase) {
 }
 
 #[acmd_script( agent = "duckhunt" , scripts = ["game_specialairlw", "game_speciallw"], category = ACMD_GAME , low_priority)]
-unsafe fn duckhunt_special_airlw_game(fighter: &mut L2CAgentBase) {
+unsafe fn duckhunt_special_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state: u64 = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 4.0);
@@ -22,30 +22,10 @@ unsafe fn duckhunt_special_airlw_game(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "duckhunt_gunman" , scripts = ["sound_readyr", "sound_readyl"] , category = ACMD_SOUND , low_priority)]
-unsafe fn gunman_downb_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_duckhunt_special_l02"));
-    }
-    frame(lua_state, 280.0);
-    if is_excute(fighter) {
-        PLAY_STATUS(fighter, Hash40::new("se_duckhunt_special_l09"));
-    } 
-}
-
-#[acmd_script( agent = "duckhunt_gunman" , scripts = ["effect_readyr" , "effect_readyl"] , category = ACMD_EFFECT , low_priority)]
-unsafe fn gunman_downb_effect_stub(fighter: &mut L2CAgentBase) {
-    
-}
-
 pub fn install() {
     install_acmd_scripts!(
         duckhunt_special_hi_game,
-        duckhunt_special_airlw_game,
-        gunman_downb_sound,
-        //gunman_downb_effect_stub,
+        duckhunt_special_lw_game,
     );
 }
 

--- a/fighters/duckhunt/src/acmd/throws.rs
+++ b/fighters/duckhunt/src/acmd/throws.rs
@@ -1,11 +1,34 @@
 
 use super::*;
 
+#[acmd_script( agent = "duckhunt", script = "game_throwlw" , category = ACMD_GAME , low_priority)]
+unsafe fn duckhunt_throwlw_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, /*Kind*/ *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, /*ID*/ 0, /*Damage*/ 5.0, /*Angle*/ 80, /*KBG*/ 40, /*FKB*/ 0, /*BKB*/ 110, /*Hitlag*/ 0.0, /*Unk*/ 1.0, /*FacingRestrict*/ *ATTACK_LR_CHECK_F, /*Unk*/ 0.0, /*Unk*/ true, /*Effect*/ Hash40::new("collision_attr_normal"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_S, /*SFXType*/ *COLLISION_SOUND_ATTR_NONE, /*Type*/ *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, /*Kind*/ *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, /*ID*/ 0, /*Damage*/ 3.0, /*Angle*/ 361, /*KBG*/ 100, /*FKB*/ 0, /*BKB*/ 40, /*Hitlag*/ 0.0, /*Unk*/ 1.0, /*FacingRestrict*/ *ATTACK_LR_CHECK_F, /*Unk*/ 0.0, /*Unk*/ true, /*Effect*/ Hash40::new("collision_attr_normal"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_S, /*SFXType*/ *COLLISION_SOUND_ATTR_NONE, /*Type*/ *ATTACK_REGION_THROW);
+    }
+    frame(lua_state, 23.0);
+    if is_excute(fighter) {
+        ATTACK_IGNORE_THROW(fighter, /*ID*/ 0, /*Part*/ 0, /*Bone*/ Hash40::new("top"), /*Damage*/ 4.0, /*Angle*/ 50, /*KBG*/ 70, /*FKB*/ 0, /*BKB*/ 50, /*Size*/ 7.0, /*X*/ 0.0, /*Y*/ 4.0, /*Z*/ 12.0, /*Hitlag*/ None, None, None, 1.0, /*SDI*/ 1.0, /*Clang_Rebound*/ *ATTACK_SETOFF_KIND_OFF, /*FacingRestrict*/ *ATTACK_LR_CHECK_POS, /*SetWeight*/ false, /*ShieldDamage*/ 0, /*Trip*/ 0.0, /*Rehit*/ 0, /*Reflectable*/ false, /*Absorbable*/ false, /*Flinchless*/ false, /*DisableHitlag*/ false, /*Direct_Hitbox*/ true, /*Ground_or_Air*/ *COLLISION_SITUATION_MASK_GA, /*Hitbits*/ *COLLISION_CATEGORY_MASK_ALL, /*CollisionPart*/ *COLLISION_PART_MASK_ALL, /*FriendlyFire*/ false, /*Effect*/ Hash40::new("collision_attr_normal"), /*SFXLevel*/ *ATTACK_SOUND_LEVEL_M, /*SFXType*/ *COLLISION_SOUND_ATTR_KICK, /*Type*/ *ATTACK_REGION_THROW);
+        AttackModule::set_catch_only_all(boma, true, false);
+        CHECK_FINISH_CAMERA(fighter, 10, 0);
+    }
+    frame(lua_state, 24.0);
+    if is_excute(fighter) {
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), 
+        WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT),
+        WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP),
+        WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
+        AttackModule::clear_all(boma);
+    }
+}
 
 
 pub fn install() {
     install_acmd_scripts!(
-
-);
+        duckhunt_throwlw_game,
+    );
 }
 

--- a/fighters/duckhunt/src/lib.rs
+++ b/fighters/duckhunt/src/lib.rs
@@ -40,4 +40,6 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     //status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frame_callback!(gunman_callback);
 }

--- a/fighters/duckhunt/src/opff.rs
+++ b/fighters/duckhunt/src/opff.rs
@@ -68,58 +68,30 @@ pub fn gunman_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
             if duckhunt_boma.is_cat_flag(Cat1::SpecialLw) && duckhunt_boma.is_button_trigger(Buttons::Special | Buttons::SpecialRaw) && WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LIFE) > 25 {
                 PLAY_STATUS(weapon, Hash40::new("se_duckhunt_special_l09"));
                 let gunman_kind = WorkModule::get_int(weapon.boma(), *WEAPON_DUCKHUNT_GUNMAN_INSTANCE_WORK_ID_KIND);
-                if PostureModule::lr(weapon.boma()) == -1.0 {
-                    match gunman_kind {
-                        0 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, 0.74, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, -0.78, 0, 0, 0, 1, true);
-                        }
-                        1 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, 0.42, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, -0.5, 0, 0, 0, 1, true);
-                        }
-                        2 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, 0.26, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, -1.29, 0, 0, 0, 1, true);
-                        }
-                        3 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, 0.85, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, -0.64, 0, 0, 0, 1, true);
-                        }
-                        4 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.17, 0.4, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.16, -1.36, 0, 0, 0, 1, true);
-                        }
-                        _ => {
-                            return
-                        }
+                let lr = PostureModule::lr(weapon.boma());
+                match gunman_kind {
+                    0 => {
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 13.3, 0.74, 0, 0, 0, 1, true);
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 13.3, -0.78, 0, 0, 0, 1, true);
                     }
-                }
-                if PostureModule::lr(weapon.boma()) == 1.0 {
-                    match gunman_kind {
-                        0 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, 0.74, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, -0.78, 0, 0, 0, 1, true);
-                        }
-                        1 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, 0.42, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, -0.5, 0, 0, 0, 1, true);
-                        }
-                        2 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, 0.26, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, -1.29, 0, 0, 0, 1, true);
-                        }
-                        3 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, 0.85, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, -0.64, 0, 0, 0, 1, true);
-                        }
-                        4 => {
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.17, 0.4, 0, 0, 0, 1, true);
-                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.16, -1.36, 0, 0, 0, 1, true);
-                        }
-                        _ => {
-                            return
-                        }
+                    1 => {
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 15.66, 0.42, 0, 0, 0, 1, true);
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 15.66, -0.5, 0, 0, 0, 1, true);
+                    }
+                    2 => {
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 16.92, 0.26, 0, 0, 0, 1, true);
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 16.92, -1.29, 0, 0, 0, 1, true);
+                    }
+                    3 => {
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 10.9, 0.85, 0, 0, 0, 1, true);
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 10.9, -0.64, 0, 0, 0, 1, true);
+                    }
+                    4 => {
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 14.17, 0.4, 0, 0, 0, 1, true);
+                        EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5*lr, 14.16, -1.36, 0, 0, 0, 1, true);
+                    }
+                    _ => {
+                        return
                     }
                 }
                 WorkModule::set_int(weapon.module_accessor, 25, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);

--- a/fighters/duckhunt/src/opff.rs
+++ b/fighters/duckhunt/src/opff.rs
@@ -21,6 +21,28 @@ unsafe fn frame_data(fighter: &mut L2CFighterCommon) {
             fighter.set_rate(1.0);
         }
     }
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
+        if fighter.motion_frame() <= 6.0 {
+            fighter.set_rate(0.7);
+        }
+        if fighter.motion_frame() > 6.0 {
+            fighter.set_rate(0.9);
+        }
+    }
+}
+
+extern "Rust" {
+    fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
+}
+
+unsafe fn gunman_timer(fighter: &mut L2CFighterCommon) {
+    let timer = VarModule::get_int(fighter.object(), vars::duckhunt::GUNMAN_TIMER);
+    if  timer != 0 {
+        VarModule::set_int(fighter.object(), vars::duckhunt::GUNMAN_TIMER, (timer-1));
+    }
+    if timer == 1 {
+        gimmick_flash(fighter);
+    }
 }
 
 #[utils::macros::opff(FIGHTER_KIND_DUCKHUNT )]
@@ -29,6 +51,7 @@ pub fn duckhunt_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
         common::opff::fighter_common_opff(fighter);
         duck_jump_cancel(fighter);
         frame_data(fighter);
+        gunman_timer(fighter);
     }
 }
 
@@ -42,11 +65,67 @@ pub fn gunman_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
         if weapon.is_status(*WEAPON_DUCKHUNT_GUNMAN_STATUS_KIND_READY) {
             let duckhunt = utils::util::get_battle_object_from_id(owner_id);
             let duckhunt_boma = &mut *(*duckhunt).module_accessor;
-            if duckhunt_boma.is_cat_flag(Cat1::SpecialLw) && duckhunt_boma.is_button_trigger(Buttons::Special | Buttons::SpecialRaw) && WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LIFE) > 20 {
+            if duckhunt_boma.is_cat_flag(Cat1::SpecialLw) && duckhunt_boma.is_button_trigger(Buttons::Special | Buttons::SpecialRaw) && WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LIFE) > 25 {
                 PLAY_STATUS(weapon, Hash40::new("se_duckhunt_special_l09"));
-                WorkModule::set_int(weapon.module_accessor, 20, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
+                let gunman_kind = WorkModule::get_int(weapon.boma(), *WEAPON_DUCKHUNT_GUNMAN_INSTANCE_WORK_ID_KIND);
+                if PostureModule::lr(weapon.boma()) == -1.0 {
+                    match gunman_kind {
+                        0 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, 0.74, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 13.3, -0.78, 0, 0, 0, 1, true);
+                        }
+                        1 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, 0.42, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 15.66, -0.5, 0, 0, 0, 1, true);
+                        }
+                        2 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, 0.26, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 16.92, -1.29, 0, 0, 0, 1, true);
+                        }
+                        3 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, 0.85, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 10.9, -0.64, 0, 0, 0, 1, true);
+                        }
+                        4 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.17, 0.4, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), 0.5, 14.16, -1.36, 0, 0, 0, 1, true);
+                        }
+                        _ => {
+                            return
+                        }
+                    }
+                }
+                if PostureModule::lr(weapon.boma()) == 1.0 {
+                    match gunman_kind {
+                        0 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, 0.74, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 13.3, -0.78, 0, 0, 0, 1, true);
+                        }
+                        1 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, 0.42, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 15.66, -0.5, 0, 0, 0, 1, true);
+                        }
+                        2 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, 0.26, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 16.92, -1.29, 0, 0, 0, 1, true);
+                        }
+                        3 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, 0.85, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 10.9, -0.64, 0, 0, 0, 1, true);
+                        }
+                        4 => {
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.17, 0.4, 0, 0, 0, 1, true);
+                            EFFECT_FOLLOW(weapon, Hash40::new("duckhunt_wildegunman_light"), Hash40::new("top"), -0.5, 14.16, -1.36, 0, 0, 0, 1, true);
+                        }
+                        _ => {
+                            return
+                        }
+                    }
+                }
+                WorkModule::set_int(weapon.module_accessor, 25, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
             }
-        } 
+            VarModule::set_int(duckhunt, vars::duckhunt::GUNMAN_TIMER, 180);
+        }
     }
 }
 


### PR DESCRIPTION
- [x] Down Air 
 * Air-only BKB 10 > 30
 * Air-only KBG 80 > 60
- [x] Jab 2 
 * Angle 361 > 70
- [x] Side Special 
 * Initial contact hitlag 2 > 5
- [x] Down Special 
 * Shot timer set to 5 seconds, uniform for all gunmen
 * Can be remotely detonated with a down special input
 * Duck Hunt does not enter spawn animation while detonating
 * Added 3 second timer to charge next gunman
 * Flashes white when charged
 * Post-shot frames 100 > 130
 * Health 5 > 7
 * FAF decreased
- [x] Down Throw
 * BKB 70 > 110
 * KBG 50 > 40
- [x] Smash Attacks
 * Added fire effect on hit
- [x] Dash Attack
 * Added reverse property on back side of late hit

Fixes #288 