### PR TITLE
nro chainloading and simple install validation

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(proc_macro_hygiene)]
 
 use skyline::libc::c_char;
+use std::{path::Path, fs};
 
 #[cfg(feature = "updater")]
 mod updater;
@@ -25,7 +26,10 @@ fn change_version_string_hook(arg: u64, string: *const c_char) {
         };
         let hdr_version = match std::fs::read_to_string("mods:/ui/hdr_version.txt") {
             Ok(version_value) => version_value.trim().to_string(),
-            Err(_) => String::from("UNKNOWN"),
+            Err(_) => {
+                skyline_web::DialogOk::ok("hdr-assets is not enabled! Please enable hdr-assets in arcropolis config.");
+                String::from("UNKNOWN")
+            }
         };
         let new_str = format!(
             "{}\nHDR Ver. {}\nAssets Ver. {}\0",
@@ -57,5 +61,137 @@ pub fn main() {
             .join();
     }
 
+    quick_validate_install();
+
     skyline::install_hooks!(change_version_string_hook);
+}
+
+pub fn is_on_ryujinx() -> bool {
+    unsafe { // Ryujinx skip based on text addr
+        let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
+        if text_addr == 0x8004000 {
+            println!("we are on Ryujinx");
+            return true;
+        } else {
+            println!("we are not on Ryujinx");
+            return false;
+        }
+    }
+}
+
+pub fn quick_validate_install() {
+    let has_smashline_development_hook = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libsmashline_hook_development.nro").is_file();
+    if has_smashline_development_hook {
+        println!("libsmashline_hook_development.nro is present");
+    } else {
+        if is_on_ryujinx() {
+            println!("No libsmashline_hook_development.nro found! We will likely crash.");
+        } else {
+            skyline_web::DialogOk::ok("No libsmashline_hook_development.nro found! We will likely crash.");
+        }
+    }
+
+    let has_arcropolis_nro = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libarcropolis.nro").is_file();
+    if has_arcropolis_nro {
+        println!("libarcropolis.nro is present");
+    } else {
+        if is_on_ryujinx() {
+            println!("No libarcropolis.nro found! We will either crash, or game functionality will be broken.");
+        } else {
+            skyline_web::DialogOk::ok("No libarcropolis.nro found! We will either crash, or game functionality will be broken.");
+        }
+    }
+
+    let has_nro_hook = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libnro_hook.nro").is_file();
+    if has_nro_hook {
+        if is_on_ryujinx() {
+            println!("libnro_hook.nro found! This will conflict with hdr! Expect a crash soon.");
+        } else {
+            let should_delete = skyline_web::Dialog::yes_no("libnro_hook.nro found! This will conflict with hdr! Would you like to delete it?");
+            if should_delete {
+                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libnro_hook.nro");
+                unsafe {
+                    skyline::nn::oe::RequestToRelaunchApplication();
+                }
+            } else {
+                skyline_web::DialogOk::ok("Warning, we will likely crash soon because of this conflict.");
+            }
+        }
+    }
+
+    let has_smashline_hook = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libsmashline_hook.nro").is_file();
+    if has_smashline_hook {
+        if is_on_ryujinx() {
+            println!("libsmashline_hook.nro found! This will conflict with hdr! Expect a crash soon.");
+        } else {
+            let should_delete = skyline_web::Dialog::yes_no("libsmashline_hook.nro found! This will conflict with hdr! Would you like to delete it?");
+            if should_delete {
+                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libsmashline_hook.nro");
+                unsafe {
+                    skyline::nn::oe::RequestToRelaunchApplication();
+                }
+            } else {
+                skyline_web::DialogOk::ok("Warning, we will likely crash soon because of this conflict.");
+            }
+        }
+    }
+
+    let has_development_nro = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro").is_file();
+    let has_dev_folder = Path::new("sd:/ultimate/mods/hdr-dev/").is_dir();
+    if has_development_nro && !has_dev_folder {
+        if is_on_ryujinx() {
+            println!("development.nro found, but there is no hdr-dev folder! This is likely a mistake.");
+        } else {
+            let should_delete = skyline_web::Dialog::yes_no("development.nro found, but there is no hdr-dev folder! This is likely a mistake. Would you like to delete it?");
+            if should_delete {
+                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro");
+                unsafe {
+                    skyline::nn::oe::RequestToRelaunchApplication();
+                }
+            } 
+        }
+    }
+    
+
+    let has_stale_hdr = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro").is_file();
+    if has_stale_hdr {
+        if is_on_ryujinx() {
+            println!("stale libhdr.nro found! This will conflict with your newer hdr! Expect a crash soon.");
+        } else {
+            let should_delete = skyline_web::Dialog::yes_no("Stale libhdr.nro found in atmos/contents! This will conflict with new hdr packaging! Would you like to delete it?");
+            if should_delete {
+                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro");
+                unsafe {
+                    skyline::nn::oe::RequestToRelaunchApplication();
+                }
+            } else {
+                skyline_web::DialogOk::ok("Warning, we will likely crash soon or have undefined behavior because of this conflict.");
+            }
+        }
+    }
+
+    let has_hdr_assets = Path::new("sd:/ultimate/mods/hdr-assets/").is_dir();
+    if has_hdr_assets {
+        println!("hdr-assets are present");
+    } else {
+        if is_on_ryujinx() {
+            println!("No hdr-assets found! This installation is incomplete. Please install the full package.");
+        } else {
+            skyline_web::DialogOk::ok("No hdr-assets found! This installation is incomplete. Please install the full package.");
+        }
+    }
+
+    let has_hdr_stages = Path::new("sd:/ultimate/mods/hdr-stages/").is_dir();
+    if has_hdr_stages {
+        println!("hdr-stages are present");
+    } else {
+        if is_on_ryujinx() {
+            println!("No hdr-stages found! This installation is incomplete. Please install the full package.");
+        } else {
+            skyline_web::DialogOk::ok("No hdr-stages found! This installation is incomplete. Please install the full package.");
+        }
+    }
+
+    println!("simple validation complete.");
+
 }

