### PR TITLE
Revert changes to resolve match load crashes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -303,9 +303,6 @@ pub mod vars {
     pub mod palutena {
         // floats
         pub const SPECIAL_LW_LR: i32 = 0x1000;
-
-        // flags
-        pub const SPECIAL_LW_AEGIS_REFLECTOR: i32 = 0x1000;
     }
 
     pub mod miiswordsman {

--- a/fighters/palutena/src/acmd/other.rs
+++ b/fighters/palutena/src/acmd/other.rs
@@ -89,8 +89,7 @@ unsafe fn palutena_reflectionboard_shoot_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 125, 40, 0, 75, 5.0, 0.0, 8.5, 0.0, Some(0.0), Some(-4.5), Some(0.0), 2.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 40, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_ITEM, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
-        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 0.1);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 125, 40, 0, 75, 5.0, 0.0, 8.5, 0.0, Some(0.0), Some(-4.5), Some(0.0), 2.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 40, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_ITEM, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
     }
     frame(lua_state, 180.0);
     if is_excute(fighter) {

--- a/fighters/palutena/src/acmd/specials.rs
+++ b/fighters/palutena/src/acmd/specials.rs
@@ -8,10 +8,6 @@ use super::*;
 unsafe fn palutena_special_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR);
-    }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 6.8, 6.8);
@@ -19,11 +15,8 @@ unsafe fn palutena_special_lw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 7.0);
     if is_excute(fighter) {
         if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW))
-           && !ArticleModule::is_exist(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD)
-           && !(VarModule::get_int(fighter.battle_object, vars::common::GIMMICK_TIMER) > 0) {
-            VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, 1); // Start counting the cooldown timer
+           && !ArticleModule::is_exist(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD) {
             VarModule::set_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR, PostureModule::lr(fighter.module_accessor));
-            VarModule::on_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR);
             StatusModule::change_status_request_from_script(boma, *FIGHTER_PALUTENA_STATUS_KIND_SPECIAL_LW_REFLECT, true);
         }
         else{
@@ -40,17 +33,13 @@ unsafe fn palutena_special_lw_game(fighter: &mut L2CAgentBase) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 3.0, 3.2);
         search!(fighter, *MA_MSC_CMD_SEARCH_SEARCH_SCH_CLR, 0);
     }
-
+    
 }
 
 #[acmd_script( agent = "palutena", script = "game_specialairlw" , category = ACMD_GAME , low_priority)]
 unsafe fn palutena_special_air_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR);
-    }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 6.8, 6.8);
@@ -58,11 +47,8 @@ unsafe fn palutena_special_air_lw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 7.0);
     if is_excute(fighter) {
         if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW))
-           && !ArticleModule::is_exist(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD)
-           && !(VarModule::get_int(fighter.battle_object, vars::common::GIMMICK_TIMER) > 0) {
-            VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, 1); // Start counting the cooldown timer
+           && !ArticleModule::is_exist(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD) {
             VarModule::set_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR, PostureModule::lr(fighter.module_accessor));
-            VarModule::on_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR);
             StatusModule::change_status_request_from_script(boma, *FIGHTER_PALUTENA_STATUS_KIND_SPECIAL_LW_REFLECT, true);
         }
         else{
@@ -87,74 +73,22 @@ unsafe fn palutena_special_lw_reflect_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            FT_MOTION_RATE(fighter, 1.5);
-            PostureModule::set_lr(boma, VarModule::get_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR));
-            PostureModule::update_rot_y_lr(boma);
-        }
-        else {
-            shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
-        }
+        PostureModule::set_lr(boma, VarModule::get_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR));
+        PostureModule::update_rot_y_lr(boma);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
+        ArticleModule::generate_article(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD, false, 0);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
-        }
+        shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            ArticleModule::generate_article(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD, false, 0);
-            FT_MOTION_RATE(fighter, 0.75);
-        }
-        else{
-            FT_MOTION_RATE(fighter, 0.6);
-        }
+        FT_MOTION_RATE(fighter, 0.6);
     }
     frame(lua_state, 35.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.0);
