### PR TITLE
Ness - PM PK Rocket behavior

### DIFF
--- a/fighters/common/src/function_hooks/ledges.rs
+++ b/fighters/common/src/function_hooks/ledges.rs
@@ -219,12 +219,15 @@ unsafe fn check_cliff_entry_specializer(boma: &mut BattleObjectModuleAccessor) -
 
     if fighter_kind == *FIGHTER_KIND_NESS {
         if status_kind == *FIGHTER_NESS_STATUS_KIND_SPECIAL_HI_ATTACK {
+            /*
             if frame > 5.0 && frame < 15.0 {
                 return 1;
             }
             else{
                 return -1;
             }
+            */
+            return 1;
         }
     }
 

--- a/fighters/ness/src/status.rs
+++ b/fighters/ness/src/status.rs
@@ -5,7 +5,8 @@ utils::import!(common::djc::attack_air_main_status);
  
 pub fn install() {
     install_status_scripts!(
-        attack_air
+        attack_air,
+        special_hi_attack
     );
 }
 
@@ -14,4 +15,54 @@ pub fn install() {
 #[status_script(agent = "ness", status = FIGHTER_STATUS_KIND_ATTACK_AIR, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 pub unsafe fn attack_air(fighter: &mut L2CFighterCommon) -> L2CValue {
     common::djc::attack_air_main_status(fighter)
+}
+
+// FIGHTER_NESS_STATUS_KIND_SPECIAL_HI_ATTACK //
+
+#[status_script(agent = "ness", status = FIGHTER_NESS_STATUS_KIND_SPECIAL_HI_ATTACK, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn special_hi_attack(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_air_hi"), 0.0, 1.0, false, 0.0, false, false);
+    if !StopModule::is_stop(fighter.module_accessor) {
+        sub_special_hi_attack(fighter);
+    }
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(sub_special_hi_attack as *const () as _));
+    fighter.main_shift(special_hi_attack_main)
+}
+
+unsafe extern "C" fn sub_special_hi_attack(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // this does...something?
+    if !fighter.is_flag(*FIGHTER_NESS_STATUS_SPECIAL_HI_FLAG_ATTACK_FALL_START) {
+        KineticModule::unable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    }
+    else {
+        if fighter.is_situation(*SITUATION_KIND_AIR) {
+            KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+        }
+        else {
+            KineticModule::unable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+        }
+    }
+    if AttackModule::is_infliction(fighter.module_accessor, *COLLISION_KIND_MASK_ALL) {
+        AttackModule::clear_inflict_kind_status(fighter.module_accessor);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_hi_attack_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+    if !MotionModule::is_end(fighter.module_accessor) {
+        if fighter.is_flag(*FIGHTER_NESS_STATUS_SPECIAL_HI_FLAG_LANDING_ENABLE) && fighter.is_situation(*SITUATION_KIND_GROUND) {
+            fighter.change_status(FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL.into(), false.into());
+            return 1.into();
+        }
+        // [insert stubbed redirection/bonk function here]
+        // LOL good riddance fucker
+        0.into()
+    }
+    else {
+        fighter.change_status(FIGHTER_NESS_STATUS_KIND_SPECIAL_HI_END.into(), false.into());
+        1.into()
+    }
 }


### PR DESCRIPTION
No more janky wallrides! No more bonking!

PK Rocket will now *stay* in its initial travel angle for the entire duration of the move, even if making contact with a wall.
Functions similarly to Fire Fox, for example.

https://user-images.githubusercontent.com/47401664/169105804-609c2177-cf6e-43fb-9d25-52646c328ddf.mp4

Resolves #441 
Resolves #445 