### PR TITLE
The Return of Ryujinx Packaging

### DIFF
--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -71,12 +71,22 @@ shutil.move("hdr-launcher.nro", "switch-package/atmosphere/contents/01006A800016
 print("making switch-package.zip")
 shutil.make_archive("switch-package", 'zip', 'switch-package')
 
-
 hash_package.hash_folder("switch-package", "content_hashes.txt")
+
+
+# make a ryujinx package too
+print("making ryujinx-package.zip")
+os.remove("switch-package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/hdr-launcher.nro")
+os.mkdir("switch-package/sdcard")
+shutil.move("switch-package/atmosphere/", "switch-package/sdcard/")
+shutil.move("switch-package/ultimate/", "switch-package/sdcard/")
+shutil.make_archive("ryujinx-package", 'zip', 'switch-package')
+
 
 # move the stuff to artifacts folder
 if os.path.exists("artifacts"):
     shutil.rmtree("artifacts")
 os.mkdir("artifacts")
 shutil.move("switch-package.zip", "artifacts")
+shutil.move("ryujinx-package.zip", "artifacts")
 shutil.move("content_hashes.txt", "artifacts")


### PR DESCRIPTION
we now package a `ryujinx-package.zip` during nightlies and betas. Files are housed in the `/sdcard/` folder, and the launcher is removed.