### PR TITLE
[Bugfix/Change] Waveland Reimplementation

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -413,7 +413,7 @@ pub trait BomaExt {
     unsafe fn get_param_int64(&mut self, obj: &str, field: &str) -> u64;
 
     // tech/general subroutine
-    unsafe fn handle_waveland(&mut self, change_status: bool) -> bool;
+    unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool;
 }
 
 impl BomaExt for BattleObjectModuleAccessor {
@@ -680,16 +680,14 @@ impl BomaExt for BattleObjectModuleAccessor {
         ModelModule::set_joint_rotate(self, Hash40::new(&bone_name), &rotation, MotionNodeRotateCompose{_address: *MOTION_NODE_ROTATE_COMPOSE_AFTER as u8}, MotionNodeRotateOrder{_address: *MOTION_NODE_ROTATE_ORDER_XYZ as u8})
     }
 
-    unsafe fn handle_waveland(&mut self, change_status: bool) -> bool {
-        if !self.is_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE])
-        || (MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU)) {
-            println!("wrong status");
+    unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool {
+        if require_airdodge && (!self.is_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE])
+        || (MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU))) {
             return false;
         }
 
         // must check this because it is for allowing the player to screw up a perfect WD and be punished with a non-perfect WD (otherwise they'd have like, 8 frames for perfect WD lol)
         if !crate::VarModule::is_flag(self.object(), crate::consts::vars::common::ENABLE_AIR_ESCAPE_MAGNET) {
-            println!("no magnet");
             return false;
         }
 
@@ -707,7 +705,6 @@ impl BomaExt for BattleObjectModuleAccessor {
             }
             true
         } else {
-            println!("{:?}", out_pos);
             false
         }
     }

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -681,6 +681,7 @@ impl BomaExt for BattleObjectModuleAccessor {
     }
 
     unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool {
+        dbg!(MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU));
         if require_airdodge && (!self.is_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE])
         || (MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU))) {
             return false;
@@ -692,8 +693,23 @@ impl BomaExt for BattleObjectModuleAccessor {
         }
 
         // ecb is top, bottom, left, right
+        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) < crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
+            let group = crate::ParamModule::get_int(self.object(), crate::ParamType::Shared, "ecb_group_shift");
+            let shift = match group {
+                0 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.small"),
+                1 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.medium"),
+                2 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.large"),
+                3 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.x_large"),
+                4 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.xx_large"),
+                _ => panic!("malformed parammodule file! unknown group number for ecb shift: {}", group)
+            };
+            shift + crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_shift_for_waveland")
+        } else {
+            0.0
+        };
+
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
-        let line_bottom = Vector2f::new(ecb_bottom.x, ecb_bottom.y - crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"));
+        let line_bottom = Vector2f::new(ecb_bottom.x, shift + ecb_bottom.y - crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"));
         let mut out_pos = Vector2f::zero();
         let result = GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, ecb_bottom.y), &line_bottom, &Vector2f::zero(), &mut out_pos, true);
         if result != 0 { // pretty sure it returns a pointer, at least it defo returns a non-0 value if success

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -711,7 +711,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
         let line_bottom = Vector2f::new(ecb_bottom.x, shift + ecb_bottom.y - crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"));
         let mut out_pos = Vector2f::zero();
-        let result = GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, ecb_bottom.y), &line_bottom, &Vector2f::zero(), &mut out_pos, true);
+        let result = GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, shift + ecb_bottom.y), &line_bottom, &Vector2f::zero(), &mut out_pos, true);
         if result != 0 { // pretty sure it returns a pointer, at least it defo returns a non-0 value if success
             let pos = PostureModule::pos(self);
             PostureModule::set_pos(self, &Vector3f::new((*pos).x, out_pos.y + 0.01, (*pos).z));

--- a/fighters/bayonetta/src/lib.rs
+++ b/fighters/bayonetta/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/brave/src/lib.rs
+++ b/fighters/brave/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 use smash::{
     lib::{

--- a/fighters/buddy/src/lib.rs
+++ b/fighters/buddy/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/captain/src/lib.rs
+++ b/fighters/captain/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 // use ::common::prelude::*;
 
 pub mod acmd;

--- a/fighters/chrom/src/lib.rs
+++ b/fighters/chrom/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/cloud/src/lib.rs
+++ b/fighters/cloud/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -261,6 +261,9 @@ unsafe extern "C" fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, arg: L2
         if fighter.handle_waveland(true, true) {
             return 1.into();
         }
+        if VarModule::countdown_int(fighter.battle_object, vars::common::AIR_ESCAPE_MAGNET_FRAME, 0) {
+            VarModule::on_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET);
+        }
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_INT_SLIDE_FRAME);
         // if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_AIR_LASSO) {

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -261,9 +261,6 @@ unsafe extern "C" fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, arg: L2
         if fighter.handle_waveland(true, true) {
             return 1.into();
         }
-        if VarModule::countdown_int(fighter.battle_object, vars::common::AIR_ESCAPE_MAGNET_FRAME, 0) {
-            VarModule::on_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET);
-        }
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_INT_SLIDE_FRAME);
         // if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_AIR_LASSO) {

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -37,7 +37,7 @@ unsafe fn status_pre_EscapeAir(fighter: &mut L2CFighterCommon) -> L2CValue {
         VarModule::off_flag(fighter.battle_object, vars::common::PERFECT_WAVEDASH);
         return 0.into();
     }
