### PR TITLE
Decrease jostle overlap rate 0.66 -> 0.3, remove vanilla jostle during standing/dashgrabs

### DIFF
--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -77,11 +77,6 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
         // Walk through other fighters
         JostleModule::set_team(boma, 0);
 
-        // Vanilla jostle during standing and dash grabs
-        if [*FIGHTER_STATUS_KIND_CATCH, *FIGHTER_STATUS_KIND_CATCH_DASH].contains(&status_kind) {
-            JostleModule::set_team(boma, 1);
-        }
-
         // clear platform drop input when entering airdodge (to avoid buffering waveland platdrop with the same down input as the actual waveland)
         if [*FIGHTER_STATUS_KIND_ESCAPE_AIR, *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE, *FIGHTER_STATUS_KIND_JUMP_SQUAT].contains(&status_kind) {
             VarModule::off_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP);

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -30,7 +30,7 @@
   <float hash="0x16f170b6e2">0.37</float>
   <float hash="0x16ad11d8d5">0.4</float>
   <float hash="0x16911ce78c">0.875</float>
-  <float hash="jostle_team_overlap_rate">0.66</float>
+  <float hash="jostle_team_overlap_rate">0.3</float>
   <float hash="damage_angle_air">0.785398</float>
   <float hash="fly_top_angle_lw">0.785398</float>
   <float hash="fly_top_angle_hi">2.35619</float>


### PR DESCRIPTION
Resolves #594 .