### PR TITLE
Jump adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -134,6 +134,7 @@ pub mod vars {
         pub const ENABLE_AIR_ESCAPE_JUMPSQUAT: i32 = 79;
         pub const SHOULD_WAVELAND: i32 = 80;
         pub const SIDE_SPECIAL_CANCEL_NO_HIT: i32 = 81;
+        pub const JUMP_NEXT: i32 = 82;
 
         
 

--- a/fighters/common/src/function_hooks/jumps.rs
+++ b/fighters/common/src/function_hooks/jumps.rs
@@ -1,0 +1,21 @@
+use super::*;
+use utils::ext::*;
+
+
+#[skyline::hook(offset = 0x6d2174, inline)]
+unsafe fn fullhop_initial_y_speed_hook(ctx: &mut skyline::hooks::InlineCtx) {
+    let callable: extern "C" fn(u64, u64, u64) -> f32 = std::mem::transmute(*ctx.registers[8].x.as_ref());
+    let work_module = *ctx.registers[0].x.as_ref();
+    let jump_y = callable(work_module, smash::hash40("jump_y"), 0);
+    let gravity = callable(work_module, smash::hash40("air_accel_y"), 0);
+    let initital_jump_vel = (jump_y * gravity * 2.0).sqrt() + (0.5 * gravity);
+    asm!("fmov s0, w8", in("w8") initital_jump_vel)
+}
+
+pub fn install() {
+    unsafe {
+        // stubs vanilla fullhop initial y velocity calculations
+        skyline::patching::nop_data(0x6d2174);
+    }
+    skyline::install_hooks!(fullhop_initial_y_speed_hook);
+}

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -31,10 +31,12 @@ pub fn install() {
     momentum_transfer::install();
     //dash_dancing::install();
 
-    // Handles getting rid of the kill zoom
     unsafe {
+        // Handles getting rid of the kill zoom
         const NOP: u32 = 0xD503201Fu32;
         skyline::patching::patch_data(utils::offsets::kill_zoom_regular(), &NOP);
         skyline::patching::patch_data(utils::offsets::kill_zoom_throw(), &NOP);
+        // Changes full hops to calculate vertical velocity identically to short hops
+        skyline::patching::patch_data(0x6d2188, &0x52800015u32);
     }
 }

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -14,6 +14,7 @@ pub mod hitstun;
 pub mod change_status;
 pub mod is_flag;
 pub mod controls;
+pub mod jumps;
 
 pub fn install() {
     reverse_hits::install();
@@ -29,6 +30,7 @@ pub fn install() {
     is_flag::install();
     controls::install();
     momentum_transfer::install();
+    jumps::install();
     //dash_dancing::install();
 
     unsafe {

--- a/fighters/common/src/function_hooks/momentum_transfer.rs
+++ b/fighters/common/src/function_hooks/momentum_transfer.rs
@@ -32,11 +32,10 @@ pub unsafe fn status_attack_air_hook(fighter: &mut L2CFighterCommon, param_1: L2
     let jump_speed_x_max = WorkModule::get_param_float(boma, hash40("run_speed_max"), 0) * ratio;
 
     let mut l2c_agent = L2CAgent::new(fighter.lua_state_agent);
-    let is_speed_backward = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) * PostureModule::lr(boma) < 0.0;
-    let prev_status_check = [*FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&StatusModule::prev_status_kind(boma, 0));
-    let mut new_speed = VarModule::get_float(fighter.object(), vars::common::CURRENT_MOMENTUM).clamp(-jump_speed_x_max, jump_speed_x_max);
+    let new_speed = VarModule::get_float(fighter.object(), vars::common::CURRENT_MOMENTUM).clamp(-jump_speed_x_max, jump_speed_x_max);
 
-    if prev_status_check {
+    if StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_JUMP
+    || (fighter_kind == *FIGHTER_KIND_SONIC && StatusModule::prev_status_kind(boma, 0) == *FIGHTER_SONIC_STATUS_KIND_SPIN_JUMP) {
         fighter.clear_lua_stack();
         lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, new_speed);
         app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
@@ -54,7 +53,8 @@ pub unsafe fn change_kinetic_momentum_related(boma: &mut smash::app::BattleObjec
     let prev_status_kind = StatusModule::prev_status_kind(boma, 0);
     let situation_kind = StatusModule::situation_kind(boma);
     let fighter_kind = boma.kind();
-    if [*FIGHTER_KIND_CAPTAIN, *FIGHTER_KIND_FALCO, *FIGHTER_KIND_FOX, *FIGHTER_KIND_GAMEWATCH, *FIGHTER_KIND_WOLF].contains(&fighter_kind) && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N
+    if (([*FIGHTER_KIND_CAPTAIN, *FIGHTER_KIND_FALCO, *FIGHTER_KIND_FOX, *FIGHTER_KIND_GAMEWATCH, *FIGHTER_KIND_WOLF].contains(&fighter_kind) && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
+    || ( fighter_kind == *FIGHTER_KIND_GAMEWATCH && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S ))
         && situation_kind == *SITUATION_KIND_AIR && [*FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&prev_status_kind) {
         return Some(-1);
     }

--- a/fighters/common/src/general_statuses/jump.rs
+++ b/fighters/common/src/general_statuses/jump.rs
@@ -1,7 +1,6 @@
 // status imports
 use super::*;
 use globals::*;
-use crate::misc::calc_melee_momentum;
 // This file contains code for wavelanding
 
 pub fn install() {
@@ -20,11 +19,6 @@ pub fn install() {
         //status_pre_JumpAerial_sub
     );
 }
-
-/* Moves that should bypass the momentum logic (in terms of the jump status script) */
-const MOMENTUM_EXCEPTION_MOVES: [smash::lib::LuaConst ; 1] = [
-    FIGHTER_SONIC_STATUS_KIND_SPIN_JUMP
-];
 
 #[common_status_script(status = FIGHTER_STATUS_KIND_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE,
     symbol = "_ZN7lua2cpp16L2CFighterCommon15status_pre_JumpEv")]
@@ -155,17 +149,6 @@ unsafe extern "C" fn status_Jump_Main(fighter: &mut L2CFighterCommon) -> L2CValu
 
 #[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon15status_Jump_subEN3lib8L2CValueES2_")]
 unsafe extern "C" fn status_Jump_sub(fighter: &mut L2CFighterCommon, arg1: L2CValue, arg2: L2CValue) -> L2CValue {
-    //println!("status_Jump_sub");
-    if !MOMENTUM_EXCEPTION_MOVES.iter().any(|x| *x == fighter.global_table[FIGHTER_KIND] ) {
-        let mut new_speed = calc_melee_momentum(fighter, false, false, false);
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, new_speed);
-        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
-        fighter.clear_lua_stack();
-        //println!("Post-jump horizontal velocity: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN));
-        VarModule::set_float(fighter.battle_object, vars::common::CURRENT_MOMENTUM, KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN)); // Set the current momentum to what was just calculated
-    }
-
     ControlModule::reset_flick_y(fighter.module_accessor);
     ControlModule::reset_flick_sub_y(fighter.module_accessor);
     fighter.global_table[FLICK_Y].assign(&0xFE.into());

--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(asm)]
 #![allow(unused)]
 #![allow(non_snake_case)]
 use smash::app::lua_bind::*;

--- a/fighters/common/src/misc.rs
+++ b/fighters/common/src/misc.rs
@@ -29,12 +29,8 @@ pub unsafe fn calc_melee_momentum(fighter: &mut L2CFighterCommon, aerial_attack:
   let fighter_kind = fighter.global_table[FIGHTER_KIND].get_i32();
   let jump_speed_x = WorkModule::get_param_float(fighter.module_accessor, hash40("jump_speed_x"), 0);
   let jump_speed_x_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("jump_speed_x_mul"), 0);
-  let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
   let dash_speed = WorkModule::get_param_float(fighter.module_accessor, hash40("dash_speed"), 0);
   let run_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("run_speed_max"), 0);
-  let walk_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("walk_speed_max"), 0);
-  let js_frames = WorkModule::get_param_int(fighter.module_accessor, hash40("jump_squat_frame"), 0);
-  let traction = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
   let stick_x = ControlModule::get_stick_x(fighter.module_accessor);
   let ratio = VarModule::get_float(fighter.battle_object, vars::common::JUMP_SPEED_RATIO);
   //println!("run_speed_max: {}", run_speed_max);
@@ -42,51 +38,25 @@ pub unsafe fn calc_melee_momentum(fighter: &mut L2CFighterCommon, aerial_attack:
 
   let jump_speed_x_max = run_speed_max * ratio;
 
-  let is_speed_backward = (KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN)) * PostureModule::lr(fighter.module_accessor) < 0.0;
-
   let mut x_vel = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN);
 
