### PR TITLE
Fix Marth not running the common FE OPFF appropriately

### DIFF
--- a/fighters/common/src/opff/fe.rs
+++ b/fighters/common/src/opff/fe.rs
@@ -72,6 +72,6 @@ pub unsafe extern "Rust" fn fe_common(fighter: &mut L2CFighterCommon) {
 pub unsafe fn fe_moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     let fighter_kind = boma.kind();
     up_special_reverse(boma, fighter_kind, status_kind, stick_x, facing, frame);
-    dancing_blade_stall(boma, id, status_kind, situation_kind, frame);
+    //dancing_blade_stall(boma, id, status_kind, situation_kind, frame);
     sword_length(boma);
 }

--- a/fighters/marth/src/opff.rs
+++ b/fighters/marth/src/opff.rs
@@ -31,7 +31,7 @@ pub fn marth_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
 		marth_frame(fighter);
-        //fe_common(fighter);
+        fe_common(fighter);
     }
 }
 


### PR DESCRIPTION
Fixes an issue where Marth wasn't properly running the FE once per fighter frame functions, leftover from when I was readjusting his Dancing Blade momentum behavior.