--- a/plugin/src/updater.rs
+++ b/plugin/src/updater.rs
@@ -3,6 +3,7 @@ use std::{path::Path, io::Cursor};
 use gh_updater::ReleaseFinderConfig;
 use semver::Version;
 use zip::ZipArchive;
+use super::*;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum WhichVersion {
@@ -40,14 +41,8 @@ fn get_version(current: &Version, release: Option<&Version>, prerelease: Option<
 }
 
 pub fn check_for_updates() {
-    unsafe { // Ryujinx skip based on text addr
-        let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
-        if text_addr == 0x8004000 {
-            println!("HDR cannot auto-update on Ryujinx");
-            return;
-        } else {
-            println!("Checking for HDR updates...");
-        }
+    if is_on_ryujinx() {
+        return
     }
 
     let release = ReleaseFinderConfig::new("HewDraw-Remix")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -107,6 +107,8 @@ for arg in sys.argv:
   if "name=" in arg:
     mod_name = arg.split('=')[1]
 
+switch_hdr_dir = "ultimate/mods/" + mod_name
+ryujinx_hdr_dir = "sdcard/ultimate/mods/" + mod_name
 
 # search for dev plugin args
 dev_characters = set()
@@ -183,16 +185,16 @@ if (is_dev_build and not is_publish):
 
   # collect switch plugin
   pkgutil.collect_plugin("hdr-switch", 
-    os.path.join(switch_rom_path, plugin_subpath), 
-    build_type, "libhdr.nro", "standalone")
+    os.path.join(switch_hdr_dir), 
+    build_type, "plugin.nro", "standalone")
 
     # collect switch romfs
   pkgutil.collect_romfs("hdr-switch", "", mod_name)
 
   # collect ryujinx plugin
   pkgutil.collect_plugin("hdr-ryujinx", 
-    os.path.join(ryujinx_rom_path, plugin_subpath), 
-    build_type, "libhdr.nro", "standalone")
+    os.path.join(ryujinx_hdr_dir), 
+    build_type, "plugin.nro", "standalone")
   
   # collect ryujinx romfs
   pkgutil.collect_romfs("hdr-ryujinx", "sdcard", mod_name)
@@ -207,8 +209,8 @@ else:
 
   # collect switch package
   pkgutil.collect_plugin("hdr-switch", 
-    os.path.join(switch_rom_path, plugin_subpath), 
-    build_type, "libhdr.nro")
+    os.path.join(switch_hdr_dir), 
+    build_type, "plugin.nro")
 
   # collect switch romfs
   pkgutil.collect_romfs("hdr-switch", "", mod_name)
