### PR TITLE
B-reverse rework

### DIFF
--- a/fighters/captain/src/opff.rs
+++ b/fighters/captain/src/opff.rs
@@ -1,6 +1,6 @@
 use super::*;
  
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 
 unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
     if fighter.is_situation(*SITUATION_KIND_AIR)
@@ -17,7 +17,7 @@ unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
 
 unsafe fn falcon_punch_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_motion(Hash40::new("special_air_n")) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/captain/src/opff.rs
+++ b/fighters/captain/src/opff.rs
@@ -1,6 +1,6 @@
 use super::*;
  
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 
 unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
     if fighter.is_situation(*SITUATION_KIND_AIR)
@@ -16,18 +16,8 @@ unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
 }
 
 unsafe fn falcon_punch_b_reverse(fighter: &mut L2CFighterCommon) {
-    let frame = fighter.motion_frame();
-    if fighter.is_motion(Hash40::new("special_air_n"))
-    && frame < 5.0
-    && fighter.is_stick_backward()
-    {
-        PostureModule::reverse_lr(fighter.module_accessor);
-        PostureModule::update_rot_y_lr(fighter.module_accessor);
-        if VarModule::is_flag(fighter.battle_object, vars::common::B_REVERSED) {
-            return;
-        }
-        KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-        VarModule::on_flag(fighter.battle_object, vars::common::B_REVERSED);
+    if fighter.is_motion(Hash40::new("special_air_n")) {
+        common::opff::b_reverse(fighter);
     }
 }
 

--- a/fighters/cloud/src/opff.rs
+++ b/fighters/cloud/src/opff.rs
@@ -1,6 +1,7 @@
 use super::*;
+use globals::*;
 
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 
 unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_END)
@@ -13,22 +14,8 @@ unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
 
 // Cloud Limit Charge start and release B-Reverse
 unsafe fn limit_charge_start_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_situation(*SITUATION_KIND_AIR)
-    && fighter.is_status_one_of(&[
-        *FIGHTER_STATUS_KIND_SPECIAL_LW,
-        *FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_CHARGE,
-        *FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_END
-    ])
-    && fighter.motion_frame() < 5.0
-    && fighter.is_stick_backward()
-    {
-        PostureModule::reverse_lr(fighter.module_accessor);
-        PostureModule::update_rot_y_lr(fighter.module_accessor);
-        if VarModule::is_flag(fighter.battle_object, vars::common::B_REVERSED) {
-            return;
-        }
-        KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-        VarModule::on_flag(fighter.battle_object, vars::common::B_REVERSED);
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
+        common::opff::b_reverse(fighter);
     }
 }
 

--- a/fighters/cloud/src/opff.rs
+++ b/fighters/cloud/src/opff.rs
@@ -1,7 +1,7 @@
 use super::*;
 use globals::*;
 
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 
 unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_END)
@@ -15,7 +15,7 @@ unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
 // Cloud Limit Charge start and release B-Reverse
 unsafe fn limit_charge_start_b_rev(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -365,7 +365,7 @@ pub unsafe fn respawn_taunt(boma: &mut BattleObjectModuleAccessor, status_kind: 
 }
 
 #[utils::export(common::opff)]
-pub unsafe fn b_reverse(fighter: &mut L2CFighterCommon) {
+pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
         if fighter.is_stick_backward() {
             PostureModule::reverse_lr(fighter.module_accessor);

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -1,7 +1,8 @@
 use utils::{
     *,
     ext::*,
-    consts::*
+    consts::*,
+    consts::globals::*
 };
 use smash::app::BattleObjectModuleAccessor;
 use smash::phx::{Vector2f, Vector3f, Vector4f};
@@ -361,6 +362,25 @@ pub unsafe fn respawn_taunt(boma: &mut BattleObjectModuleAccessor, status_kind: 
     };
 
     MotionModule::change_motion(boma, motion, 0.0, 1.0, false, 0.0, false, false);
+}
+
+#[utils::export(common::opff)]
+pub unsafe fn b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
+        if fighter.is_stick_backward() {
+            PostureModule::reverse_lr(fighter.module_accessor);
+            PostureModule::update_rot_y_lr(fighter.module_accessor);
+        }
+    }
+    if fighter.global_table[CURRENT_FRAME].get_i32() == 3 {
+        if fighter.is_stick_backward()
+        && !VarModule::is_flag(fighter.battle_object, vars::common::B_REVERSED) {
+            PostureModule::reverse_lr(fighter.module_accessor);
+            PostureModule::update_rot_y_lr(fighter.module_accessor);
+            KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+            VarModule::on_flag(fighter.battle_object, vars::common::B_REVERSED);
+        }
+    }
 }
 
 pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32, curr_frame: f32) {

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -63,17 +63,7 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 // DK Giant Punch charge B-Reverse
 unsafe fn giant_punch_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -63,7 +63,7 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 // DK Giant Punch charge B-Reverse
 unsafe fn giant_punch_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -61,8 +61,8 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 }
 
 // DK Giant Punch charge B-Reverse
