### PR TITLE
IRAR rework v2

### DIFF
--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -18,8 +18,7 @@ pub fn install() {
         uniq_process_JumpSquat_exec_status,
         uniq_process_JumpSquat_exec_status_param,
         sub_jump_squat_uniq_check_sub,
-        sub_jump_squat_uniq_check_sub_mini_attack,
-        sub_status_JumpSquat_check_stick_lr_update
+        sub_jump_squat_uniq_check_sub_mini_attack
     );
 }
 /***
@@ -77,8 +76,7 @@ unsafe extern "C" fn status_pre_JumpSquat_param(fighter: &mut L2CFighterCommon, 
 #[common_status_script(status = FIGHTER_STATUS_KIND_JUMP_SQUAT, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN,
     symbol = "_ZN7lua2cpp16L2CFighterCommon16status_JumpSquatEv")]
 unsafe fn status_JumpSquat(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let lr_update = fighter.sub_status_JumpSquat_check_stick_lr_update();
-    fighter.status_JumpSquat_common(lr_update);
+    fighter.status_JumpSquat_common(L2CValue::Bool(false));
     fighter.sub_shift_status_main(L2CValue::Ptr(status_JumpSquat_Main as *const () as _))
 }
 
@@ -193,11 +191,6 @@ unsafe fn status_JumpSquat_common(fighter: &mut L2CFighterCommon, lr_update: L2C
     }
     // I think this int might be referring to how many frames we check for tap jump?
     WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_INSTANCE_WORK_ID_INT_STICK_JUMP_COMMAND_LIFE);
-    // `lr_update` comes from a dif subroutine
-    if lr_update.get_bool() {
-        PostureModule::set_stick_lr(fighter.module_accessor, 0.0);
-        PostureModule::update_rot_y_lr(fighter.module_accessor);
-    }
     ControlModule::reset_flick_y(fighter.module_accessor);
     ControlModule::reset_flick_sub_y(fighter.module_accessor);
     fighter.global_table[FLICK_Y].assign(&0xFE.into());
@@ -448,10 +441,4 @@ unsafe fn sub_jump_squat_uniq_check_sub_mini_attack(fighter: &mut L2CFighterComm
         }
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_MINI_ATTACK);
     }
-}
-
-#[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon42sub_status_JumpSquat_check_stick_lr_updateEv")]
-unsafe fn sub_status_JumpSquat_check_stick_lr_update(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let prev_status = fighter.global_table[PREV_STATUS_KIND].get_i32();
-    L2CValue::Bool(prev_status == *FIGHTER_STATUS_KIND_DASH && !VarModule::is_flag(fighter.battle_object, vars::common::IS_MOONWALK_JUMP))
 }

--- a/fighters/common/src/general_statuses/turn.rs
+++ b/fighters/common/src/general_statuses/turn.rs
@@ -90,54 +90,54 @@ unsafe extern "C" fn status_turn_main(fighter: &mut L2CFighterCommon) -> L2CValu
         if fighter.global_table[STICK_X].get_f32() == 0.0 {
             VarModule::off_flag(fighter.battle_object, vars::common::DISABLE_BACKDASH);
         }
-        if !status_turncommon(fighter).get_bool() {
-            //println!("turncommon false");
-            if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
-                if fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0 || fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0 || VarModule::is_flag(fighter.battle_object, vars::common::IS_TURNDASH_INPUT) || VarModule::is_flag(fighter.battle_object, vars::common::IS_BACKDASH) || VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) {
-                    let dash_stick_x: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dash_stick_x"));
-                    let stick_x = fighter.global_table[STICK_X].get_f32();
-                    let turn_work_lr: f32 = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_TURN_WORK_FLOAT_LR);
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            if fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0 || fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0 || VarModule::is_flag(fighter.battle_object, vars::common::IS_TURNDASH_INPUT) || VarModule::is_flag(fighter.battle_object, vars::common::IS_BACKDASH) || VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) {
+                let dash_stick_x: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dash_stick_x"));
+                let stick_x = fighter.global_table[STICK_X].get_f32();
+                let turn_work_lr: f32 = WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_TURN_WORK_FLOAT_LR);
 
-                    if stick_x * turn_work_lr >= dash_stick_x {
-                        if MotionModule::frame(fighter.module_accessor) >= 1.0 {
-                            //println!("backdash in turn");
-                            VarModule::on_flag(fighter.battle_object, vars::common::IS_BACKDASH);
-                            VarModule::on_flag(fighter.battle_object, vars::common::IS_TURNDASH_INPUT);
-                            interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
-                        }
+                if stick_x * turn_work_lr >= dash_stick_x {
+                    if MotionModule::frame(fighter.module_accessor) >= 1.0 {
+                        //println!("backdash in turn");
+                        VarModule::on_flag(fighter.battle_object, vars::common::IS_BACKDASH);
+                        VarModule::on_flag(fighter.battle_object, vars::common::IS_TURNDASH_INPUT);
+                        interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
                     }
+                }
 
-                    if !VarModule::is_flag(fighter.battle_object, vars::common::DISABLE_BACKDASH) && stick_x * -1.0 * turn_work_lr >= dash_stick_x {
-                        if MotionModule::frame(fighter.module_accessor) >= 1.0 {
-                            //println!("dash in turn");
+                if !VarModule::is_flag(fighter.battle_object, vars::common::DISABLE_BACKDASH) && stick_x * -1.0 * turn_work_lr >= dash_stick_x {
+                    if MotionModule::frame(fighter.module_accessor) >= 1.0 {
+                        //println!("dash in turn");
+                        VarModule::off_flag(fighter.battle_object, vars::common::IS_BACKDASH);
+                        interrupt!(fighter, FIGHTER_STATUS_KIND_DASH, true);
+                    }
+                }
+                if stick_x * -1.0 * turn_work_lr < dash_stick_x && (VarModule::is_flag(fighter.battle_object, vars::common::IS_BACKDASH) || VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT)) {
+                    if StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_DASH {
+                        // perfect pivot
+                        if MotionModule::frame(fighter.module_accessor) <= 1.0 || (VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) && MotionModule::frame(fighter.module_accessor) <= 7.0) {
                             VarModule::off_flag(fighter.battle_object, vars::common::IS_BACKDASH);
-                            interrupt!(fighter, FIGHTER_STATUS_KIND_DASH, true);
-                        }
-                    }
-                    if stick_x * -1.0 * turn_work_lr < dash_stick_x && (VarModule::is_flag(fighter.battle_object, vars::common::IS_BACKDASH) || VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT)) {
-                        if StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_DASH && StatusModule::prev_status_kind(fighter.module_accessor, 1) != *FIGHTER_STATUS_KIND_WAIT {
-                            // perfect pivot
-                            if MotionModule::frame(fighter.module_accessor) <= 1.0 || (VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) && MotionModule::frame(fighter.module_accessor) <= 7.0) {
-                                VarModule::off_flag(fighter.battle_object, vars::common::IS_BACKDASH);
-                                let dash_speed: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("dash_speed"), 0);
-                                let mut multiplier = -0.75;
-                                if VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) {
-                                    multiplier = -0.5
-                                }
-                                VarModule::off_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT);
-                                let pivot_boost: smash::phx::Vector3f = smash::phx::Vector3f {x: dash_speed * multiplier, y: 0.0, z: 0.0};
-                                KineticModule::clear_speed_all(fighter.module_accessor);
-                                KineticModule::add_speed(fighter.module_accessor, &pivot_boost);
+                            let dash_speed: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("dash_speed"), 0);
+                            let mut multiplier = -0.75;
+                            if VarModule::is_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT) {
+                                multiplier = -0.5
                             }
+                            VarModule::off_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT);
+                            let pivot_boost: smash::phx::Vector3f = smash::phx::Vector3f {x: dash_speed * multiplier, y: 0.0, z: 0.0};
+                            KineticModule::clear_speed_all(fighter.module_accessor);
+                            KineticModule::add_speed(fighter.module_accessor, &pivot_boost);
                         }
                     }
                 }
             }
-            fighter.clear_lua_stack();
-            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL);
-            let speed_control = app::sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
-            //println!("turn speed_control: {}", speed_control);
-            //println!("turn total speed: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN));
+        }
+        /***fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let speed_control = app::sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
+        println!("turn speed_control: {}", speed_control);
+        println!("turn total speed: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN));
+        ***/
+        if !status_turncommon(fighter).get_bool() {
             return L2CValue::I32(0);
         }
     }


### PR DESCRIPTION
General change which affects IRAR:
- Frame-perfect (immediate) pivot cancels now properly apply slide into next action

IRAR input:
- IRAR can now only be performed out of a smash turn (in dash, input turn, then jump on next frame)
- Stick must be below dash threshold to apply perfect pivot boost into IRAR. Otherwise, you will pivot jump in place