### PR TITLE
Taunting from Dash/Run/Runbrake and Teeter Cancelling

### DIFF
--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -417,6 +417,40 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
     );
 
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+    && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+    || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0)
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
     interrupt_if!(fighter.sub_transition_group_check_ground_attack().get_bool());
 
     if WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_DASH_WORK_INT_ENABLE_ATTACK_FRAME) > 0

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -433,29 +433,6 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
     }
 
-    /* if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
-
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
-    && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
-    || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0)
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    } */
-
     interrupt_if!(fighter.sub_transition_group_check_ground_attack().get_bool());
 
     if WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_DASH_WORK_INT_ENABLE_ATTACK_FRAME) > 0

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -417,8 +417,13 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         fighter.global_table[PAD_FLAG].get_i32() & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
     );
 
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
+    if (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+        && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+        || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0))
     && {
         fighter.clear_lua_stack();
         fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
@@ -428,7 +433,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
     }
 
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+    /* if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
     && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
     && {
         fighter.clear_lua_stack();
@@ -449,7 +454,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         fighter.pop_lua_stack(1).get_bool()
     } {
         interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
+    } */
 
     interrupt_if!(fighter.sub_transition_group_check_ground_attack().get_bool());
 

--- a/fighters/common/src/general_statuses/run.rs
+++ b/fighters/common/src/general_statuses/run.rs
@@ -107,6 +107,40 @@ unsafe extern "C" fn status_run_main(fighter: &mut L2CFighterCommon) -> L2CValue
 	//println!("run speed_motion: {}", speed_motion);
 	//println!("run total speed: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN));
 
+	if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+    && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+    || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0)
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
+    }
+
     call_original!(fighter)
 }
 

--- a/fighters/common/src/general_statuses/run.rs
+++ b/fighters/common/src/general_statuses/run.rs
@@ -107,31 +107,13 @@ unsafe extern "C" fn status_run_main(fighter: &mut L2CFighterCommon) -> L2CValue
 	//println!("run speed_motion: {}", speed_motion);
 	//println!("run total speed: {}", KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN));
 
-	if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
-
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
-
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
-    && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
-    || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0)
+	if (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+        && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+        || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0))
     && {
         fighter.clear_lua_stack();
         fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
@@ -261,31 +243,13 @@ unsafe fn status_runbrake(fighter: &mut L2CFighterCommon) -> L2CValue {
 
 #[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon20status_RunBrake_MainEv")]
 unsafe fn status_runbrake_main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
-
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
-    && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0
-    && {
-        fighter.clear_lua_stack();
-        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
-        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
-        fighter.pop_lua_stack(1).get_bool()
-    } {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_APPEAL, false);
-    }
-
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
-    && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
-    || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0)
+    if (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+        && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+        || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0))
     && {
         fighter.clear_lua_stack();
         fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -363,6 +363,23 @@ pub unsafe fn respawn_taunt(boma: &mut BattleObjectModuleAccessor, status_kind: 
     MotionModule::change_motion(boma, motion, 0.0, 1.0, false, 0.0, false, false);
 }
 
+// Teeter cancelling
+pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    
+    if (boma.is_situation(*SITUATION_KIND_GROUND)
+    && GroundModule::get_correct(boma) == *GROUND_CORRECT_KIND_GROUND
+    && KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL).abs() > 0.0) {
+        // Conditions for transitioning to teeter animation in sub_ground_check_ottotto
+        if (GroundModule::is_ottotto(boma, 1.5) // Original value: 0.86
+        && fighter.global_table[STICK_X].get_f32().abs() < 0.75) {
+            fighter.change_status(
+                FIGHTER_STATUS_KIND_OTTOTTO.into(),
+                true.into()
+            );
+        }
+    }
+}
+
 #[utils::export(common::opff)]
 pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
