### PR TITLE
Pivot adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -139,6 +139,7 @@ pub mod vars {
         pub const JUMP_NEXT: i32 = 82;
         pub const IS_JAB_LOCK_ROLL: i32 = 83;
         pub const SHOULD_TRUMP_TETHER: i32 = 84;
+        pub const CAN_PERFECT_PIVOT: i32 = 85;
         
 
         // int

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -506,6 +506,12 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
     && (!ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) || ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON))  // AND cstick is off, other than the first frame of its input
     && is_backdash_input {  // AND is a backdash input
         //println!("transition to backdash");
+        if fighter.global_table[CURRENT_FRAME].get_i32() <= 2 {
+            VarModule::on_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);
+        }
+        else {
+            VarModule::off_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);
+        }
         VarModule::on_flag(fighter.battle_object, vars::common::IS_SMASH_TURN);
         interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
     }
@@ -562,9 +568,6 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
         VarModule::on_flag(fighter.battle_object, vars::common::IS_LATE_PIVOT);
         PostureModule::reverse_lr(fighter.module_accessor);
         PostureModule::update_rot_y_lr(fighter.module_accessor);
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL);
-        app::sv_kinetic_energy::unable(fighter.lua_state_agent);
         interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
     }
 
@@ -671,6 +674,10 @@ unsafe fn status_end_dash(fighter: &mut L2CFighterCommon) -> L2CValue {
 	if StatusModule::status_kind_next(fighter.module_accessor) != *FIGHTER_STATUS_KIND_RUN {
 		VarModule::off_flag(fighter.battle_object, vars::common::ENABLE_BOOST_RUN);
 	}
+    if StatusModule::status_kind_next(fighter.module_accessor) != *FIGHTER_STATUS_KIND_TURN {
+        println!("can pp off");
+        VarModule::off_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);
+    }
 	
 	VarModule::set_float(fighter.battle_object, vars::common::CURR_DASH_SPEED, initial_speed);
 

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -675,7 +675,6 @@ unsafe fn status_end_dash(fighter: &mut L2CFighterCommon) -> L2CValue {
 		VarModule::off_flag(fighter.battle_object, vars::common::ENABLE_BOOST_RUN);
 	}
     if StatusModule::status_kind_next(fighter.module_accessor) != *FIGHTER_STATUS_KIND_TURN {
-        println!("can pp off");
         VarModule::off_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);
     }
 	

--- a/fighters/common/src/general_statuses/turn.rs
+++ b/fighters/common/src/general_statuses/turn.rs
@@ -96,8 +96,8 @@ unsafe extern "C" fn status_turn_main(fighter: &mut L2CFighterCommon) -> L2CValu
         && stick_x * -1.0 * turn_work_lr < dash_stick_x  // if left stick is below dash threshold
         && VarModule::is_flag(fighter.battle_object, vars::common::IS_SMASH_TURN)  // AND you are currently in a smash turn
         && StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_DASH  // AND your previous status was a dash (not turn)
-        && MotionModule::frame(fighter.module_accessor) <= 1.0
-        && VarModule::is_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT) {  // AND you are on frame 0 or frame 1 of your smash turn
+        && MotionModule::frame(fighter.module_accessor) <= 1.0  // AND you are on frame 0 or frame 1 of your smash turn
+        && VarModule::is_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT) {  // AND you input smash turn within dash's perfect pivot window
             // perfect pivot
             VarModule::off_flag(fighter.battle_object, vars::common::IS_SMASH_TURN);
             VarModule::off_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);

--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -205,6 +205,14 @@ unsafe fn grab_jump_refresh(boma: &mut BattleObjectModuleAccessor) {
 
 unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_DASH) {
+        let run_accel_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("run_accel_add"), 0);
+        let run_accel_add = WorkModule::get_param_float(fighter.module_accessor, hash40("run_accel_mul"), 0);
+        let ground_brake = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
+        let dash_speed: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("dash_speed"), 0);
+        let run_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("run_speed_max"), 0);
+        let dash_stick_x: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dash_stick_x"));
+        let stick_x = fighter.global_table[STICK_X].get_f32();
+
         let bidou_buttons = &[
         Buttons::Attack,
         Buttons::AttackRaw,
@@ -225,23 +233,34 @@ unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
             VarModule::on_flag(fighter.battle_object, vars::common::DISABLE_BACKDASH);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
         }
