### PR TITLE
Fix missing auto cancel window at the end of mythra up air

### DIFF
--- a/fighters/elight/src/acmd/aerials.rs
+++ b/fighters/elight/src/acmd/aerials.rs
@@ -226,6 +226,10 @@ unsafe fn elight_attack_air_hi_game(fighter: &mut L2CAgentBase) {
         }
         AttackModule::clear_all(boma);
     }
+    frame(lua_state, 25.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+    }
     frame(lua_state, 43.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 0.8);


### PR DESCRIPTION
Auto cancels starting on frame 19, nerfed from f16 in vannila to match timings
(Because in vannila the hitboxes end on f13 and in hdr they end on f16)

Fixes #435 