### PR TITLE
packaging updates

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -123,10 +123,21 @@ jobs:
       with:
         repository: HDR-Development/romfs-release
 
+    # validate that the chosen release exists
+    - name: get the specified release
+      uses: cardinalby/git-get-release-action@v1
+      if: github.event.inputs.romfs_version != 'latest'
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      with:
+        tag: ${{ github.event.inputs.romfs_version }}   
+        repo: 'HDR-Development/romfs-release'
+
     - name: make package with chosen version
       if: github.event.inputs.romfs_version != 'latest'
       run: |
         python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ github.event.inputs.romfs_version }} 
+
 
     - name: make package with latest
       if: github.event.inputs.romfs_version == 'latest'

--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -141,7 +141,7 @@ jobs:
         prerelease: false
         file_glob: true
         asset_name: the_asset
-        repo_name: HDR-Development/HDR-Nightlies
+        repo_name: HDR-Development/HDR-Releases
         release_name: ${{ needs.version_and_changelog.outputs.version }}-nightly
         tag: ${{ needs.version_and_changelog.outputs.version }}
         overwrite: true

--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -2,7 +2,11 @@ name: make beta
 
 on:
   workflow_dispatch:
-
+    romfs_version:
+      type: string
+      description: The romfs version tag to use
+      required: true
+      default: latest
 jobs:
   version_and_changelog:
     runs-on: ubuntu-latest
@@ -108,5 +112,37 @@ jobs:
         asset_name: the_asset
         release_name: ${{ steps.trimmed_tag.outputs.tag }}-beta
         tag: ${{ steps.trimmed_tag.outputs.tag }}
+        overwrite: true
+        body: ${{ needs.version_and_changelog.outputs.changelog }}
+
+  full_package:
+    runs-on: ubuntu-latest
+    needs: [version_and_changelog, plugin_build]
+    - id: romfs_latest
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: HDR-Development/romfs-release
+
+    - name: make package with chosen version
+      if: github.event.inputs.romfs_version != 'latest'
+      run: |
+        python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ github.event.inputs.romfs_version }} 
+
+    - name: make package with latest
+      if: github.event.inputs.romfs_version == 'latest'
+      run: |
+        python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ steps.romfs_latest.outputs.release }}
+
+    - name: Upload full package to nightlies
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: package.zip
+        prerelease: false
+        file_glob: true
+        asset_name: the_asset
+        repo_name: HDR-Development/HDR-Nightlies
+        release_name: ${{ needs.version_and_changelog.outputs.version }}-nightly
+        tag: ${{ needs.version_and_changelog.outputs.version }}
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -64,7 +64,7 @@ jobs:
     # build the project
     - run: |
         export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin \
-        && cd scripts && python3 make_dist.py publish version=${{ needs.version_and_changelog.outputs.version }}-nightly name=hdr && cd ..
+        && cd scripts && python3 make_dist.py build version=${{ needs.version_and_changelog.outputs.version }}-nightly name=hdr && cd ..
       env:
         HOME: /root
 
@@ -104,10 +104,10 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.RELEASE_TOKEN }}
-        file: package.zip
+        file: artifacts/*
         prerelease: false
         file_glob: true
-        asset_name: the_asset
+        asset_name: package
         repo_name: HDR-Development/HDR-Nightlies
         release_name: ${{ needs.version_and_changelog.outputs.version }}-nightly
         tag: ${{ needs.version_and_changelog.outputs.version }}

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -88,6 +88,9 @@ jobs:
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}
 
+  full_package:
+    runs-on: ubuntu-latest
+    needs: [version_and_changelog, plugin_build]
     - id: romfs_version
       uses: pozetroninc/github-action-get-latest-release@master
       with:
@@ -102,7 +105,7 @@ jobs:
       with:
         repo_token: ${{ secrets.RELEASE_TOKEN }}
         file: package.zip
-        prerelease: true
+        prerelease: false
         file_glob: true
         asset_name: the_asset
         repo_name: HDR-Development/HDR-Nightlies

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ plugin/hdr_version.txt
 **/package/
 **/zips/
 *.zip
-scripts/content_hashes.txt
+**/content_hashes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ plugin/hdr_version.txt
 **/package.zip
 **/package/
 **/zips/
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ plugin/hdr_version.txt
 **/package/
 **/zips/
 *.zip
