### PR TITLE
Revert long jab lock animation KB threshold to vanilla

### DIFF
--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -6,7 +6,6 @@
   <float hash="damage_level3">40.5</float>
   <float hash="damage_speed_mul">0.03</float>
   <float hash="damage_angle_ground_max">44</float>
-  <float hash="down_damage_s_reaction">999</float>
   <float hash="damage_fly_quake_l">90</float>
   <int hash="damage_fly_speed_up_reaction_frame_min">998</int>
   <int hash="damage_fly_speed_up_reaction_frame_max">999</int>


### PR DESCRIPTION
Resolves #530 .

Pushes the long jab lock threshold down from 999 units of KB to 15 like in vanilla (commit name on original branch is inaccurate).