### PR TITLE
Falcon nair readjustments

### DIFF
--- a/fighters/captain/src/acmd/aerials.rs
+++ b/fighters/captain/src/acmd/aerials.rs
@@ -8,17 +8,18 @@ unsafe fn captain_attack_air_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     frame(lua_state, 6.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("sys_attack_arc"), Hash40::new("top"), 0.0, 4.5, 2.0, -148, -141, -3.0, 1.1, true, 0.7);
+        EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("sys_attack_arc"), Hash40::new("top"), 0.0, 4.5, 3.0, -148, -141, -3.0, 1.1, true, 0.7);
         //LAST_EFFECT_SET_RATE(fighter, 1.5);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_line_b"), Hash40::new("top"), 0.0, 8.0, -5.0, -17.0, 5.0, 0.0, 1.1, true);
-        //LAST_EFFECT_SET_RATE(fighter, 2.0);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_line_b"), Hash40::new("top"), 0.0, 8.0, -5.0, -15.0, 5.0, 0.0, 1.1, true);
+        //LAST_EFFECT_SET_RATE(fighter, 0.8);
     }
-    frame(lua_state, 13.0);
+    frame(lua_state, 14.0);
     if is_excute(fighter) {
-        EFFECT_ALPHA(fighter, Hash40::new("sys_attack_impact"), Hash40::new("top"), 0.0, 12.0, 14.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 360.0, true, 0.5);
+        //EFFECT_ALPHA(fighter, Hash40::new("sys_attack_impact"), Hash40::new("top"), 0.0, 12.0, 14.0, 0.0, 0.0, 0.0, 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 360.0, true, 0.5);
+        EFFECT_ALPHA(fighter, Hash40::new("sys_attack_impact"), Hash40::new("kneel"), 6.0, -0.7, 0.0, 0.0, 0.0, 0.0, 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 360.0, true, 0.65);
     }
 }
 
@@ -79,7 +80,7 @@ unsafe fn captain_attack_air_n_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 7.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 5.0);
+        FT_MOTION_RATE(fighter, 5.0/(9.1-7.0));
         ATTACK(fighter, 0, 0, Hash40::new("legr"), 4.0, 367, 25, 0, 50, 6.0, 3.2, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 1, 0, Hash40::new("legr"), 4.0, 68, 0, 0, 65, 6.0, 3.2, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 2, 0, Hash40::new("kneer"), 4.0, 367, 25, 0, 50, 5.0, 5.2, -0.7, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
@@ -87,21 +88,32 @@ unsafe fn captain_attack_air_n_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 4, 0, Hash40::new("hip"), 4.0, 68, 25, 0, 50, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 5, 0, Hash40::new("hip"), 4.0, 367, 0, 0, 50, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
-    
-    wait(lua_state, 1.0);
+    frame(lua_state, 9.1);
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 1.0/(10.0-9.1));
+    }
+    frame(lua_state, 10.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        FT_MOTION_RATE(fighter, 1.357);
+        FT_MOTION_RATE(fighter, 5.0/(11.5-10.0));
     }
-    
+    frame(lua_state, 11.5);
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 1.0);
+    }
+    frame(lua_state, 12.5);
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, (1.0)/(14.0-12.5));
+    }
     frame(lua_state, 14.0);    
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.333);
+        //FT_MOTION_RATE(fighter, 1.333);
+        FT_MOTION_RATE(fighter, 1.0);
         ATTACK(fighter, 0, 0, Hash40::new("kneel"), 4.5, 361, 120, 0, 50, 5.2, 5.0, -0.7, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 1, 0, Hash40::new("legl"), 4.5, 361, 120, 0, 50, 5.75, 3.2, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 2, 0, Hash40::new("hip"), 4.5, 361, 120, 0, 50, 4.7, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
-    wait(lua_state, 7.0);
+    wait(lua_state, 10.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.000);
         AttackModule::clear_all(boma);


### PR DESCRIPTION
Readjusted the motion rates throughout Captain Falcon's nair to better mimic Melee/PM's animation which current nair is based off of, as well as retimed, repositioned, and rotated some of the effects to better suit the animation and visually represent the hitbox timing. A demonstration video is linked below:

https://youtu.be/0Ne7SoYl9lE

[Rukai data](https://rukaidata.com/P+/Captain%20Falcon/subactions/AttackAirN.html) and the [SSBWiki](https://www.ssbwiki.com/Captain_Falcon_(SSBM)/Neutral_aerial#/media/File:CFalcon_Neutral_Aerial.gif) and [Melee Frame Data](http://meleeframedata.com/captain_falcon) visualizations were referenced.

Resolves #449