-    }
-
-}
-
-#[acmd_script( agent = "palutena", script = "effect_speciallwreflect" , category = ACMD_EFFECT , low_priority)]
-unsafe fn palutena_special_lw_reflect_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
-            EFFECT_FOLLOW(fighter, Hash40::new("palutena_wand_light_trace"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-            EffectModule::enable_sync_init_pos_last(boma);
-            EFFECT_FOLLOW(fighter, Hash40::new("palutena_wand_light2"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-            EFFECT(fighter, Hash40::new("palutena_throw_twinkle"), Hash40::new("top"), 0.0, 16.0, -8.0, 0, 0, 0, 0.95, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT(fighter, Hash40::new("palutena_mirror_break"), Hash40::new("top"), 0.0, 16.0, -8.0, 0, 0, 0, 0.225, 0, 0, 0, 0, 0, 0, true);
-        }
-        else{
-            EFFECT(fighter, Hash40::new("palutena_mirror"), Hash40::new("top"), 12.0, 12.0, 0, 0, 22.5, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
-            EFFECT_DETACH_KIND(fighter, Hash40::new("palutena_backlight"), -1);
-        }
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("palutena_backlight"), Hash40::new("top"), -1, 21, 1, 0, 90, 0, 1, true, 0.7);
-        }
-    }
-    frame(lua_state, 35.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT_OFF_KIND(fighter, Hash40::new("palutena_wand_light_trace"), false, false);
-            EFFECT_OFF_KIND(fighter, Hash40::new("palutena_wand_light2"), false, false);
-        }
     }
 
 }
@@ -164,73 +98,22 @@ unsafe fn palutena_special_air_lw_reflect_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            FT_MOTION_RATE(fighter, 1.5);
-            PostureModule::set_lr(boma, VarModule::get_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR));
-            PostureModule::update_rot_y_lr(boma);
-        }
-        else {
-            shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
-        }
+        PostureModule::set_lr(boma, VarModule::get_float(fighter.battle_object, vars::palutena::SPECIAL_LW_LR));
+        PostureModule::update_rot_y_lr(boma);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
+        ArticleModule::generate_article(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD, false, 0);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
-        }
+        shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PALUTENA_REFLECTOR_KIND_REFLECTOR, *FIGHTER_REFLECTOR_GROUP_EXTEND);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            ArticleModule::generate_article(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD, false, 0);
-            FT_MOTION_RATE(fighter, 0.75);
-        }
-        else{
-            FT_MOTION_RATE(fighter, 0.6);
-        }
+        FT_MOTION_RATE(fighter, 0.6);
     }
     frame(lua_state, 35.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.0);
-    }
-
-}
-
-#[acmd_script( agent = "palutena", script = "effect_specialairlwreflect" , category = ACMD_EFFECT , low_priority)]
-unsafe fn palutena_special_air_lw_reflect_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT_FOLLOW(fighter, Hash40::new("palutena_wand_light_trace"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-            EffectModule::enable_sync_init_pos_last(boma);
-            EFFECT_FOLLOW(fighter, Hash40::new("palutena_wand_light2"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-            EFFECT(fighter, Hash40::new("palutena_throw_twinkle"), Hash40::new("top"), 0.0, 16.0, -8.0, 0, 0, 0, 0.95, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT(fighter, Hash40::new("palutena_mirror_break"), Hash40::new("top"), 0.0, 16.0, -8.0, 0, 0, 0, 0.225, 0, 0, 0, 0, 0, 0, true);
-        }
-        else{
-            EFFECT(fighter, Hash40::new("palutena_mirror"), Hash40::new("top"), 12.0, 12.0, 0, 0, 22.5, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
-            EFFECT_DETACH_KIND(fighter, Hash40::new("palutena_backlight"), -1);
-        }
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("palutena_backlight"), Hash40::new("top"), -1, 21, 1, 0, 90, 0, 1, true, 0.7);
-        }
-    }
-    frame(lua_state, 35.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::palutena::SPECIAL_LW_AEGIS_REFLECTOR) {
-            EFFECT_OFF_KIND(fighter, Hash40::new("palutena_wand_light_trace"), false, false);
-            EFFECT_OFF_KIND(fighter, Hash40::new("palutena_wand_light2"), false, false);
-        }
     }
 
 }
