### PR TITLE
Fix visual glitches during elemental attack hitlag

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -38,7 +38,6 @@
   <int hash="hit_stop_delay_flick_frame">2</int>
   <int hash="hit_stop_delay_flick_max_count">50</int>
   <float hash="hit_stop_delay_auto_mul">0.5</float>
-  <float hash="attack_hit_slow_rate">0.01</float>
   <float hash="damage_reaction_mul_max">1</float>
   <list hash="pattern_power_mul">
     <hash40 index="0">dummy</hash40>


### PR DESCRIPTION
Reverted attack_hit_slow_rate change in common.prcxml

Fixes giant lines appearing on screen during elemental attacks' hitlag