-unsafe fn giant_punch_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
+unsafe fn giant_punch_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -129,7 +129,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     barrel_timer(fighter, boma, id);
     barrel_reset(fighter, id, status_kind);
     barrel_training(fighter, id, status_kind);
-    giant_punch_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    giant_punch_b_reverse(fighter);
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
     barrel_pull(fighter, boma, status_kind, situation_kind);
     headbutt_aerial_stall(fighter, boma, id, status_kind, situation_kind, frame);

--- a/fighters/ganon/src/opff.rs
+++ b/fighters/ganon/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -34,7 +34,7 @@ unsafe fn dtaunt_counter(boma: &mut BattleObjectModuleAccessor, motion_kind: u64
 // Warlock Punch B-Reverse
 unsafe fn warlock_punch_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_motion(Hash40::new("special_air_n")) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/ganon/src/opff.rs
+++ b/fighters/ganon/src/opff.rs
@@ -32,8 +32,8 @@ unsafe fn dtaunt_counter(boma: &mut BattleObjectModuleAccessor, motion_kind: u64
 }
 
 // Warlock Punch B-Reverse
-unsafe fn warlock_punch_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, motion_kind: u64, stick_x: f32, facing: f32, frame: f32) {
-    if motion_kind == hash40("special_air_n") {
+unsafe fn warlock_punch_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_motion(Hash40::new("special_air_n")) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -69,7 +69,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     aerial_wiz_foot_jump_reset_bounce(boma, status_kind, situation_kind);
     wizards_foot_b_reverse(boma, id, status_kind, stick_x, facing, frame);
     //dtaunt_counter(boma, motion_kind, frame);
-    warlock_punch_b_reverse(fighter, boma, id, motion_kind, stick_x, facing, frame);
+    warlock_punch_b_reverse(fighter);
     repeated_warlock_punch_turnaround(boma, status_kind, stick_x, facing, frame);
 }
 

--- a/fighters/ganon/src/opff.rs
+++ b/fighters/ganon/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -32,19 +32,9 @@ unsafe fn dtaunt_counter(boma: &mut BattleObjectModuleAccessor, motion_kind: u64
 }
 
 // Warlock Punch B-Reverse
-unsafe fn warlock_punch_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, motion_kind: u64, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn warlock_punch_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, motion_kind: u64, stick_x: f32, facing: f32, frame: f32) {
     if motion_kind == hash40("special_air_n") {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -75,11 +65,11 @@ unsafe fn repeated_warlock_punch_turnaround(boma: &mut BattleObjectModuleAccesso
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aerial_wiz_foot_jump_reset_bounce(boma, status_kind, situation_kind);
     wizards_foot_b_reverse(boma, id, status_kind, stick_x, facing, frame);
     //dtaunt_counter(boma, motion_kind, frame);
-    warlock_punch_b_reverse(boma, id, motion_kind, stick_x, facing, frame);
+    warlock_punch_b_reverse(fighter, boma, id, motion_kind, stick_x, facing, frame);
     repeated_warlock_punch_turnaround(boma, status_kind, stick_x, facing, frame);
 }
 
@@ -93,6 +83,6 @@ pub fn ganon_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn ganon_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -18,8 +18,8 @@ unsafe fn aether_drift(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Ike Quick Draw B-Reverse
-unsafe fn quickdraw_b_reverse(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
+unsafe fn quickdraw_b_reverse(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -61,7 +61,7 @@ unsafe fn jump_attack_cancels(boma: &mut BattleObjectModuleAccessor, id: usize, 
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aether_drift(boma, status_kind, situation_kind, stick_x, facing);
-    quickdraw_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    quickdraw_b_reverse(fighter);
     jump_attack_cancels(boma, id, status_kind, situation_kind, cat[0], stick_x, facing);
 }
 

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -18,19 +18,9 @@ unsafe fn aether_drift(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Ike Quick Draw B-Reverse
-unsafe fn quickdraw_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_IKE_STATUS_KIND_SPECIAL_S_HOLD].contains(&status_kind) {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+unsafe fn quickdraw_b_reverse(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -69,9 +59,9 @@ unsafe fn jump_attack_cancels(boma: &mut BattleObjectModuleAccessor, id: usize, 
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aether_drift(boma, status_kind, situation_kind, stick_x, facing);
-    quickdraw_b_reverse(boma, id, status_kind, stick_x, facing, frame);
+    quickdraw_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
     jump_attack_cancels(boma, id, status_kind, situation_kind, cat[0], stick_x, facing);
 }
 
@@ -85,6 +75,6 @@ pub fn ike_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn ike_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -20,7 +20,7 @@ unsafe fn aether_drift(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 // Ike Quick Draw B-Reverse
 unsafe fn quickdraw_b_reverse(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -45,7 +45,7 @@ unsafe fn hammer_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, stat
 // Hammer Flip B-Reverse
 unsafe fn hammer_flip_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -43,21 +43,9 @@ unsafe fn hammer_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, stat
 }
 
 // Hammer Flip B-Reverse
-unsafe fn hammer_flip_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn hammer_flip_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
-        if situation_kind == *SITUATION_KIND_AIR {
-            if frame < 5.0 {
-                if stick_x * facing < 0.0 {
-                    PostureModule::reverse_lr(boma);
-                    PostureModule::update_rot_y_lr(boma);
-                    if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                        let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                        KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                        VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                    }
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -316,10 +304,10 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     final_cutter_cancel(boma, id, status_kind, cat[0], frame);
     hammer_fastfall_landcancel(boma, status_kind, situation_kind, cat[1], stick_y);
-    hammer_flip_b_reverse(boma, id, status_kind, situation_kind, stick_x, facing, frame);
+    hammer_flip_b_reverse(fighter, boma, id, status_kind, situation_kind, stick_x, facing, frame);
 
 
     // Frame Data
@@ -353,6 +341,6 @@ pub fn kirby_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn kirby_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -43,8 +43,8 @@ unsafe fn hammer_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, stat
 }
 
 // Hammer Flip B-Reverse
-unsafe fn hammer_flip_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
+unsafe fn hammer_flip_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -307,7 +307,7 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     final_cutter_cancel(boma, id, status_kind, cat[0], frame);
     hammer_fastfall_landcancel(boma, status_kind, situation_kind, cat[1], stick_y);
-    hammer_flip_b_reverse(fighter, boma, id, status_kind, situation_kind, stick_x, facing, frame);
+    hammer_flip_b_reverse(fighter);
 
 
     // Frame Data

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -13,19 +13,9 @@ unsafe fn jetpack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32
 }
 
 // Propellerpack B-Reverse
-unsafe fn propellerpack_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn propellerpack_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if [*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START].contains(&status_kind) {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -42,10 +32,10 @@ unsafe fn crownerang_item_grab(boma: &mut BattleObjectModuleAccessor, status_kin
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     jetpack_cancel(boma, status_kind, cat[0]);
     //crownerang_item_grab(boma, status_kind, cat[0]);
-    propellerpack_b_rev(boma, id, status_kind, stick_x, facing, frame);
+    propellerpack_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_KROOL )]
@@ -58,6 +48,6 @@ pub fn krool_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn krool_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -13,8 +13,8 @@ unsafe fn jetpack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32
 }
 
 // Propellerpack B-Reverse
-unsafe fn propellerpack_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START].contains(&status_kind) {
+unsafe fn propellerpack_b_rev(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START]) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -35,7 +35,7 @@ unsafe fn crownerang_item_grab(boma: &mut BattleObjectModuleAccessor, status_kin
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     jetpack_cancel(boma, status_kind, cat[0]);
     //crownerang_item_grab(boma, status_kind, cat[0]);
-    propellerpack_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
+    propellerpack_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_KROOL )]

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -15,7 +15,7 @@ unsafe fn jetpack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32
 // Propellerpack B-Reverse
 unsafe fn propellerpack_b_rev(fighter: &mut L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START]) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/link/src/opff.rs
+++ b/fighters/link/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -15,19 +15,9 @@ unsafe fn bow_fastfall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Link Remote Bomb pull and detonation B-Reverse
-unsafe fn bomb_n_deton_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+unsafe fn bomb_n_deton_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST].contains(&status_kind) {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -132,9 +122,9 @@ pub unsafe extern "Rust" fn links_common(fighter: &mut smash::lua2cpp::L2CFighte
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_fastfall(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_n_deton_b_reverse(boma, id, status_kind, situation_kind, stick_x, stick_y, facing, frame);
+    bomb_n_deton_b_reverse(fighter, boma, id, status_kind, situation_kind, stick_x, stick_y, facing, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LINK )]
@@ -148,6 +138,6 @@ pub fn link_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn link_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/link/src/opff.rs
+++ b/fighters/link/src/opff.rs
@@ -15,8 +15,8 @@ unsafe fn bow_fastfall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Link Remote Bomb pull and detonation B-Reverse
-unsafe fn bomb_n_deton_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST].contains(&status_kind) {
+unsafe fn bomb_n_deton_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST]) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -124,7 +124,7 @@ pub unsafe extern "Rust" fn links_common(fighter: &mut smash::lua2cpp::L2CFighte
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_fastfall(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_n_deton_b_reverse(fighter, boma, id, status_kind, situation_kind, stick_x, stick_y, facing, frame);
+    bomb_n_deton_b_reverse(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LINK )]

--- a/fighters/link/src/opff.rs
+++ b/fighters/link/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -17,7 +17,7 @@ unsafe fn bow_fastfall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 // Link Remote Bomb pull and detonation B-Reverse
 unsafe fn bomb_n_deton_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST]) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/littlemac/src/opff.rs
+++ b/fighters/littlemac/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -50,14 +50,14 @@ unsafe fn straight_lunge_cancels(boma: &mut BattleObjectModuleAccessor, status_k
 // B-Reverse Straight Lunge charge
 unsafe fn straight_lunge_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START]) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 
 // B-Reverse Rising Uppercut
 unsafe fn rising_uppercut_b_rev(fighter: &mut L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_START]) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/littlemac/src/opff.rs