@@ -216,8 +218,8 @@ else:
 
   # collect ryujinx plugin
   pkgutil.collect_plugin("hdr-ryujinx", 
-    os.path.join(ryujinx_rom_path, plugin_subpath), 
-    build_type, "libhdr.nro")
+    os.path.join(ryujinx_hdr_dir), 
+    build_type, "plugin.nro")
   
   # collect ryujinx romfs
   pkgutil.collect_romfs("hdr-ryujinx", "sdcard", mod_name)

--- a/scripts/pkgutil.py
+++ b/scripts/pkgutil.py
@@ -15,7 +15,9 @@ def collect_plugin(package_name: str, package_path: str, build_type: str, plugin
   print("plugin source: " + plugin_source)
 
   plugin_destination = os.path.join('build', package_name, package_path)
-  pathlib.Path(plugin_destination).mkdir(parents=True)
+  os.makedirs(plugin_destination, exist_ok=True)
+  print("copying plugin from: " + plugin_source)
+  print("copying plugin into: " + plugin_destination)
   shutil.copy(
     os.path.join(plugin_source), 
     os.path.join(plugin_destination, plugin_name))
@@ -28,7 +30,8 @@ def collect_romfs(package_name: str, context_path: str, mod_name: str):
   romfs_destination = os.path.join("build", package_name, context_path, "ultimate/mods", mod_name)
   shutil.copytree(
     os.path.join(romfs_source), 
-    os.path.join(romfs_destination))
+    os.path.join(romfs_destination),
+    dirs_exist_ok=True)
   shutil.copyfile(os.path.join("romfs/config.json"), os.path.join(romfs_destination, "config.json"))
   shutil.copyfile(os.path.join("plugin/hdr_version.txt"), os.path.join(romfs_destination, "ui/hdr_version.txt"))
   return


### PR DESCRIPTION
1. moving nros into the hdr, hdr-pr, and hdr-dev folders so that they can be turned on or off with arcropolis.
2. adding basic install validation. Will have popups (or in the case of ryujinx, logging) when we determine that this install is broken, and it will warn the user (and in some cases, offer to fix it for them).
- warns you if you dont have the libsmashline_hook_development.nro
- warns you if you dont have arcropolis
- warns you if you have libnro_hook.nro (since this conflicts with libsmashline_hook_development), and offers to remove it
- warns you if you have libsmashline_hook.nro (since this conflicts with libsmashline_hook_development), and offers to remove it
- warns you if you have an old libhdr.nro in `/atmos/contents/titleid`, and offers to remove it (we chainload them in `hdr`, `hdr-dev`, `hdr-pr`, etc now
- warns you if you have a development.nro but dont have hdr-dev, as this is typically a mistake, and offers to remove it.
- warns you if the hdr-assets folder is not found on sd, and tells you to reinstall
- warns you if hdr-stages folder is not found, and tells you to reinstall
- warns you if the assets version could not be determined, because this means hdr-assets is disabled.