+scripts/content_hashes.txt

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -27,7 +27,6 @@ def download_and_extract(owner: str, repo: str, tag: str, asset: str, extract_di
     else:
         print("getting release from url: " + url)
 
-    print(url)
     urllib.request.urlretrieve(url, asset)
     with zipfile.ZipFile(asset, 'r') as zip_ref: 
         if extract_directory:

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -1,3 +1,4 @@
+from codecs import ignore_errors
 from time import sleep
 import urllib.request, shutil, os, sys
 from urllib.request import urlopen
@@ -16,12 +17,17 @@ if os.path.exists("package.zip"):
     os.remove("package.zip")
 os.mkdir("package")
 
-def download_and_extract(owner: str, repo: str, tag: str, asset: str):
+def download_and_extract(owner: str, repo: str, tag: str, asset: str, extract_directory = None):
     url = "https://github.com/" + owner + "/" + repo + "/releases/download/" + tag + "/" + asset
     print(url)
     urllib.request.urlretrieve(url, asset)
-    with zipfile.ZipFile(asset, 'r') as zip_ref:
-        zip_ref.extractall("package")
+    with zipfile.ZipFile(asset, 'r') as zip_ref: 
+        if extract_directory:
+            extract_home = extract_directory
+            os.makedirs("package" + extract_home, exist_ok=True)
+        else:
+            extract_home = ""
+        zip_ref.extractall("package" + extract_home)
         sleep(1)
     os.remove(asset)
 
@@ -30,6 +36,8 @@ os.makedirs("package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/
 download_and_extract("HDR-Development", "HewDraw-Remix", hdr_version, "hdr-switch.zip")
 download_and_extract("HDR-Development", "romfs-release", romfs_version, "romfs.zip")
 download_and_extract("Raytwo", "ARCropolis", "v3.1.0", "release.zip")
+download_and_extract("Raytwo", "ARCropolis", "v3.1.0", "release.zip")
+download_and_extract("skyline-dev", "skyline", "beta", "skyline.zip", "/atmosphere/contents/01006A800016E000/")
 
 #print("getting libnro_hook.nro")
 #urllib.request.urlretrieve("https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.3.0/libnro_hook.nro", "libnro_hook.nro")

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -4,6 +4,10 @@ import urllib.request, shutil, os, sys
 from urllib.request import urlopen
 from shutil import copyfileobj
 import zipfile
+import hashlib
+import glob
+import hash_package
+
 
 if "help" in sys.argv or "--help" in sys.argv or "-h" in sys.argv or len(sys.argv) != 3:
   print("provide arguments for, in order, HewDraw-Remix version and romfs version")
@@ -60,3 +64,13 @@ shutil.move("libsmashline_hook_development.nro", "package/atmosphere/contents/01
 
 print("making package.zip")
 shutil.make_archive("package", 'zip', 'package')
+
+
+hash_package.hash_folder("package", "content_hashes.txt")
+
+# move the stuff to artifacts folder
+if os.path.exists("artifacts"):
+    os.remove("artifacts")
+os.mkdir("artifacts")
+shutil.move("package.zip", "artifacts")
+shutil.move("content_hashes.txt", "artifacts")

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -29,7 +29,7 @@ os.makedirs("package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/
 
 download_and_extract("HDR-Development", "HewDraw-Remix", hdr_version, "hdr-switch.zip")
 download_and_extract("HDR-Development", "romfs-release", romfs_version, "romfs.zip")
-download_and_extract("Raytwo", "ARCropolis", "v3.0.0", "release.zip")
+download_and_extract("Raytwo", "ARCropolis", "v3.1.0", "release.zip")
 
 #print("getting libnro_hook.nro")
 #urllib.request.urlretrieve("https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.3.0/libnro_hook.nro", "libnro_hook.nro")

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -47,7 +47,6 @@ os.makedirs("package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/
 download_and_extract("HDR-Development", "HewDraw-Remix", hdr_version, "hdr-switch.zip")
 download_and_extract("HDR-Development", "romfs-release", romfs_version, "romfs.zip")
 download_and_extract("Raytwo", "ARCropolis", "v3.1.0", "release.zip")
-download_and_extract("Raytwo", "ARCropolis", "v3.1.0", "release.zip")
 download_and_extract("skyline-dev", "skyline", "beta", "skyline.zip", "/atmosphere/contents/01006A800016E000/")
 
 #print("getting libnro_hook.nro")

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -19,6 +19,14 @@ os.mkdir("package")
 
 def download_and_extract(owner: str, repo: str, tag: str, asset: str, extract_directory = None):
     url = "https://github.com/" + owner + "/" + repo + "/releases/download/" + tag + "/" + asset
+
+    # special case for packaging "latest"
+    if tag == 'latest':
+        url = "https://github.com/" + owner + "/" + repo + "/releases/latest/download/" + asset
+        print("getting latest from url: " + url)
+    else:
+        print("getting release from url: " + url)
+
     print(url)
     urllib.request.urlretrieve(url, asset)
     with zipfile.ZipFile(asset, 'r') as zip_ref: 

--- a/scripts/hash_package.py
+++ b/scripts/hash_package.py
@@ -1,0 +1,38 @@
+from codecs import ignore_errors
+from time import sleep
+import urllib.request, shutil, os, sys
+from urllib.request import urlopen
+from shutil import copyfileobj
+import zipfile
+import hashlib
+import glob
+
+# example:
+# hash_folder("package", "content_hashes.txt")
+# returns: the file name that was created
+def hash_folder(folder_path: str, file_name: str):
+    if os.path.exists(file_name):
+        os.remove(file_name)
+    original_dir = os.getcwd()
+    os.chdir(folder_path)
+    files = glob.glob('**/*.*', recursive=True)
+    os.chdir(original_dir)
+    all_hashes = []
+
+    for file in files:
+        # Open,close, read file and calculate MD5 on its contents 
+        with open(os.path.join(folder_path + "/" + file), 'rb') as file_to_check:
+            # read contents of the file
+            data = file_to_check.read()    
+            # pipe contents of the file through
+            md5_returned = hashlib.md5(data).hexdigest()
+            all_hashes.append(os.path.join("/", file) + ":" + md5_returned)
+            #print(os.path.join("/", file) + ":" + md5_returned)
+
+    file_str = ""
+    for line in all_hashes:
+        file_str += line + "\n"
+
+    with open(file_name, 'w') as f:
+        f.write(file_str)
+

--- a/scripts/hash_package.py
+++ b/scripts/hash_package.py
@@ -1,9 +1,4 @@
-from codecs import ignore_errors
-from time import sleep
-import urllib.request, shutil, os, sys
-from urllib.request import urlopen
-from shutil import copyfileobj
-import zipfile
+import os
 import hashlib
 import glob
 
@@ -11,10 +6,13 @@ import glob
 # hash_folder("package", "content_hashes.txt")
 # returns: the file name that was created
 def hash_folder(folder_path: str, file_name: str):
+    # create output file
     if os.path.exists(file_name):
         os.remove(file_name)
+
     original_dir = os.getcwd()
     os.chdir(folder_path)
+    # get all files in the directory
     files = glob.glob('**/*.*', recursive=True)
     os.chdir(original_dir)
     all_hashes = []
@@ -29,10 +27,12 @@ def hash_folder(folder_path: str, file_name: str):
             all_hashes.append(os.path.join("/", file) + ":" + md5_returned)
             #print(os.path.join("/", file) + ":" + md5_returned)
 
+    # build full output
     file_str = ""
     for line in all_hashes:
         file_str += line + "\n"
 
+    # write output to file
     with open(file_name, 'w') as f:
         f.write(file_str)
 


### PR DESCRIPTION
- [x] bumping the version of arcropolis that we package
- [x] packaging latest skyline in every package.
- [x] changing nightly releases to be labelled as "latest"
- [x] automate full packaging of beta builds
- [x] checking and handling "latest" as the version tag for plugin and romfs in packaging script
- [x] defaulting to latest romfs if no version is given in make_beta workflow_dispatch inputs
- [x] validate the given romfs release version, and fail the make_nightly if not valid
- [x] remove original updater that was built into the nro
- [x] calculate and upload file hashes as part of packaging (for future install validation)

resolves #350
resolves HDR-Development/hdr-launcher#13
resolves #341
resolves HDR-Development/hdr-launcher#1
resolves #342 
needs HDR-Development/hdr-private#46