### PR TITLE
Fix double traction

### DIFF
--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -270,14 +270,6 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
             }
         }
     }
-	
-	
-    if x1 == hash40("ground_brake") {
-        //if double_traction_check[hdr::get_player_number(&mut *boma)] {
-        if VarModule::is_flag(boma_reference.object(), vars::common::ENABLE_DOUBLE_TRACTION){
-            return original!()(x0, hash40("ground_brake"), 0) * 2.0;
-        }
-    }
 
     /*if x1 == hash40("air_speed_x_stable") {
         if StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_JUMP_SQUAT {


### PR DESCRIPTION
Double traction is now properly applied when you are above max walk speed (during certain states)

Needs to be coupled with fighter_param_motion.prc changes HDR-Development/hdr-private/pull/35

Fixes #218 