### PR TITLE
switching to release token to avoid api rate limits

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags')
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     outputs: 
       changelog: ${{ steps.github_changelog.outputs.changelog }}
       version: ${{ steps.get_last_beta.outputs.tag_name }}
@@ -27,7 +27,7 @@ jobs:
       id: get_last_beta
       uses: cardinalby/git-get-release-action@v1
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
         releaseNameRegEx: beta
 
@@ -49,7 +49,7 @@ jobs:
       with:
         sinceTag: ${{ steps.get_last_beta.outputs.tag_name }}
         stripHeaders: true
-        token: ${{ secrets.GITHUB_TOKEN }} 
+        token: ${{ secrets.RELEASE_TOKEN }}
 
     - name: Upload changelog
       uses: actions/upload-artifact@v2
@@ -100,14 +100,14 @@ jobs:
         delete_release: true # default: false
         tag_name: ${{ steps.trimmed_tag.outputs.tag }} # tag name to delete
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
 
     # upload asset
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
         file: distributions/*
         prerelease: false
         file_glob: true

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -8,7 +8,7 @@ jobs:
   version_and_changelog:
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     outputs: 
       version: ${{ steps.push_tag.outputs.version }}
       changelog: ${{ steps.github_changelog.outputs.changelog }}
@@ -20,7 +20,7 @@ jobs:
         id: push_tag
         with:
           mode: bump
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.RELEASE_TOKEN }}
           minor-label: semver:feature
           patch-label: semver:patch
           with-v: true
@@ -37,7 +37,7 @@ jobs:
         with:
           sinceTag: ${{ steps.push_tag.outputs.old-version }}
           stripHeaders: true
-          token: ${{ secrets.GITHUB_TOKEN }} 
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Upload changelog
         uses: actions/upload-artifact@v2
@@ -78,7 +78,7 @@ jobs:
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
         file: distributions/*
         prerelease: true
         file_glob: true


### PR DESCRIPTION
using the built in github token results in rate limits which break our builds. Thus, we should be using our RELEASE_TOKEN