### PR TITLE
workflow improvements and to-beta.zip and to-nightly.zip

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -219,3 +219,52 @@ jobs:
         tag: ${{ needs.plugin_build.outputs.trimmed_tag }}
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}
+
+  ################  handle the creation of to-nightly.zip  ################
+  to_nightly:
+    runs-on: ubuntu-latest
+    needs: [full_package, version_and_changelog]
+    steps:
+    - name: checkout version
+      uses: actions/checkout@v2
+
+    # download the nightly
+    - id: latest_nightly
+      uses: robinraju/release-downloader@v1.3
+      with:
+        repository: "HDR-Development/HDR-Nightlies"
+        latest: true
+        fileName: "switch-package.zip"
+
+    # move the nightly to the artifacts dir
+    - run: mkdir artifacts && mv switch-package.zip artifacts
+
+    # build the to-nightly.zip
+    - name: make to-nightly.zip artifact
+      run: |
+        python3 scripts/make_diff.py beta
+
+    - name: show upgrade artifacts
+      run: |
+        ls && stat * && echo && ls upgrade_artifacts && stat upgrade_artifacts/*
+
+    - run: mv upgrade_artifacts/upgrade.zip to-nightly.zip
+
+    # get the most recent latest beta
+    - id: latest_beta
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: HDR-Development/HDR-Releases
+
+    # upload the to-nightly.zip to the beta for the launcher
+    - name: Upload to-nightly.zip to beta
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to-nightly.zip
+        prerelease: false
+        file_glob: false
+        asset_name: to-nightly
+        repo_name: HDR-Development/HDR-Releases
+        tag: ${{ steps.latest_beta.outputs.release }}
+        overwrite: true

--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -50,12 +50,13 @@ jobs:
         stripHeaders: true
         token: ${{ secrets.GITHUB_TOKEN  }}
         verbose: false
+        issuesWoLabels: false
         compareLink: false
         simpleList: true
 
 
     - name: Upload changelog
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: changelog
         path: CHANGELOG.md
@@ -101,7 +102,7 @@ jobs:
     #    echo lol > distributions/hdr-ryujinx.zip
 
     - name: Upload version
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: version
         path: plugin/hdr_version.txt

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -37,10 +37,12 @@ jobs:
         with:
           sinceTag: ${{ steps.push_tag.outputs.old-version }}
           stripHeaders: true
+          verbose: false
+          issuesWoLabels: false
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Upload changelog
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: changelog
           path: CHANGELOG.md
@@ -75,7 +77,7 @@ jobs:
     #    echo lol > distributions/hdr-ryujinx.zip
 
     - name: Upload version
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: version
         path: plugin/hdr_version.txt

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -96,6 +96,7 @@ jobs:
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}
     
+  ##############  handle the creasion of the full package installation  ##############
   full_package:
     runs-on: ubuntu-latest
     needs: [version_and_changelog, plugin_build]
@@ -168,3 +169,96 @@ jobs:
         tag: ${{ needs.version_and_changelog.outputs.version }}
         overwrite: true
         body: ${{ needs.version_and_changelog.outputs.changelog }}
+
+  ################  handle the creation of to-nightly.zip  ################
+  to_nightly:
+    runs-on: ubuntu-latest
+    needs: [full_package, version_and_changelog]
+    steps:
+    - name: checkout version
+      uses: actions/checkout@v2
+
+    # get the nightly
+    - id: latest_nightly
+      uses: robinraju/release-downloader@v1.3
+      with:
+        repository: "HDR-Development/HDR-Nightlies"
+        tag: ${{ needs.version_and_changelog.outputs.version }}
+        fileName: "switch-package.zip"
+
+    # move the nightly to the artifacts dir
+    - run: mkdir artifacts && mv switch-package.zip artifacts
+
+    # build the to-nightly.zip
+    - name: make to-nightly.zip artifact
+      run: |
+        python3 scripts/make_diff.py beta
+
+    - name: show upgrade artifacts
+      run: |
+        ls && stat * && echo && ls upgrade_artifacts && stat upgrade_artifacts/*
+
+    - run: mv upgrade_artifacts/upgrade.zip to-nightly.zip
+
+    # get the most recent latest beta
+    - id: latest_beta
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: HDR-Development/HDR-Releases
+
+    # upload the to-nightly.zip to the beta for the launcher
+    - name: Upload to-nightly.zip to beta
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to-nightly.zip
+        prerelease: false
+        file_glob: false
+        asset_name: to-nightly
+        repo_name: HDR-Development/HDR-Releases
+        tag: ${{ steps.latest_beta.outputs.release }}
+        overwrite: true
+
+
+  ################  handle the creation of to-beta.zip  ################
+  to_beta:
+    runs-on: ubuntu-latest
+    needs: [full_package, version_and_changelog]
+    steps:
+    - name: checkout version
+      uses: actions/checkout@v2
+
+    # get the beta
+    - id: latest_beta
+      uses: robinraju/release-downloader@v1.3
+      with:
+        repository: "HDR-Development/HDR-Releases"
+        latest: true
+        fileName: "switch-package.zip"
+
+    # move the beta to the artifacts dir
+    - run: mkdir artifacts && mv switch-package.zip artifacts
+
+    # build the to-beta.zip
+    - name: make to-beta.zip artifact
+      run: |
+        python3 scripts/make_diff.py https://github.com/HDR-Development/HDR-Nightlies/releases/download/${{ needs.version_and_changelog.outputs.version }}/switch-package.zip
+
+    - name: show upgrade artifacts
+      run: |
+        ls && stat * && echo && ls upgrade_artifacts && stat upgrade_artifacts/*
+
+    - run: mv upgrade_artifacts/upgrade.zip to-beta.zip
+
+    # upload the to-beta.zip to the beta for the launcher
+    - name: Upload to-beta.zip to nightly
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to-beta.zip
+        prerelease: false
+        file_glob: false
+        asset_name: to-beta
+        repo_name: HDR-Development/HDR-Nightlies
+        tag: ${{ needs.version_and_changelog.outputs.version }}
+        overwrite: true

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -34,12 +34,12 @@ jobs:
     #    echo lol > distributions/hdr-ryujinx.zip
 
     - name: Upload hdr-switch
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: hdr-switch
         path: distributions/hdr-switch.zip
     - name: Upload hdr-ryujinx
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: hdr-ryujinx
         path: distributions/hdr-ryujinx.zip

--- a/scripts/make_diff.py
+++ b/scripts/make_diff.py
@@ -21,11 +21,15 @@ if not os.path.exists("artifacts/switch-package.zip"):
 
 if sys.argv[1] == "nightly":
     release_type = "Nightlies"
-else:
+    url = "https://github.com/HDR-Development/HDR-" + release_type + "/releases/latest/download/switch-package.zip"
+elif sys.argv[1] == "beta":
     release_type = "Releases"
+    url = "https://github.com/HDR-Development/HDR-" + release_type + "/releases/latest/download/switch-package.zip"
+else:
+    release_type = "direct_url"
+    url = sys.argv[1]
 
-url = "https://github.com/HDR-Development/HDR-" + release_type + "/releases/latest/download/switch-package.zip"
-print("getting latest from url: " + url)
+print("type: " + release_type + ", getting latest from url: " + url)
 
 urllib.request.urlretrieve(url, "switch-package-previous.zip")
 


### PR DESCRIPTION
- upgrading upload-artifact to v3, which may reduce the number of artifact uploads that fail due to ERRCONNRESET and other sporadic errors.
- cleaning up changelog to not include issues that don't have a label when they get closed
- nightlies and betas now create and upload to-beta.zip and to-nightly.zip files on their respective releases, for future launcher use