### PR TITLE
creating upgrade zip and deletions list for packaging

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -139,16 +139,41 @@ jobs:
         tag: ${{ github.event.inputs.romfs_version }}   
         repo: 'HDR-Development/romfs-release'
 
+    # make package depending on version chosen
     - name: make package with chosen version
       if: github.event.inputs.romfs_version != 'latest'
       run: |
         python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ github.event.inputs.romfs_version }} 
 
-
     - name: make package with latest
       if: github.event.inputs.romfs_version == 'latest'
       run: |
         python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ steps.romfs_latest.outputs.release }}
+
+
+    # get the most recent latest full release
+    - id: package_latest
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: HDR-Development/HDR-Releases
+
+    # build the upgrade.zip and upgrade_deletions.txt
+    - name: make upgrade artifacts
+      run: |
+        python3 scripts/make_diff.py beta
+
+    # upload the upgrade data to the previous release for auto updater
+    - name: Upload upgrade data to previous release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: upgrade_artifacts/*
+        prerelease: false
+        file_glob: true
+        asset_name: upgrade
+        repo_name: HDR-Development/HDR-Releases
+        tag: ${{ steps.package_latest.outputs.release }}
+        overwrite: true
 
     - uses: actions/download-artifact@v3
       with:
@@ -167,7 +192,7 @@ jobs:
         file_glob: true
         asset_name: artifacts
         repo_name: HDR-Development/HDR-Releases
-        release_name: ${{ needs.version_and_changelog.outputs.version }}-nightly
+        release_name: ${{ needs.version_and_changelog.outputs.version }}-beta
         tag: ${{ needs.version_and_changelog.outputs.version }}
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -104,6 +104,31 @@ jobs:
       run: |
         python3 scripts/full_package.py ${{ needs.version_and_changelog.outputs.version }} ${{ steps.romfs_version.outputs.release }}
 
+    # get the most recent latest full release
+    - id: package_latest
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: HDR-Development/HDR-Nightlies
+
+    # build the upgrade.zip and upgrade_deletions.txt
+    - name: make upgrade artifacts
+      run: |
+        python3 scripts/make_diff.py nightly
+
+    # upload the upgrade data to the previous release for auto updater
+    - name: Upload upgrade data to previous release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: upgrade_artifacts/*
+        prerelease: false
+        file_glob: true
+        asset_name: upgrade
+        repo_name: HDR-Development/HDR-Nightlies
+        tag: ${{ steps.package_latest.outputs.release }}
+        overwrite: true
+
+
     - uses: actions/download-artifact@v3
       with:
         name: changelog

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ plugin/hdr_version.txt
 **/zips/
 *.zip
 **/content_hashes.txt
+**/diff/
+scripts/artifacts/upgrade_deletions.txt

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ plugin/hdr_version.txt
 **/content_hashes.txt
 **/diff/
 scripts/artifacts/upgrade_deletions.txt
+**/upgrade/
+**/upgrade_artifacts/

--- a/scripts/diff_lib.py
+++ b/scripts/diff_lib.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+import shutil, os, sys, pathlib, zipfile
+
+def create_diff(zip1: str, zip2: str, output_name: str):
+    deleted_files = set()
+    changed_files = set()
+    deletions_text = ""
+    with zipfile.ZipFile(zip1, 'r') as zip1:
+        with zipfile.ZipFile(zip2, 'r') as zip2:
+            # get the files from zip1 that are changed or deleted
+            for info1 in zip1.infolist():
+                try:
+                    info2 = zip2.getinfo(info1.filename)
+                    if info1.CRC != info2.CRC:
+                        changed_files.add(info1.filename)
+                except:
+                    deleted_files.add(info1.filename)
+
+            for info2 in zip2.infolist():
+                try:
+                    info1 = zip1.getinfo(info2.filename)
+                except:
+                    changed_files.add(info2.filename)
+
+            for file in changed_files:
+                print("changed file: " + file)
+                
+
+            for file in deleted_files:
+                print("deleted file: " + file)
+                deletions_text += file + "\n"
+
+            # removing old diffs
+            shutil.rmtree('diff', True)
+            if output_name in os.listdir('.'):
+                os.remove(output_name)
+
+            for file in changed_files:
+                zip2.extract(file, "diff")
+
+
+    shutil.make_archive(output_name, 'zip', 'diff')
+
+    
+    with open('upgrade_deletions.txt', "w") as deletions_file:
+        deletions_file.write(deletions_text)
+
+
+
+if __name__ == '__main__':
+    print("diffing zips")
+
+    if "help" in sys.argv or "--help" in sys.argv or "-h" in sys.argv:
+        print("compares two zip files, and generates a third zip containing the changed/new files, as well as a differences file for what was deleted")
+        print("For example:")
+        print("./diff_zips.py beta.zip release.zip")
+        exit(0)
+
+    if len(sys.argv) != 3:
+        exit("invalid argument count!")
+
+    create_diff(sys.argv[1], sys.argv[2], "diff.zip")

--- a/scripts/diff_lib.py
+++ b/scripts/diff_lib.py
@@ -32,8 +32,8 @@ def create_diff(zip1: str, zip2: str, output_name: str):
 
             # removing old diffs
             shutil.rmtree('diff', True)
-            if output_name in os.listdir('.'):
-                os.remove(output_name)
+            if (output_name + ".zip") in os.listdir('.'):
+                os.remove(output_name + ".zip")
 
             for file in changed_files:
                 zip2.extract(file, "diff")

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -19,6 +19,8 @@ romfs_version = sys.argv[2]
 shutil.rmtree("package", True)
 if os.path.exists("switch-package.zip"):
     os.remove("switch-package.zip")