+++ b/fighters/littlemac/src/opff.rs
@@ -48,29 +48,15 @@ unsafe fn straight_lunge_cancels(boma: &mut BattleObjectModuleAccessor, status_k
 }
 
 // B-Reverse Straight Lunge charge
-unsafe fn straight_lunge_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START].contains(&status_kind) {
-        if MotionModule::frame(boma) < 1.0 {
-            if fighter.is_stick_backward() {
-                PostureModule::reverse_lr(fighter.module_accessor);
-                PostureModule::update_rot_y_lr(fighter.module_accessor);
-            }
-        }
-        if fighter.global_table[CURRENT_FRAME].get_i32() == 3 {
-            if fighter.is_stick_backward()
-            && !VarModule::is_flag(fighter.battle_object, vars::common::B_REVERSED) {
-                PostureModule::reverse_lr(fighter.module_accessor);
-                PostureModule::update_rot_y_lr(fighter.module_accessor);
-                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                VarModule::on_flag(fighter.battle_object, vars::common::B_REVERSED);
-            }
-        }
+unsafe fn straight_lunge_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START]) {
+        common::opff::b_reverse(fighter);
     }
 }
 
 // B-Reverse Rising Uppercut
-unsafe fn rising_uppercut_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_START].contains(&status_kind) {
+unsafe fn rising_uppercut_b_rev(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_START]) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -106,8 +92,8 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     normal_side_special(boma, status_kind);
     straight_lunge_cancels(boma, status_kind, situation_kind, cat[0], cat[1], frame);