-    if fighter.handle_waveland(false) {
+    if fighter.handle_waveland(true, false) {
         if (fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_DAMAGE_FALL || fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_DAMAGE_FLY) {
             if app::FighterUtil::is_touch_passive_ground(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32)
             && passive_fb_value <= stick_x.abs() {
@@ -258,7 +258,7 @@ unsafe fn sub_escape_air_waveland_check(fighter: &mut L2CFighterCommon) {
 #[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon19sub_escape_air_uniqEN3lib8L2CValueE")]
 unsafe extern "C" fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, arg: L2CValue) -> L2CValue {
     if arg.get_bool() {
-        if fighter.handle_waveland(true) {
+        if fighter.handle_waveland(true, true) {
             return 1.into();
         }
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
@@ -486,7 +486,7 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     let stick_x = fighter.global_table[STICK_X].get_f32();
     let passive_fb_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value"));
     // lazy eval gaurantees that we don't call handle_waveland if we are on the ground
-    if situation_kind == *SITUATION_KIND_GROUND || fighter.handle_waveland(false) {
+    if situation_kind == *SITUATION_KIND_GROUND || fighter.handle_waveland(true, false) {
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND) {
             if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE_FB)
                 && app::FighterUtil::is_touch_passive_ground(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32)

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -282,7 +282,9 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
             if VarModule::is_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_JUMPSQUAT) {
                 // check if we are doing directional airdodge
                 let stick = app::sv_math::vec2_length(fighter.global_table[STICK_X].get_f32(), fighter.global_table[STICK_Y].get_f32());
-                if stick >= WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick")) {
+                if stick >= WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"))
+                    && fighter.stick_y() <= 0.0
+                {
                     VarModule::on_flag(fighter.battle_object, vars::common::PERFECT_WAVEDASH);
                     // change kinetic/ground properties for wavedash
                     GroundModule::correct(fighter.module_accessor, app::GroundCorrectKind(*GROUND_CORRECT_KIND_NONE));

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -283,7 +283,7 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
                 // check if we are doing directional airdodge
                 let stick = app::sv_math::vec2_length(fighter.global_table[STICK_X].get_f32(), fighter.global_table[STICK_Y].get_f32());
                 if stick >= WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"))
-                    && fighter.stick_y() <= 0.0
+                    && fighter.global_table[STICK_Y].get_f32() <= 0.0
                 {
                     VarModule::on_flag(fighter.battle_object, vars::common::PERFECT_WAVEDASH);
                     // change kinetic/ground properties for wavedash

--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(asm)]
+#![deny(deprecated)]
 #![allow(unused)]
 #![allow(non_snake_case)]
 use smash::app::lua_bind::*;

--- a/fighters/daisy/src/lib.rs
+++ b/fighters/daisy/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/dedede/src/lib.rs
+++ b/fighters/dedede/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/demon/src/lib.rs
+++ b/fighters/demon/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/diddy/src/lib.rs
+++ b/fighters/diddy/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/dolly/src/lib.rs
+++ b/fighters/dolly/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/donkey/src/lib.rs
+++ b/fighters/donkey/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/duckhunt/src/lib.rs
+++ b/fighters/duckhunt/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/edge/src/lib.rs
+++ b/fighters/edge/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/eflame/src/lib.rs
+++ b/fighters/eflame/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/elight/src/lib.rs
+++ b/fighters/elight/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/falco/src/lib.rs
+++ b/fighters/falco/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/fox/src/lib.rs
+++ b/fighters/fox/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/gamewatch/src/lib.rs
+++ b/fighters/gamewatch/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ganon/src/lib.rs
+++ b/fighters/ganon/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/gaogaen/src/lib.rs
+++ b/fighters/gaogaen/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/gekkouga/src/lib.rs
+++ b/fighters/gekkouga/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ike/src/lib.rs
+++ b/fighters/ike/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/inkling/src/lib.rs
+++ b/fighters/inkling/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/jack/src/lib.rs
+++ b/fighters/jack/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/kamui/src/lib.rs
+++ b/fighters/kamui/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ken/src/lib.rs
+++ b/fighters/ken/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/kirby/src/lib.rs
+++ b/fighters/kirby/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/koopa/src/lib.rs
+++ b/fighters/koopa/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/koopag/src/lib.rs
+++ b/fighters/koopag/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 // pub mod acmd;
 

--- a/fighters/koopajr/src/lib.rs
+++ b/fighters/koopajr/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/koopajr/src/status.rs
+++ b/fighters/koopajr/src/status.rs
@@ -224,19 +224,8 @@ unsafe extern "C" fn sub_escape_air_common_main(fighter: &mut L2CFighterCommon) 
         if sub_escape_air_common_strans_main(fighter).get_bool() {
             return L2CValue::Bool(true);
         }
-        if VarModule::is_flag(fighter.battle_object, vars::common::SHOULD_WAVELAND) {
-            // VarModule::off_flag(fighter.battle_object, vars::common::SHOULD_WAVELAND);
-            // GroundModule::attach_ground(fighter.module_accessor, false);
-            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING);
-            force_ground_attach(fighter);
-            fighter.change_status(FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING.into(), false.into());
-            VarModule::off_flag(fighter.battle_object, vars::common::SHOULD_WAVELAND);
+        if fighter.handle_waveland(true) {
             return true.into();
-            // fighter.change_status(
-            //     L2CValue::I32(*FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING),
-            //     L2CValue::Bool(false)
-            // );
-            // return true.into();
         }
         if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING) {
             fighter.change_status(

--- a/fighters/koopajr/src/status.rs
+++ b/fighters/koopajr/src/status.rs
@@ -103,32 +103,11 @@ unsafe fn force_ground_attach(fighter: &mut L2CFighterCommon) {
     }
 }
 
-unsafe fn sub_escape_air_waveland_check(fighter: &mut L2CFighterCommon) {
-    let id = VarModule::get_int(fighter.battle_object, vars::common::COSTUME_SLOT_NUMBER) as usize;
-    if VarModule::is_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET) {
-        let mut fighter_pos = Vector3f {
-            x: PostureModule::pos_x(fighter.module_accessor),
-            y: PostureModule::pos_y(fighter.module_accessor),
-            z: PostureModule::pos_z(fighter.module_accessor),
-        };
-        let mut threshold = ParamModule::get_float(fighter.object(), ParamType::Common, "waveland_distance_threshold");
-        fighter_pos.y += VarModule::get_float(fighter.object(), vars::common::ECB_Y_OFFSETS);
-        VarModule::set_float(fighter.battle_object, vars::common::Y_POS, fighter_pos.y);
-        VarModule::set_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR, GroundModule::get_distance_to_floor(fighter.module_accessor, &fighter_pos, fighter_pos.y, true));
-        let dist = VarModule::get_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR);
-        //println!("dist: {}", dist);
-        if 0.0 <= dist && dist <= threshold {
-            //println!("should_waveland");
-            fighter_pos.y -= dist;
-            PostureModule::set_pos(fighter.module_accessor, &fighter_pos);
-            VarModule::on_flag(fighter.battle_object, vars::common::SHOULD_WAVELAND);
-        }
-    }
-}
-
 unsafe extern "C" fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, arg: L2CValue) -> L2CValue {
     if arg.get_bool() {
-        sub_escape_air_waveland_check(fighter);
+        if fighter.handle_waveland(false, true) {
+            return 1.into();
+        }
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_INT_SLIDE_FRAME);
         // if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_AIR_LASSO) {
@@ -224,7 +203,7 @@ unsafe extern "C" fn sub_escape_air_common_main(fighter: &mut L2CFighterCommon) 
         if sub_escape_air_common_strans_main(fighter).get_bool() {
             return L2CValue::Bool(true);
         }
-        if fighter.handle_waveland(true) {
+        if fighter.handle_waveland(false, true) {
             return true.into();
         }
         if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING) {

--- a/fighters/krool/src/lib.rs
+++ b/fighters/krool/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/link/src/lib.rs
+++ b/fighters/link/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/littlemac/src/lib.rs
+++ b/fighters/littlemac/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/lucario/src/lib.rs
+++ b/fighters/lucario/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/lucas/src/lib.rs
+++ b/fighters/lucas/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/lucina/src/lib.rs
+++ b/fighters/lucina/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/luigi/src/lib.rs
+++ b/fighters/luigi/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/mario/src/lib.rs
+++ b/fighters/mario/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/mariod/src/lib.rs
+++ b/fighters/mariod/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/marth/src/lib.rs
+++ b/fighters/marth/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/master/src/lib.rs
+++ b/fighters/master/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/metaknight/src/lib.rs
+++ b/fighters/metaknight/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/mewtwo/src/lib.rs
+++ b/fighters/mewtwo/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/miifighter/src/lib.rs
+++ b/fighters/miifighter/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/miigunner/src/lib.rs
+++ b/fighters/miigunner/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/miiswordsman/src/lib.rs
+++ b/fighters/miiswordsman/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/murabito/src/lib.rs
+++ b/fighters/murabito/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/nana/src/lib.rs
+++ b/fighters/nana/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ness/src/lib.rs
+++ b/fighters/ness/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/packun/src/lib.rs
+++ b/fighters/packun/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pacman/src/lib.rs
+++ b/fighters/pacman/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/palutena/src/lib.rs
+++ b/fighters/palutena/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/peach/src/lib.rs
+++ b/fighters/peach/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pfushigisou/src/lib.rs
+++ b/fighters/pfushigisou/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pichu/src/lib.rs
+++ b/fighters/pichu/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pickel/src/lib.rs
+++ b/fighters/pickel/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pikachu/src/lib.rs
+++ b/fighters/pikachu/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pikmin/src/lib.rs
+++ b/fighters/pikmin/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pit/src/lib.rs
+++ b/fighters/pit/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pitb/src/lib.rs
+++ b/fighters/pitb/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/plizardon/src/lib.rs
+++ b/fighters/plizardon/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/popo/src/lib.rs
+++ b/fighters/popo/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/purin/src/lib.rs
+++ b/fighters/purin/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/pzenigame/src/lib.rs
+++ b/fighters/pzenigame/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/richter/src/lib.rs
+++ b/fighters/richter/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ridley/src/lib.rs
+++ b/fighters/ridley/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/robin/src/lib.rs
+++ b/fighters/robin/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/robot/src/lib.rs
+++ b/fighters/robot/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/rockman/src/lib.rs
+++ b/fighters/rockman/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/rosetta/src/lib.rs
+++ b/fighters/rosetta/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/roy/src/lib.rs
+++ b/fighters/roy/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/ryu/src/lib.rs
+++ b/fighters/ryu/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/samus/src/lib.rs
+++ b/fighters/samus/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/samusd/src/lib.rs
+++ b/fighters/samusd/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/sheik/src/lib.rs
+++ b/fighters/sheik/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/shizue/src/lib.rs
+++ b/fighters/shizue/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/shulk/src/lib.rs
+++ b/fighters/shulk/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/simon/src/lib.rs
+++ b/fighters/simon/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/snake/src/lib.rs
+++ b/fighters/snake/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/sonic/src/lib.rs
+++ b/fighters/sonic/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/szerosuit/src/lib.rs
+++ b/fighters/szerosuit/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/tantan/src/lib.rs
+++ b/fighters/tantan/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/toonlink/src/lib.rs
+++ b/fighters/toonlink/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/trail/src/lib.rs
+++ b/fighters/trail/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/wario/src/lib.rs
+++ b/fighters/wario/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/wiifit/src/lib.rs
+++ b/fighters/wiifit/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/wolf/src/lib.rs
+++ b/fighters/wolf/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/yoshi/src/lib.rs
+++ b/fighters/yoshi/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/younglink/src/lib.rs
+++ b/fighters/younglink/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/fighters/zelda/src/lib.rs
+++ b/fighters/zelda/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]
 
 pub mod acmd;
 

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,4 +1,7 @@
-#![feature(asm)]#![allow(unused)]#![allow(non_snake_case)]#![allow(unused_imports)]#![allow(unused_variables)]
+#![feature(asm)]
+#![deny(deprecated)]
+#![allow(unused)]
+#![allow(non_snake_case)]#![allow(unused_imports)]#![allow(unused_variables)]
 #![feature(proc_macro_hygiene)]
 
 use skyline::libc::c_char;

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -17,17 +17,23 @@ development_subpath = "smashline/"
 ryujinx_rom_path = "mods/contents/01006a800016e000/skyline/romfs"
 switch_rom_path = "atmosphere/contents/01006a800016e000/romfs"
 
-def install_with_ip(ip: str):
+def install_with_ip(ip: str, is_dev: bool):
   plugin_subpath = "skyline/plugins/"
   development_subpath = "smashline/"
   switch_rom_path = "atmosphere/contents/01006a800016e000/romfs"
 
   if os.name == 'nt':
-    os.system('curl.exe -T ..\\plugin\\target\\standalone\\aarch64-skyline-switch\\release\\libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
-    os.system('curl.exe -T ..\\plugin\\target\\development\\aarch64-skyline-switch\\release\\libhdr.nro ftp://' + ip + ':5000/' + switch_rom_path + '/' + development_subpath + 'development.nro')
+    if not is_dev:
+      os.system('curl.exe -T ..\\plugin\\target\\aarch64-skyline-switch\\release\\libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
+    else:
+      os.system('curl.exe -T ..\\plugin\\target\\standalone\\aarch64-skyline-switch\\release\\libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
+      os.system('curl.exe -T ..\\plugin\\target\\development\\aarch64-skyline-switch\\release\\libhdr.nro ftp://' + ip + ':5000/' + switch_rom_path + '/' + development_subpath + 'development.nro')
   else:
-    os.system('curl -T ../plugin/target/standalone/aarch64-skyline-switch/release/libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
-    os.system('curl -T ../plugin/target/development/aarch64-skyline-switch/release/libhdr.nro ftp://' + ip + ':5000/' + switch_rom_path + '/' + development_subpath + 'development.nro')
+    if not is_dev:
+      os.system('curl -T ../plugin/target/aarch64-skyline-switch/release/libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
+    else:
+      os.system('curl -T ../plugin/target/standalone/aarch64-skyline-switch/release/libhdr.nro ftp://' + ip + ':5000/ultimate/mods/hdr-dev/plugin.nro')
+      os.system('curl -T ../plugin/target/development/aarch64-skyline-switch/release/libhdr.nro ftp://' + ip + ':5000/' + switch_rom_path + '/' + development_subpath + 'development.nro')
 
 # handle fallback exe on windows
 def handle_fallback():
@@ -214,11 +220,38 @@ if (is_dev_build and not is_publish):
 
 
 else:
-  # simple build
   if is_publish:
-    pkgutil.build(release_arg, "--features=\"updater\",\"main_nro\",\"add_status\"")
+    feature_list = "--features=\"update\",\"main_nro\",\"add_status\""
   else:
-    pkgutil.build(release_arg, "--features=\"main_nro\",\"add_status\"")
+    feature_list = "--features=\"main_nro\",\"add_status\""
+
+  is_only = False
+
+  for arg in sys.argv:
+    if not "only" in arg:
+      continue
+
+    if not "=" in arg:
+      print("only specified, but no character arguments given!\n please use 'dev=mario,luigi,samus' format")
+      break
+
+    is_only = True
+
+    char_list = (arg.split('=')[1]).split(",")
+
+    for char in char_list:
+      if char not in characters:
+        print("fighter " + char + " does not exist! (are you using the ingame name for the character?) Valid names are:\n")
+        for char_ok in characters:
+          print(char_ok)
+        exit()
+      feature_list += ",\"" + char + "\""
+
+  # simple build
+  if is_only:
+    pkgutil.build(release_arg, "--no-default-features " + feature_list)
+  else:
+    pkgutil.build(release_arg, feature_list)
 
   # collect switch package
   pkgutil.collect_plugin("hdr-switch", 
@@ -244,5 +277,5 @@ for arg in sys.argv:
     if not "=" in arg:
       print("ip specified but not ip argument given!")
       break
-    install_with_ip(arg.split('=')[1])
+    install_with_ip(arg.split('=')[1], is_dev_build)
     break


### PR DESCRIPTION
1. Deprecated the old waveland check code in favor of `handle_waveland` in the `BomaExt` trait (so it can be reused elsewhere with ease.
2. Modified the waveland code to *not* loop while setting your position lower and lower, which at points in the past would cause infinite loops/hangs.
    - It now is a singular line-segment test down by the units specified by the waveland threshold in `fighter/common/hdr/fighter_param.xml`
    - It uses the bottom of the ECB rhombus instead of `PostureModule::pos`, which should be more accurate/meaningful positioning to base waveland detection on
    - Uses the actual ground collision instead of whatever the "floor" is considered

Resolves #515 