### PR TITLE
Jab lock rework

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -135,7 +135,7 @@ pub mod vars {
         pub const SHOULD_WAVELAND: i32 = 80;
         pub const SIDE_SPECIAL_CANCEL_NO_HIT: i32 = 81;
         pub const JUMP_NEXT: i32 = 82;
-
+        pub const IS_JAB_LOCK_ROLL: i32 = 83;
         
 
         // int
@@ -151,6 +151,7 @@ pub mod vars {
         pub const ATTACK_DASH_CANCEL_FRAME: i32 = 0xA;
         pub const AIR_ESCAPE_MAGNET_FRAME: i32 = 0xB;
         pub const TURN_DASH_FRAME: i32 = 0xC;
+        pub const DOWN_STAND_FB_KIND: i32 = 0xD;
 
         // float
         pub const LAST_ATTACK_DAMAGE_DEALT: i32 = 0x0;

--- a/fighters/common/src/general_statuses/downdamage.rs
+++ b/fighters/common/src/general_statuses/downdamage.rs
@@ -1,0 +1,105 @@
+use super::*;
+use globals::*;
+
+// This file contains code for jab locks
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+    skyline::install_hooks!(
+        get_down_stand_fb_kind_hook
+    );
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            status_DownDamage_Main
+        );
+    }
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_DownDamage_Main)]
+unsafe fn status_DownDamage_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_START_AIR)
+    || (!WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_START_AIR)
+        && (!WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FALL) || fighter.global_table[SITUATION_KIND] != SITUATION_KIND_AIR)) {
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FALL)
+        && MotionModule::is_end(fighter.module_accessor) 
+        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_DAMAGE_FALL),
+                L2CValue::Bool(false)
+            );
+            return 0.into();
+        }
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DOWN_STAND)
+        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
+        && MotionModule::is_end(fighter.module_accessor)
+        && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_KNOCKOUT)
+        && WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_DOWN_WORK_FLOAT_DOWN_FRAME) <= 0.0 {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_DOWN_STAND),
+                L2CValue::Bool(false)
+            );
+            return 0.into();
+        }
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DOWN_WAIT)
+        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
+        && MotionModule::is_end(fighter.module_accessor) {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_DOWN_WAIT_CONTINUE),
+                L2CValue::Bool(false)
+            );
+            return 0.into();
+        }
+        fighter.sub_down_chk_reflect_wall();
+        if !StatusModule::is_changing(fighter.module_accessor) {
+            if (fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND && fighter.global_table[PREV_SITUATION_KIND] == SITUATION_KIND_GROUND)
+            || fighter.global_table[SITUATION_KIND] != SITUATION_KIND_GROUND {
+                if fighter.global_table[SITUATION_KIND] != SITUATION_KIND_AIR || fighter.global_table[PREV_SITUATION_KIND] != SITUATION_KIND_GROUND {
+                    return 0.into();
+                }
+            }
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_SITUATION_CHANGE);
+        }
+        if fighter.global_table[SITUATION_KIND] != SITUATION_KIND_GROUND {
+            GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_SITUATION_CHANGE) {
+                return 0.into();
+            }
+            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
+        }
+        else {
+            GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
+            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_SITUATION_CHANGE) {
+                return 0.into();
+            }
+            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
+        }
+    }
+    else {
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DAMAGE_FLAG_END_REACTION) {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_DAMAGE_FALL),
+                L2CValue::Bool(false)
+            );
+            return 0.into();
+        }
+        else {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_MISS_FOOT),
+                L2CValue::Bool(false)
+            );
+            return 0.into();
+        }
+    }
+    return 0.into()
+}
+
+#[skyline::hook(replace = ControlModule::get_down_stand_fb_kind)]
+unsafe fn get_down_stand_fb_kind_hook(boma: &mut BattleObjectModuleAccessor) -> u64 {
+    if boma.is_prev_status(*FIGHTER_STATUS_KIND_DOWN_DAMAGE) {
+        return VarModule::get_int(boma.object(), vars::common::DOWN_STAND_FB_KIND) as u64;
+    }
+    original!()(boma)
+}

--- a/fighters/common/src/general_statuses/downdamage.rs
+++ b/fighters/common/src/general_statuses/downdamage.rs
@@ -20,6 +20,15 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_DownDamage_Main)]
 unsafe fn status_DownDamage_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if StopModule::is_stop(fighter.module_accessor) {
+        if fighter.is_cat_flag(Cat2::DownToDownStandFB) {
+            VarModule::on_flag(fighter.battle_object, vars::common::IS_JAB_LOCK_ROLL);
+            VarModule::set_int(fighter.battle_object, vars::common::DOWN_STAND_FB_KIND, ControlModule::get_down_stand_fb_kind(fighter.module_accessor) as i32);
+        }
+        else {
+            VarModule::off_flag(fighter.battle_object, vars::common::IS_JAB_LOCK_ROLL);
+        }
+    }
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_START_AIR)
     || (!WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DOWN_DAMAGE_FLAG_START_AIR)
         && (!WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FALL) || fighter.global_table[SITUATION_KIND] != SITUATION_KIND_AIR)) {
@@ -46,11 +55,26 @@ unsafe fn status_DownDamage_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DOWN_WAIT)
         && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
         && MotionModule::is_end(fighter.module_accessor) {
-            fighter.change_status(
+            /***fighter.change_status(
                 L2CValue::I32(*FIGHTER_STATUS_KIND_DOWN_WAIT_CONTINUE),
                 L2CValue::Bool(false)
             );
             return 0.into();
+            ***/
+            if VarModule::is_flag(fighter.battle_object, vars::common::IS_JAB_LOCK_ROLL) {
+                fighter.change_status(
+                    L2CValue::I32(*FIGHTER_STATUS_KIND_DOWN_STAND_FB),
+                    L2CValue::Bool(true)
+                );
+                return 0.into();
+            }
+            else {
+                fighter.change_status(
+                    L2CValue::I32(*FIGHTER_STATUS_KIND_DOWN_STAND),
+                    L2CValue::Bool(true)
+                );
+                return 0.into();
+            }
         }
         fighter.sub_down_chk_reflect_wall();
         if !StatusModule::is_changing(fighter.module_accessor) {

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -22,6 +22,7 @@ mod attackhi4;
 mod attacklw4;
 mod passive;
 mod damagefall;
+mod downdamage;
 // [LUA-REPLACE-REBASE]
 // [SHOULD-CHANGE]
 // Reimplement the whole status script (already done) instead of doing this.
@@ -370,6 +371,7 @@ pub fn install() {
     attacklw4::install();
     passive::install();
     damagefall::install();
+    downdamage::install();
 
     smashline::install_status_scripts!(
         damage_fly_end,

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -5,6 +5,7 @@
   <float hash="damage_level2">23.625</float>
   <float hash="damage_level3">36</float>
   <float hash="damage_angle_ground_max">44</float>
+  <float hash="down_damage_s_reaction">999</float>
   <float hash="damage_fly_quake_l">90</float>
   <int hash="damage_fly_speed_up_reaction_frame_min">998</int>
   <int hash="damage_fly_speed_up_reaction_frame_max">999</int>


### PR DESCRIPTION
- Jab lock "flop" animation reduced 40f -> 14f
- Getup attack disabled out of jab lock
- Your getup option is now "locked in" based on your stick position during jab lock hitlag: if your stick is held in a direction during hitlag, you will automatically roll in that direction once your flop animation is over. If your stick is neutral during hitlag, you will automatically regular getup once your flop animation is over. This means that inputting any button, or nothing at all, after being jab locked will still automatically transition you into regular getup.

Resolves #258 