+if os.path.exists("switch-package"):
+    shutil.rmtree("switch-package")
 os.mkdir("switch-package")
 
 def download_and_extract(owner: str, repo: str, tag: str, asset: str, extract_directory = None):
@@ -42,7 +44,7 @@ def download_and_extract(owner: str, repo: str, tag: str, asset: str, extract_di
         sleep(1)
     os.remove(asset)
 
-os.makedirs("switch-package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/")
+os.makedirs("switch-package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/")
 
 download_and_extract("HDR-Development", "HewDraw-Remix", hdr_version, "hdr-switch.zip")
 download_and_extract("HDR-Development", "romfs-release", romfs_version, "romfs.zip")
@@ -51,15 +53,15 @@ download_and_extract("skyline-dev", "skyline", "beta", "skyline.zip", "/atmosphe
 
 #print("getting libnro_hook.nro")
 #urllib.request.urlretrieve("https://github.com/ultimate-research/nro-hook-plugin/releases/download/v0.3.0/libnro_hook.nro", "libnro_hook.nro")
-#shutil.move("libnro_hook.nro", "package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/")
+#shutil.move("libnro_hook.nro", "package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/")
 
 #print("getting libsmashline_hook.nro")
 #urllib.request.urlretrieve("https://github.com/blu-dev/smashline_hook/releases/download/1.1.1/libsmashline_hook.nro", "libsmashline_hook.nro")
-#shutil.move("libsmashline_hook.nro", "package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/")
+#shutil.move("libsmashline_hook.nro", "package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/")
 
 print("getting libsmashline_hook_development.nro")
 urllib.request.urlretrieve("https://github.com/blu-dev/smashline_hook/releases/download/1.1.1/libsmashline_hook_development.nro", "libsmashline_hook_development.nro")
-shutil.move("libsmashline_hook_development.nro", "switch-package/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/")
+shutil.move("libsmashline_hook_development.nro", "switch-package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/")
 
 print("making switch-package.zip")
 shutil.make_archive("switch-package", 'zip', 'switch-package')
@@ -69,7 +71,7 @@ hash_package.hash_folder("switch-package", "content_hashes.txt")
 
 # move the stuff to artifacts folder
 if os.path.exists("artifacts"):
-    os.remove("artifacts")
+    shutil.rmtree("artifacts")
 os.mkdir("artifacts")
 shutil.move("switch-package.zip", "artifacts")
 shutil.move("content_hashes.txt", "artifacts")

--- a/scripts/make_diff.py
+++ b/scripts/make_diff.py
@@ -1,0 +1,33 @@
+from codecs import ignore_errors
+from time import sleep
+import urllib.request, shutil, os, sys
+from urllib.request import urlopen
+from shutil import copyfileobj
+import zipfile
+import diff_lib
+
+
+if "help" in sys.argv or "--help" in sys.argv or "-h" in sys.argv or len(sys.argv) != 2:
+    if len(sys.argv) != 2:
+        print("bad argument length!")
+    print("make_diff.py <nightly/beta>")
+    exit(0)
+
+if not os.path.exists("artifacts/switch-package.zip"):
+    exit("package zip not found!")
+
+if sys.argv[1] == "nightly":
+    release_type = "Nightlies"
+else:
+    release_type = "Releases"
+
+url = "https://github.com/HDR-Development/HDR-" + release_type + "/releases/latest/download/switch-package.zip"
+print("getting latest from url: " + url)
+
+urllib.request.urlretrieve(url, "switch-package-previous.zip")
+
+diff_lib.create_diff("switch-package-previous.zip", "artifacts/switch-package.zip", "upgrade")
+
+shutil.move("upgrade.zip", "artifacts")
+shutil.move("upgrade_deletions.txt", "artifacts")
+

--- a/scripts/make_diff.py
+++ b/scripts/make_diff.py
@@ -28,6 +28,5 @@ urllib.request.urlretrieve(url, "switch-package-previous.zip")
 
 diff_lib.create_diff("switch-package-previous.zip", "artifacts/switch-package.zip", "upgrade")
 
-shutil.move("upgrade.zip", "artifacts")
-shutil.move("upgrade_deletions.txt", "artifacts")
+
 

--- a/scripts/make_diff.py
+++ b/scripts/make_diff.py
@@ -6,6 +6,9 @@ from shutil import copyfileobj
 import zipfile
 import diff_lib
 
+#  this file diffs the existing switch-package.zip against whatever the latest nightly or
+#  beta is, depending on arguments, and produces a upgrade.zip for that version to this
+#  version, as well as an upgrade_deletions.txt file with the files that should be deleted
 
 if "help" in sys.argv or "--help" in sys.argv or "-h" in sys.argv or len(sys.argv) != 2:
     if len(sys.argv) != 2:
@@ -28,5 +31,10 @@ urllib.request.urlretrieve(url, "switch-package-previous.zip")
 
 diff_lib.create_diff("switch-package-previous.zip", "artifacts/switch-package.zip", "upgrade")
 
-
+# move the stuff to artifacts folder
+if os.path.exists("upgrade_artifacts"):
+    shutil.rmtree("upgrade_artifacts")
+os.mkdir("upgrade_artifacts")
+shutil.move("upgrade.zip", "upgrade_artifacts")
+shutil.move("upgrade_deletions.txt", "upgrade_artifacts")
 


### PR DESCRIPTION
adding logic to create an upgrade.zip, which will be uploaded to the previous version to facilitate "walking the chain" of updates.

this adds scripts and logic to our auto packaging to create and upload an upgrade.zip and a upgrade_deletions.txt to the most recent release, which can be used to upgrade to the version we are currently uploading.

resolves HDR-Development/hdr-launcher#3