@@ -393,6 +410,7 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     waveland_plat_drop(boma, cat[1], status_kind);
     hitfall(boma, status_kind, situation_kind, fighter_kind, cat);
     respawn_taunt(boma, status_kind);
+    teeter_cancel(fighter, boma);
 
     freeze_stages(boma);
 }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -367,10 +367,23 @@ pub unsafe fn respawn_taunt(boma: &mut BattleObjectModuleAccessor, status_kind: 
 pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     
     if (boma.is_situation(*SITUATION_KIND_GROUND)
+    && boma.is_status_one_of(
+    &[*FIGHTER_STATUS_KIND_WAIT,
+        *FIGHTER_STATUS_KIND_DASH,
+        *FIGHTER_STATUS_KIND_APPEAL,
+        *FIGHTER_STATUS_KIND_LANDING,
+        *FIGHTER_STATUS_KIND_LANDING_LIGHT,
+        *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR,
+        *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL,
+        *FIGHTER_STATUS_KIND_LANDING_DAMAGE_LIGHT]
+    )
     && GroundModule::get_correct(boma) == *GROUND_CORRECT_KIND_GROUND
-    && KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL).abs() > 0.0) {
+    && (KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL)
+    - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND)
+    - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN)).abs() > 0.0) {
+
         // Conditions for transitioning to teeter animation in sub_ground_check_ottotto
-        if (GroundModule::is_ottotto(boma, 1.5) // Original value: 0.86
+        if (GroundModule::is_ottotto(boma, 1.72) // Original value: 0.86
         && fighter.global_table[STICK_X].get_f32().abs() < 0.75) {
             fighter.change_status(
                 FIGHTER_STATUS_KIND_OTTOTTO.into(),

--- a/fighters/common/src/shoto_status.rs
+++ b/fighters/common/src/shoto_status.rs
@@ -176,6 +176,22 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
     if fighter.sub_transition_group_check_ground_attack().get_bool() {
         return true.into();
     }
+    if (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_HI != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW)
+        && fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_LW != 0)
+    || (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S)
+        && (fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_L != 0
+        || fighter.global_table[CMD_CAT2].get_i32() & *FIGHTER_PAD_CMD_CAT2_FLAG_APPEAL_S_R != 0))
+    && {
+        fighter.clear_lua_stack();
+        fighter.push_lua_stack(&mut L2CValue::new_int(0x1daca540be));
+        app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
+        fighter.pop_lua_stack(1).get_bool()
+    } {
+        fighter.change_status(*FIGHTER_STATUS_KIND_APPEAL, false.into());
+        return 1.into();
+    }
     if 0 < WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_DASH_WORK_INT_ENABLE_ATTACK_FRAME)
     && (fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
     || FighterUtil::is_valid_auto_catch_item(fighter.module_accessor, false)) {

--- a/fighters/common/src/shoto_status.rs
+++ b/fighters/common/src/shoto_status.rs
@@ -189,7 +189,7 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
         app::sv_battle_object::notify_event_msc_cmd(fighter.lua_state_agent);
         fighter.pop_lua_stack(1).get_bool()
     } {
-        fighter.change_status(*FIGHTER_STATUS_KIND_APPEAL, false.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_APPEAL.into(), false.into());
         return 1.into();
     }
     if 0 < WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_DASH_WORK_INT_ENABLE_ATTACK_FRAME)


### PR DESCRIPTION
Taunt from dash, run (edit: and runbrake) and cancel (edit: taunts, dashes and landing animations) at the edge with the teeter animation. This requires the stick's x position to be less than |0.75| and for the player to be under a certain speed.

~~Teeter cancelling is by design left open to other actions than just taunting like in PM, but it doesn't outright interrupt all attacks or anything like that.~~

~~Going to mark as a draft for now because of some late night fixes that could have unseen consequences but should be good
Late night fixes in question were kinetic energy check missing the .abs() so teeter cancelling didn't work on the left side and allowing taunt from run~~


Resolves #397