-    straight_lunge_charge_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
-    rising_uppercut_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
+    straight_lunge_charge_b_rev(fighter);
+    rising_uppercut_b_rev(fighter);
     tech_roll_help(boma, motion_kind, facing, frame);
     nspecial_cancels(boma, status_kind, situation_kind, cat[0]);
 }

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -97,18 +97,8 @@ unsafe fn up_b_wall_jump(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
 
 // F.L.U.D.D. B-Reverse
 unsafe fn fludd_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_CHARGE, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT].contains(&status_kind) {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+    if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT].contains(&status_kind) {
+        common::opff::b_reverse(fighter);
     }
 }
 

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -98,7 +98,7 @@ unsafe fn up_b_wall_jump(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
 // F.L.U.D.D. B-Reverse
 unsafe fn fludd_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT]) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -96,8 +96,8 @@ unsafe fn up_b_wall_jump(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
 }
 
 // F.L.U.D.D. B-Reverse
-unsafe fn fludd_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT].contains(&status_kind) {
+unsafe fn fludd_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT]) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -197,7 +197,7 @@ unsafe fn noknok_training(fighter: &mut L2CFighterCommon, id: usize, status_kind
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     //dair_mash_rise(fighter, boma, id, motion_kind, situation_kind, frame);
     up_b_wall_jump(fighter, boma, id, status_kind, situation_kind, cat[0], frame);
-    fludd_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    fludd_b_reverse(fighter);
     dspecial_cancels(boma, status_kind, situation_kind, cat[0]);
     special_n_article_fix(fighter, boma, id, status_kind, situation_kind, frame);
     noknok_timer(fighter, boma, id);

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -84,7 +84,7 @@ unsafe fn missile_land_cancel_b_rev(fighter: &mut L2CFighterCommon, boma: &mut B
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -76,7 +76,7 @@ unsafe fn laser_blaze_ff_land_cancel(boma: &mut BattleObjectModuleAccessor, situ
     }
 }
 
-unsafe fn missile_land_cancel_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn missile_land_cancel_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
     if [*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_GROUND,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_AIR,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_GROUND,
@@ -84,17 +84,7 @@ unsafe fn missile_land_cancel_b_rev(boma: &mut BattleObjectModuleAccessor, id: u
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -127,11 +117,11 @@ unsafe fn arm_rocket_airdash(boma: &mut BattleObjectModuleAccessor, id: usize, s
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind, cat[0], cat[1]);
     absorb_vortex_jc_turnaround_shinejump_cancel(boma, status_kind, situation_kind, cat[0], stick_x, facing, frame);
     laser_blaze_ff_land_cancel(boma, situation_kind, motion_kind, cat[1], stick_y);
-    missile_land_cancel_b_rev(boma, id, status_kind, situation_kind, stick_x, facing, frame);
+    missile_land_cancel_b_rev(fighter, boma, id, status_kind, situation_kind);
 	cannon_jump_kick_actionability(boma, id, status_kind, frame);
 	arm_rocket_airdash(boma, id, status_kind, frame);
 
@@ -182,6 +172,6 @@ pub fn miigunner_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn miigunner_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -32,7 +32,7 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
 // Pac-Man Bonus Fruit charge B-Reverse
 unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -30,8 +30,8 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
 }
 
 // Pac-Man Bonus Fruit charge B-Reverse
-unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
+unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -39,7 +39,7 @@ unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommo
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind);
     bonus_fruit_toss_ac(boma, status_kind, situation_kind, cat[0], frame);
-    bonus_fruit_charge_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
+    bonus_fruit_charge_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PACMAN )]

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -30,27 +30,16 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
 }
 
 // Pac-Man Bonus Fruit charge B-Reverse
