### PR TITLE
dk bair lowered programmatically

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -347,6 +347,7 @@ pub trait BomaExt {
     unsafe fn is_flick_y(&mut self, sensitivity: f32) -> bool;
     unsafe fn is_input_jump(&mut self) -> bool;
     unsafe fn get_aerial(&mut self) -> Option<AerialKind>;
+    unsafe fn set_joint_rotate(&mut self, bone_name: &str, rotation: Vector3f);
     /// returns whether or not the stick x is pointed in the "forwards" direction for
     /// a character
     unsafe fn is_stick_forward(&mut self) -> bool;
@@ -589,6 +590,11 @@ impl BomaExt for BattleObjectModuleAccessor {
     unsafe fn get_jump_count_max(&mut self) -> i32 {
         return WorkModule::get_int(self, *FIGHTER_INSTANCE_WORK_ID_INT_JUMP_COUNT_MAX);
     }
+
+    unsafe fn set_joint_rotate(&mut self, bone_name: &str, rotation: Vector3f) {
+        ModelModule::set_joint_rotate(self, Hash40::new(&bone_name), &rotation, MotionNodeRotateCompose{_address: *MOTION_NODE_ROTATE_COMPOSE_AFTER as u8}, MotionNodeRotateOrder{_address: *MOTION_NODE_ROTATE_ORDER_XYZ as u8})
+    }
+
 }
 
 pub trait LuaUtil {

--- a/fighters/donkey/src/acmd/aerials.rs
+++ b/fighters/donkey/src/acmd/aerials.rs
@@ -117,7 +117,7 @@ unsafe fn donkey_attack_air_b_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state,6.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter,Hash40::new("donkey_attack_line"), Hash40::new("donkey_attack_line"), Hash40::new("top"), 6, 6, 9, 190, 0, 0, 1.8, true, *EF_FLIP_YZ)
+        EFFECT_FOLLOW_FLIP(fighter,Hash40::new("donkey_attack_line"), Hash40::new("donkey_attack_line"), Hash40::new("top"), 6, 6, 9, 180, 0, 0, 1.8, true, *EF_FLIP_YZ)
     }
     frame(lua_state,7.0);
     if is_excute(fighter) {

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -129,7 +129,7 @@ unsafe fn down_special_cancels(fighter: &mut L2CFighterCommon, boma: &mut Battle
 pub unsafe fn dk_bair_rotation(fighter: &mut L2CFighterCommon) {
     if fighter.is_motion(Hash40::new("attack_air_b")) {
         // angle bair down slightly
-        fighter.set_joint_rotate("legl", Vector3f::new(0.0, 0.0, -10.0))
+        fighter.set_joint_rotate("legl", Vector3f::new(0.0, 0.0, -20.0))
     }
 }
 

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -126,6 +126,12 @@ unsafe fn down_special_cancels(fighter: &mut L2CFighterCommon, boma: &mut Battle
     }
 }
 
+pub unsafe fn dk_bair_rotation(fighter: &mut L2CFighterCommon) {
+    if fighter.is_motion(Hash40::new("attack_air_b")) {
+        // angle bair down slightly
+        fighter.set_joint_rotate("legl", Vector3f::new(0.0, 0.0, -10.0))
+    }
+}
 
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -145,7 +151,8 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 pub fn donkey_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
-		donkey_frame(fighter)
+		donkey_frame(fighter);
+        dk_bair_rotation(fighter);
     }
 }
 


### PR DESCRIPTION
dk bair is now angled more flat like it has been in previous games. His boxing potential has been missing this tool because it doesnt hit standing opponents out of shorthop, similarly to falcon's same issue

Also introduces an extension trait to set bone rotations easily, instead of a model rotation module.
Resolves  #351