### PR TITLE
Adding retries for workflow artifact uploads

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -41,9 +41,19 @@ jobs:
 
       - name: Upload changelog
         uses: actions/upload-artifact@v2
+        # we want to keep going if this failed, because we will try again
+        continue-on-error: true
         with:
           name: changelog
           path: CHANGELOG.md
+      
+      - name: upload changelog retry
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: CHANGELOG.md
+
 
   plugin_build:
     env:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -12,11 +12,11 @@ jobs:
     container: 
       image: jugeeya/cargo-skyline:2.1.0-dkp
     steps:
-    - testing: test continue on failed
+    - name: test continue on failed
       continue-on-error: true
       run: exit 1
 
-    - testingfailed: test failed, retry
+    - name: test failed, retry
       if: ${{ failure() }}
       run: echo "we retried!"
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -13,11 +13,9 @@ jobs:
       image: jugeeya/cargo-skyline:2.1.0-dkp
     steps:
     - name: test continue on failed
-      continue-on-error: true
       run: exit 1
 
     - name: test failed, retry
-      if: ${{ failure() }}
       run: echo "we retried!"
 
 
@@ -30,17 +28,17 @@ jobs:
       uses: actions/checkout@v2
 
     # build the project
-    - run: |
-        export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin \
-        && cd scripts && python3 make_dist.py build version=1.69.420-pr name=hdr-pr && cd ..
-      env:
-        HOME: /root
-
-    ## mock upload files
     #- run: |
-    #    mkdir distributions
-    #    echo lol > distributions/hdr-switch.zip
-    #    echo lol > distributions/hdr-ryujinx.zip
+    #    export PATH=$PATH:/root/.cargo/bin:/opt/devkitpro/devkitA64/bin \
+    #    && cd scripts && python3 make_dist.py build version=1.69.420-pr name=hdr-pr && cd ..
+    #  env:
+    #    HOME: /root
+
+    # mock upload files
+    - run: |
+        mkdir distributions
+        echo lol > distributions/hdr-switch.zip
+        echo lol > distributions/hdr-ryujinx.zip
 
     - name: Upload hdr-switch
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -16,7 +16,6 @@ jobs:
       run: exit 1
 
     - name: test failed, retry
-      if: ${{ failure() }}
       run: echo "we retried!"
 
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -16,6 +16,7 @@ jobs:
       run: exit 1
 
     - name: test failed, retry
+      if: ${{ failure() }}
       run: echo "we retried!"
 
 

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -12,6 +12,15 @@ jobs:
     container: 
       image: jugeeya/cargo-skyline:2.1.0-dkp
     steps:
+    - testing: test continue on failed
+      continue-on-error: true
+      run: exit 1
+
+    - testingfailed: test failed, retry
+      if: ${{ failure() }}
+      run: echo "we retried!"
+
+
     - name: setup python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
This adds a single retry to most of our file uploads. We somewhat commonly end up with `ERRCONNRESET` errors during upload of artifacts in PR, nightly, and beta builds. Now, we will try a second time if this occurs. If the second try fails, then the workflow will still fail.