### PR TITLE
Sephiroth Jab Recovery 25 > 12

### DIFF
--- a/fighters/edge/src/acmd/ground.rs
+++ b/fighters/edge/src/acmd/ground.rs
@@ -29,9 +29,9 @@ unsafe fn sephiroth_attack_11_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 16.0/(36.0-16.0));
+        FT_MOTION_RATE(fighter, 16.0/(23.0-16.0));
     }
-    frame(lua_state, 36.0);
+    frame(lua_state, 23.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.0);
     }


### PR DESCRIPTION
should reduce Sephiroth's Jab recovery by 13 frames