### PR TITLE
fixing rate limits on pr label changes by using release token

### DIFF
--- a/.github/workflows/semver_label_check.yml
+++ b/.github/workflows/semver_label_check.yml
@@ -1,6 +1,6 @@
 name: validate pr labels
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, reopened, synchronize, ready_for_review]
 jobs:
   check-pr:
@@ -11,6 +11,6 @@ jobs:
         name: Validate Pull Request Metadata
         with:
           mode: validate
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.RELEASE_TOKEN }}
           minor-label: semver:feature
           patch-label: semver:patch


### PR DESCRIPTION
pr label validation uses the github token, which means it is getting rate limited. This change switches to the release token (which is a personal access token) to avoid rate limits that are stopping pr validation. We also switch to using PR target, so that people cannot abuse this as a security concern.