@@ -241,9 +124,7 @@ pub fn install() {
         palutena_special_lw_game,
         palutena_special_air_lw_game,
         palutena_special_lw_reflect_game,
-        palutena_special_lw_reflect_effect,
         palutena_special_air_lw_reflect_game,
-        palutena_special_air_lw_reflect_effect,
     );
 }
 

--- a/fighters/palutena/src/lib.rs
+++ b/fighters/palutena/src/lib.rs
@@ -40,6 +40,4 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     //status::install();
     opff::install(is_runtime);
-    use opff::*;
-    smashline::install_agent_frame_callback!(reflection_board_callback);
 }

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -4,12 +4,8 @@ use super::*;
 use globals::*;
 
  
-pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     palutena_teleport_cancel(boma, id, status_kind, situation_kind, cat[0]);
-    palutena_counter_b_reverse(boma, id, status_kind, situation_kind, stick_x, facing, frame, cat[0]);
-    aegis_reflector_timer(fighter, boma, id);
-    aegis_reflector_reset(fighter, id, status_kind);
-    aegis_reflector_training(fighter, id, status_kind);
 }
 
 pub unsafe fn palutena_teleport_cancel(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32) {
@@ -69,60 +65,6 @@ pub unsafe fn palutena_teleport_cancel(boma: &mut BattleObjectModuleAccessor, id
     }
 }
 
-pub unsafe fn palutena_counter_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32, cat1: i32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
-    }
-}
-
-extern "Rust" {
-    fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
-}
-
-
-// Aegis Reflector Timer Count
-unsafe fn aegis_reflector_timer(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize) {
-    let gimmick_timerr = VarModule::get_int(fighter.battle_object, vars::common::GIMMICK_TIMER);
-    if gimmick_timerr > 0 && gimmick_timerr < 901 {
-        if gimmick_timerr > 899 {
-            VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, 0);
-            gimmick_flash(boma);
-        } else {
-            VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, gimmick_timerr + 1);
-        }
-    }
-}
-
-// Aegis Reflector Timer Death Reset
-unsafe fn aegis_reflector_reset(fighter: &mut L2CFighterCommon, id: usize, status_kind: i32) {
-    if [*FIGHTER_STATUS_KIND_DEAD,
-        *FIGHTER_STATUS_KIND_REBIRTH,
-        *FIGHTER_STATUS_KIND_WIN,
-        *FIGHTER_STATUS_KIND_LOSE,
-        *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
-        VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, 0);
-    }
-}
-
-// Training Mode Aegis Reflector timer taunt reset
-unsafe fn aegis_reflector_training(fighter: &mut L2CFighterCommon, id: usize, status_kind: i32) {
-    if is_training_mode() {
-        if status_kind == *FIGHTER_STATUS_KIND_APPEAL {
-            VarModule::set_int(fighter.battle_object, vars::common::GIMMICK_TIMER, 0);
-        }
-    }
-}
-
 #[utils::macros::opff(FIGHTER_KIND_PALUTENA )]
 pub fn palutena_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
@@ -133,23 +75,6 @@ pub fn palutena_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn palutena_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
-    }
-}
-
-#[smashline::weapon_frame_callback]
-pub fn reflection_board_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
-    unsafe { 
-        if weapon.kind() != WEAPON_KIND_PALUTENA_REFLECTIONBOARD {
-            return
-        }
-        if weapon.is_status(*WEAPON_PALUTENA_REFLECTIONBOARD_STATUS_KIND_SHOOT) {
-            let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
-            let palutena = utils::util::get_battle_object_from_id(owner_id);
-            let palutena_boma = &mut *(*palutena).module_accessor;
-            if AttackModule::is_infliction_status(weapon.module_accessor, *COLLISION_KIND_MASK_ATTACK){
-                StatusModule::change_status_request_from_script(weapon.module_accessor, *WEAPON_PALUTENA_REFLECTIONBOARD_STATUS_KIND_BREAK, false);
-            }
-        }
+        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }


### PR DESCRIPTION
reverting aegis reflector changes because they cause the plugin to crash at match load consistently for people. PR will be reopened with the changes again for future work.