-unsafe fn bonus_fruit_charge_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_SPECIAL_N,
-        *FIGHTER_PACMAN_STATUS_KIND_SPECIAL_N_HOLD].contains(&status_kind) {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
+        common::opff::b_reverse(fighter);
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind);
     bonus_fruit_toss_ac(boma, status_kind, situation_kind, cat[0], frame);
-    bonus_fruit_charge_b_rev(boma, id, status_kind, stick_x, facing, frame);
+    bonus_fruit_charge_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PACMAN )]
@@ -63,6 +52,6 @@ pub fn pacman_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn pacman_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/pikmin/src/opff.rs
+++ b/fighters/pikmin/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -18,7 +18,7 @@ unsafe fn winged_pikmin_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
 // Olimar Pikmin Order B-Reverse
 unsafe fn pikmin_order_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/pikmin/src/opff.rs
+++ b/fighters/pikmin/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -16,19 +16,9 @@ unsafe fn winged_pikmin_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
 }
 
 // Olimar Pikmin Order B-Reverse
-unsafe fn pikmin_order_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn pikmin_order_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -61,9 +51,9 @@ pub unsafe fn solimar_scaling(boma: &mut BattleObjectModuleAccessor, status_kind
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     winged_pikmin_cancel(boma, status_kind, cat[0]);
-    pikmin_order_b_reverse(boma, id, status_kind, stick_x, facing, frame);
+    pikmin_order_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
     solimar_scaling(boma, status_kind, frame);
 }
 