-  if StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_JUMP_SQUAT {
+  if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
       //println!("Jumpsquat momentum...");
       x_vel = VarModule::get_float(fighter.battle_object, vars::common::JUMPSQUAT_VELOCITY);
       //println!("x_vel: {}", x_vel);
   }
 
-  if fighter_kind == *FIGHTER_KIND_PICKEL && [*FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_JUMP_SQUAT, *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N3_JUMP_SQUAT].contains(&StatusModule::prev_status_kind(fighter.module_accessor, 0)) {
+  if fighter_kind == *FIGHTER_KIND_PICKEL && fighter.is_status_one_of(&[*FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_JUMP_SQUAT, *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N3_JUMP_SQUAT]) {
       x_vel = VarModule::get_float(fighter.battle_object, vars::common::JUMPSQUAT_VELOCITY);
   }
 
-  if fighter_kind == *FIGHTER_KIND_TANTAN && [*FIGHTER_TANTAN_STATUS_KIND_ATTACK_JUMP_SQUAT].contains(&StatusModule::prev_status_kind(fighter.module_accessor, 0)) {
+  if fighter_kind == *FIGHTER_KIND_TANTAN && fighter.is_status_one_of(&[*FIGHTER_TANTAN_STATUS_KIND_ATTACK_JUMP_SQUAT]) {
       x_vel = VarModule::get_float(fighter.battle_object, vars::common::JUMPSQUAT_VELOCITY);
   }
 
-  //println!("jumpsquat velocity: {}", x_vel);
-  //println!("current velocity: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN));
+  //println!("current velocity: {}", x_vel);
 
   let mut calcJumpSpeed = (x_vel * jump_speed_x_mul) + (jump_speed_x * stick_x);  // Calculate jump momentum based on the momentum you had on the last frame of jumpsquat
-
-  // Helper momentum for attack cancel aerials
-  if attack_cancel {
-      //println!("Attack Cancel! Calculated jump speed so far: {}", calcJumpSpeed);
-      // If Attack Cancel RAR
-      if    [*FIGHTER_STATUS_KIND_DASH, *FIGHTER_STATUS_KIND_TURN_DASH].contains(&StatusModule::prev_status_kind(fighter.module_accessor, 2)) {
-          //println!("Initial Dash Attack Cancel");
-          /*
-          if dash_speed > run_speed_max{
-              calcJumpSpeed = ((jump_speed_x * x_vel/dash_speed) + (jump_speed_x_mul * x_vel));
-          }
-          else{
-              calcJumpSpeed = ((jump_speed_x * x_vel/run_speed_max) + (jump_speed_x_mul * x_vel));
-          }
-          */
-
-      }
-      /*
-      if walking{
-          calcJumpSpeed = ((jump_speed_x * x_vel/walk_speed_max) + (jump_speed_x_mul * x_vel));
-      }
-      */
-  }
 
   //println!("calcJumpSpeed: {}", calcJumpSpeed);
 


### PR DESCRIPTION
- Ground momentum is now properly applied on frame 1 of jump, rather than frame 2
- Full hop vertical velocity is now calculated identically to short hops (no more balloony FHs)
- Attacking out of spin jumps with Sonic now retains momentum
- G&W sideB now retains momentum lol
- General code cleanup

Resolves #374 
Resolves #317 