### PR TITLE
Reduce dash smash attack window from 6f to 2f

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -17,6 +17,7 @@
   <float hash="shield_recovery1">0.07</float>
   <float hash="shield_damage_mul">1.4</float>
   <float hash="shield_setoff_mul">0.55</float>
+  <float hash="dash_s4_frame">2</float>
   <float hash="shield_setoff_mul_fighter_shot">0.5156</float>
   <float hash="shield_stiff_mul_attack_4">1</float>
   <float hash="shield_stiff_mul_attack_air">1</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -2,6 +2,7 @@
 <struct>
   <int hash="precede">5</int>
   <int hash="precede_extension">0</int>
+  <float hash="dash_s4_frame">2</float>
   <int hash="dash_speed_keep_frame">1</int>
   <float hash="dash_escape_frame">1</float>
   <int hash="turn_dash_frame">-1</int>
@@ -17,7 +18,6 @@
   <float hash="shield_recovery1">0.07</float>
   <float hash="shield_damage_mul">1.4</float>
   <float hash="shield_setoff_mul">0.55</float>
-  <float hash="dash_s4_frame">2</float>
   <float hash="shield_setoff_mul_fighter_shot">0.5156</float>
   <float hash="shield_stiff_mul_attack_4">1</float>
   <float hash="shield_stiff_mul_attack_air">1</float>


### PR DESCRIPTION
Reduces the 6f window at the start of a dash where an a input will become a smash attack to 2f 