@@ -77,6 +67,6 @@ pub fn pikmin_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn pikmin_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/pikmin/src/opff.rs
+++ b/fighters/pikmin/src/opff.rs
@@ -16,8 +16,8 @@ unsafe fn winged_pikmin_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
 }
 
 // Olimar Pikmin Order B-Reverse
-unsafe fn pikmin_order_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+unsafe fn pikmin_order_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -53,7 +53,7 @@ pub unsafe fn solimar_scaling(boma: &mut BattleObjectModuleAccessor, status_kind
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     winged_pikmin_cancel(boma, status_kind, cat[0]);
-    pikmin_order_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    pikmin_order_b_reverse(fighter);
     solimar_scaling(boma, status_kind, frame);
 }
 

--- a/fighters/richter/src/opff.rs
+++ b/fighters/richter/src/opff.rs
@@ -21,15 +21,15 @@ unsafe fn cross_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: 
 }
 
 // Richter Holy Water B-Reverse
-unsafe fn holy_water_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+unsafe fn holy_water_b_rev(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
         common::opff::b_reverse(fighter);
     }
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     cross_dash_cancel(boma, status_kind, situation_kind, cat[0], frame);
-    holy_water_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
+    holy_water_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_RICHTER )]

--- a/fighters/richter/src/opff.rs
+++ b/fighters/richter/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -23,7 +23,7 @@ unsafe fn cross_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: 
 // Richter Holy Water B-Reverse
 unsafe fn holy_water_b_rev(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/richter/src/opff.rs
+++ b/fighters/richter/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -21,25 +21,15 @@ unsafe fn cross_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: 
 }
 
 // Richter Holy Water B-Reverse
-unsafe fn holy_water_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn holy_water_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     cross_dash_cancel(boma, status_kind, situation_kind, cat[0], frame);
-    holy_water_b_rev(boma, id, status_kind, stick_x, facing, frame);
+    holy_water_b_rev(fighter, boma, id, status_kind, stick_x, facing, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_RICHTER )]
@@ -52,6 +42,6 @@ pub fn richter_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn richter_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/samus/src/opff.rs
+++ b/fighters/samus/src/opff.rs
@@ -1,10 +1,10 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
  
