### PR TITLE
Reinstate vanilla cstick IRAR behavior

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -152,6 +152,7 @@ pub mod vars {
         pub const AIR_ESCAPE_MAGNET_FRAME: i32 = 0xB;
         pub const TURN_DASH_FRAME: i32 = 0xC;
         pub const DOWN_STAND_FB_KIND: i32 = 0xD;
+        pub const CSTICK_LIFE: i32 = 0xE;
 
         // float
         pub const LAST_ATTACK_DAMAGE_DEALT: i32 = 0x0;

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -453,5 +453,7 @@ unsafe fn sub_jump_squat_uniq_check_sub_mini_attack(fighter: &mut L2CFighterComm
 #[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon42sub_status_JumpSquat_check_stick_lr_updateEv")]
 unsafe fn sub_status_JumpSquat_check_stick_lr_update(fighter: &mut L2CFighterCommon) -> L2CValue {
     let prev_status = fighter.global_table[PREV_STATUS_KIND].get_i32();
+    // only allow jumpsquat to flip you around if your previous status was Dash and your directional input was caused by cstick (cstick input 2 frames within jumpsquat)
+    // allows for cstick IRAR
     L2CValue::Bool(prev_status == *FIGHTER_STATUS_KIND_DASH && VarModule::get_int(fighter.battle_object, vars::common::CSTICK_LIFE) > 0)
 }

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -129,6 +129,7 @@ pub unsafe fn airdodge_refresh_on_hit_disable(boma: &mut BattleObjectModuleAcces
     VarModule::set_flag(boma.object(), vars::common::PREV_FLAG_DISABLE_ESCAPE_AIR, WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR));
 }
 
+// counter which checks how long cstick has overridden left stick directional input
 pub unsafe fn cstick_override_detection(fighter: &mut L2CFighterCommon) {
     if VarModule::get_int(fighter.battle_object, vars::common::CSTICK_LIFE) > 0 {
         VarModule::inc_int(fighter.battle_object, vars::common::CSTICK_LIFE);

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -129,6 +129,18 @@ pub unsafe fn airdodge_refresh_on_hit_disable(boma: &mut BattleObjectModuleAcces
     VarModule::set_flag(boma.object(), vars::common::PREV_FLAG_DISABLE_ESCAPE_AIR, WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR));
 }
 
+pub unsafe fn cstick_override_detection(fighter: &mut L2CFighterCommon) {
+    if VarModule::get_int(fighter.battle_object, vars::common::CSTICK_LIFE) > 0 {
+        VarModule::inc_int(fighter.battle_object, vars::common::CSTICK_LIFE);
+    }
+    if ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+        VarModule::set_int(fighter.battle_object, vars::common::CSTICK_LIFE, 1);
+    }
+    if VarModule::get_int(fighter.battle_object, vars::common::CSTICK_LIFE) > 2 {  // ideally replace this hardcoded 2 with "stick_life" from substick_parameter.prc
+        VarModule::set_int(fighter.battle_object, vars::common::CSTICK_LIFE, 0);
+    }
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     
     
@@ -136,5 +148,6 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleA
     //sliding_smash_disable(fighter, boma, status_kind, fighter_kind);
     buffered_cstick_aerial_fixes(fighter, boma, status_kind);
     airdodge_refresh_on_hit_disable(boma, status_kind);
+    cstick_override_detection(fighter);
 }
 


### PR DESCRIPTION
During dash, inputting cstick backwards then jump within next 2 frames will allow a full momentum IRAR, as in vanilla.

Resolves #458 