-        if fighter.global_table[STICK_X].get_f32() == 0.0 {
+        if stick_x == 0.0 {
             // if you return stick to neutral after a cstick dash, allow dashbacks again
             VarModule::off_flag(fighter.battle_object, vars::common::DISABLE_BACKDASH);
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
         }
 
-        let is_dash_input: bool = (fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0) || (enable_bidou && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) && fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor) > 0.6);  // we register a dash input by 1. Using game's command cat dash check, or 2. Checking if cstick has been input and is > 0.6 (max cstick x value is 0.625)
-        let is_backdash_input: bool = (fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0) || (enable_bidou && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) && fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor) < -0.6);
+        // initial dash energy
+        if fighter.global_table[CURRENT_FRAME].get_i32() == 0 && stick_x.abs() >= dash_stick_x {
+            // apply speed on f1 of dash (takes effect on f2 ingame)
+            let prev_speed = VarModule::get_float(fighter.battle_object, vars::common::CURR_DASH_SPEED);
+            let applied_speed = (dash_speed * PostureModule::lr(fighter.module_accessor)) + (stick_x.signum() * ((run_accel_mul + (run_accel_add * stick_x.abs())))) + prev_speed;  // initial dash speed + 1f of run acceleration + previous status' last speed
+            //println!("Changing current dash speed: {}", applied_speed);
+            let applied_speed_clamped = applied_speed.clamp(-run_speed_max, run_speed_max);
+            fighter.clear_lua_stack();
+            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, applied_speed_clamped);
+            app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+        }
+
+        // dash -> redash/backdash energy
+        let is_dash_input: bool = (fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0) || (enable_bidou && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) && stick_x * PostureModule::lr(fighter.module_accessor) > 0.6);  // we register a dash input by 1. Using game's command cat dash check, or 2. Checking if cstick has been input and is > 0.6 (max cstick x value is 0.625)
+        let is_backdash_input: bool = (fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0) || (enable_bidou && ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) && stick_x * PostureModule::lr(fighter.module_accessor) < -0.6);
 
         if (WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH)
         && (!ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) || ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON))
         && is_backdash_input)  // if valid backdash input
         || (WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("re_dash_frame")) as f32 <= MotionModule::frame(fighter.module_accessor)  // if current frame is after redash frame
         && is_dash_input) {  // OR valid re-dash input
-            let ground_brake = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
             let mut initial_speed = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN);
-            let run_speed_max = WorkModule::get_param_float(fighter.module_accessor, hash40("run_speed_max"), 0);
 
             let mut applied_speed = (initial_speed * 0.25) - (ground_brake * PostureModule::lr(fighter.module_accessor));  // Only retain a fraction of your momentum into a re-dash or backdash; makes for snappy dash dancing (Melee functionality)
             if (is_dash_input && VarModule::is_flag(fighter.battle_object, vars::common::IS_MOONWALK) && FighterMotionModuleImpl::is_valid_cancel_frame(fighter.module_accessor, -1, true)) || fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_JUMP_BUTTON != 0 {  // if the jump button is held, retain full momentum into next status

--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -239,13 +239,12 @@ unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
         }
 
-        // initial dash energy
         if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
             if stick_x.abs() >= dash_stick_x {
-                // apply speed on f2 of dash (CURRENT_FRAME counter hasn't updated yet)
+                // apply initial dash energy on f2 of dash (CURRENT_FRAME counter hasn't updated yet)
                 let prev_speed = VarModule::get_float(fighter.battle_object, vars::common::CURR_DASH_SPEED);
                 let applied_speed = (dash_speed * PostureModule::lr(fighter.module_accessor)) + (stick_x.signum() * ((run_accel_mul + (run_accel_add * stick_x.abs())))) + prev_speed;  // initial dash speed + 1f of run acceleration + previous status' last speed
-                println!("Changing current dash speed: {}", applied_speed);
+                //println!("Changing current dash speed: {}", applied_speed);
                 let applied_speed_clamped = applied_speed.clamp(-run_speed_max, run_speed_max);
                 fighter.clear_lua_stack();
                 lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, applied_speed_clamped);
@@ -254,6 +253,7 @@ unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
             else if StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_TURN 
             && StatusModule::prev_status_kind(fighter.module_accessor, 1) == *FIGHTER_STATUS_KIND_DASH  // if you are in a backdash
             && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+                // apply late (F3) pivot energy
                 KineticModule::clear_speed_all(fighter.module_accessor);
                 if VarModule::is_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT) {
                     VarModule::off_flag(fighter.battle_object, vars::common::CAN_PERFECT_PIVOT);


### PR DESCRIPTION
- Reinstated late (f3) pivots
- Perfect (sliding) pivots are now only possible when pivot is input within the first 2 frames of dash (identical window as Sm4sh)
- Pivots input after frame 2 of dash are now Melee-style (no slide)


https://user-images.githubusercontent.com/47401664/171768980-d52e21ca-a45e-4619-8b15-dd275d3f1a0d.mp4

Resolves #531 