-pub unsafe fn land_cancel_and_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+pub unsafe fn land_cancel_and_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
     if [*FIGHTER_STATUS_KIND_SPECIAL_S,
         *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1G,
         *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1A,
@@ -13,20 +13,7 @@ pub unsafe fn land_cancel_and_b_reverse(boma: &mut BattleObjectModuleAccessor, i
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        if situation_kind == *SITUATION_KIND_AIR{
-            KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
-            if frame < 5.0 {
-                if stick_x * facing < 0.0 {
-                    PostureModule::reverse_lr(boma);
-                    PostureModule::update_rot_y_lr(boma);
-                    if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                        let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                        KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                        VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                    }
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -79,7 +66,7 @@ pub unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kin
 #[no_mangle]
 pub unsafe extern "Rust" fn common_samus(fighter: &mut L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        land_cancel_and_b_reverse(&mut *info.boma, info.id, info.status_kind, info.situation_kind, info.stick_x, info.facing, info.frame);
+        land_cancel_and_b_reverse(fighter, &mut *info.boma, info.id, info.status_kind, info.situation_kind);
         morphball_crawl(&mut *info.boma, info.status_kind, info.frame);
         nspecial_cancels(&mut *info.boma, info.status_kind, info.situation_kind);
     }

--- a/fighters/samus/src/opff.rs
+++ b/fighters/samus/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -13,7 +13,7 @@ pub unsafe fn land_cancel_and_b_reverse(fighter: &mut L2CFighterCommon, boma: &m
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -1,10 +1,10 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
  
-unsafe fn holy_water_ac_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn holy_water_ac_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
         if frame > 19.0 {
             if boma.is_cat_flag(Cat1::AirEscape) && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR) {
@@ -13,17 +13,7 @@ unsafe fn holy_water_ac_b_rev(boma: &mut BattleObjectModuleAccessor, id: usize, 
                 }
             }
         }
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -60,8 +50,8 @@ unsafe fn land_cancel_cross(boma: &mut BattleObjectModuleAccessor, id: usize, si
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    holy_water_ac_b_rev(boma, id, status_kind, situation_kind, cat[0], stick_x, facing, frame);
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+    holy_water_ac_b_rev(fighter, boma, id, status_kind, situation_kind, cat[0], frame);
     cross_ff_land_cancel(boma, id, status_kind, situation_kind, cat[1], stick_y);
     air_cross_air_off(boma, id, status_kind, situation_kind);
     land_cancel_cross(boma, id, situation_kind);
@@ -77,6 +67,6 @@ pub fn simon_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn simon_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -13,7 +13,7 @@ unsafe fn holy_water_ac_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleO
                 }
             }
         }
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/toonlink/src/opff.rs
+++ b/fighters/toonlink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -17,19 +17,9 @@ unsafe fn heros_bow_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Toon Link Bomb pull B-Reverse
-unsafe fn bomb_pull_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn bomb_pull_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 
@@ -44,9 +34,9 @@ extern "Rust" {
     fn links_common(fighter: &mut smash::lua2cpp::L2CFighterCommon);
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     heros_bow_ff(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_pull_b_reverse(boma, id, status_kind, stick_x, facing, frame);
+    bomb_pull_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
 	sword_length(boma);
     
 
@@ -78,6 +68,6 @@ pub fn toonlink_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn toonlink_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/toonlink/src/opff.rs
+++ b/fighters/toonlink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -19,7 +19,7 @@ unsafe fn heros_bow_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 // Toon Link Bomb pull B-Reverse
 unsafe fn bomb_pull_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/toonlink/src/opff.rs
+++ b/fighters/toonlink/src/opff.rs
@@ -17,8 +17,8 @@ unsafe fn heros_bow_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 }
 
 // Toon Link Bomb pull B-Reverse
-unsafe fn bomb_pull_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+unsafe fn bomb_pull_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -36,7 +36,7 @@ extern "Rust" {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     heros_bow_ff(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_pull_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    bomb_pull_b_reverse(fighter);
 	sword_length(boma);
     
 

--- a/fighters/younglink/src/opff.rs
+++ b/fighters/younglink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
+utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
 use super::*;
 use globals::*;
 
@@ -28,7 +28,7 @@ unsafe fn fire_arrow_ff(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
 // Young Link Bomb pull B-Reverse
 unsafe fn bomb_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::b_reverse(fighter);
+        common::opff::check_b_reverse(fighter);
     }
 }
 

--- a/fighters/younglink/src/opff.rs
+++ b/fighters/younglink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::fighter_common_opff);
+utils::import_noreturn!(common::opff::{fighter_common_opff, b_reverse});
 use super::*;
 use globals::*;
 
@@ -28,17 +28,7 @@ unsafe fn fire_arrow_ff(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
 // Young Link Bomb pull B-Reverse
 unsafe fn bomb_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-                }
-            }
-        }
+        common::opff::b_reverse(fighter);
     }
 }
 

--- a/fighters/younglink/src/opff.rs
+++ b/fighters/younglink/src/opff.rs
@@ -26,8 +26,8 @@ unsafe fn fire_arrow_ff(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
 }
 
 // Young Link Bomb pull B-Reverse
-unsafe fn bomb_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+unsafe fn bomb_b_reverse(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
         common::opff::b_reverse(fighter);
     }
 }
@@ -92,7 +92,7 @@ unsafe fn holdable_dair(boma: &mut BattleObjectModuleAccessor, motion_kind: u64,
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     special_s_article_fix(fighter, boma, id, status_kind, situation_kind, frame);
     fire_arrow_ff(fighter, boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_b_reverse(fighter, boma, id, status_kind, stick_x, facing, frame);
+    bomb_b_reverse(fighter);
     bombchu_timer(fighter, boma, id);
     bombchu_reset(fighter, id, status_kind);
     bombchu_training(fighter, id, status_kind);


### PR DESCRIPTION
B-reverse code has been reworked to better emulate vanilla B-reverse input/behavior.

Also fixes an issue that let you B-reverse charge specials after the first 5 frames (intended B-reverse window).

Fixes #388 
Fixes #234