### PR TITLE
Rework aerial glide tossing (airdodge cancelled item throws)

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -139,7 +139,6 @@ pub mod vars {
         pub const JUMP_NEXT: i32 = 82;
         pub const IS_JAB_LOCK_ROLL: i32 = 83;
         pub const SHOULD_TRUMP_TETHER: i32 = 84;
-        pub const AGT_USED: i32 = 85;
         
 
         // int
@@ -156,6 +155,7 @@ pub mod vars {
         pub const TURN_DASH_FRAME: i32 = 0xA;
         pub const DOWN_STAND_FB_KIND: i32 = 0xB;
         pub const CSTICK_LIFE: i32 = 0xC;
+        pub const AGT_USED_COUNTER: i32 = 0xD;
 
         // float
         pub const LAST_ATTACK_DAMAGE_DEALT: i32 = 0x0;

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -139,6 +139,7 @@ pub mod vars {
         pub const JUMP_NEXT: i32 = 82;
         pub const IS_JAB_LOCK_ROLL: i32 = 83;
         pub const SHOULD_TRUMP_TETHER: i32 = 84;
+        pub const AGT_USED: i32 = 85;
         
 
         // int

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -470,6 +470,8 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
                 );
                 let staling_mul = (1.0 - 0.1 * (VarModule::get_int(fighter.object(), vars::common::AGT_USED_COUNTER) as f32)).max(0.0);
                 KineticModule::mul_speed(fighter.module_accessor, &Vector3f{x: staling_mul, y: staling_mul, z: staling_mul}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+                WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
+                VarModule::inc_int(fighter.object(), vars::common::AGT_USED_COUNTER);
                 return 1.into();
         }
     }

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -458,8 +458,7 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW)
         && pad & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
         && ItemModule::is_have_item(fighter.module_accessor, 0)
-        && curr_frame <= 3
-        && VarModule::is_flag(fighter.battle_object, vars::common::AGT_USED) {
+        && curr_frame <= 3 {
             fighter.clear_lua_stack();
             lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_NO_THROW);
             smash::app::sv_module_access::item(fighter.lua_state_agent);
@@ -469,6 +468,8 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
                     L2CValue::I32(*FIGHTER_STATUS_KIND_ITEM_THROW),
                     L2CValue::Bool(false)
                 );
+                let mut staling_mul = (1.0 - 0.1 * (VarModule::get_int(fighter.object(), vars::common::AGT_USED_COUNTER) as f32)).max(0.0);
+                KineticModule::mul_speed(fighter.module_accessor, &Vector3f{x: staling_mul, y: staling_mul, z: staling_mul}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
                 return 1.into();
         }
     }

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -457,7 +457,8 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     let pad = fighter.global_table[PAD_FLAG].get_i32();
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW)
         && pad & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
-        && ItemModule::is_have_item(fighter.module_accessor, 0) {
+        && ItemModule::is_have_item(fighter.module_accessor, 0)
+        && curr_frame <= 3 {
             fighter.clear_lua_stack();
             lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_NO_THROW);
             smash::app::sv_module_access::item(fighter.lua_state_agent);

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -468,7 +468,7 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
                     L2CValue::I32(*FIGHTER_STATUS_KIND_ITEM_THROW),
                     L2CValue::Bool(false)
                 );
-                let mut staling_mul = (1.0 - 0.1 * (VarModule::get_int(fighter.object(), vars::common::AGT_USED_COUNTER) as f32)).max(0.0);
+                let staling_mul = (1.0 - 0.1 * (VarModule::get_int(fighter.object(), vars::common::AGT_USED_COUNTER) as f32)).max(0.0);
                 KineticModule::mul_speed(fighter.module_accessor, &Vector3f{x: staling_mul, y: staling_mul, z: staling_mul}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
                 return 1.into();
         }

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -458,7 +458,8 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW)
         && pad & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
         && ItemModule::is_have_item(fighter.module_accessor, 0)
-        && curr_frame <= 3 {
+        && curr_frame <= 3
+        && VarModule::is_flag(fighter.battle_object, vars::common::AGT_USED) {
             fighter.clear_lua_stack();
             lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_NO_THROW);
             smash::app::sv_module_access::item(fighter.lua_state_agent);

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -395,15 +395,16 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
 
 // Aerial Glide Toss helper
 pub unsafe fn aerial_glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    // Keep airdodge if you AGT (cant AGT again until you land)
+    // Keep airdodge if you AGT
     if boma.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
-    && boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW) {
+    && boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW)
+    && MotionModule::frame(boma) == 1.0 {
         WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
-        VarModule::on_flag(boma.object(), vars::common::AGT_USED);
+        VarModule::inc_int(boma.object(), vars::common::AGT_USED_COUNTER);
     }
 
-    // Reset AGT used flag on landing/ledge/death
-    if VarModule::is_flag(boma.object(), vars::common::AGT_USED)
+    // Reset AGT used counter on landing/ledge/death
+    if VarModule::get_int(boma.object(), vars::common::AGT_USED_COUNTER) > 0
     && (!boma.is_situation(*SITUATION_KIND_AIR) ||
         boma.is_status_one_of(&[
             *FIGHTER_STATUS_KIND_DEAD,
@@ -412,7 +413,7 @@ pub unsafe fn aerial_glide_toss(fighter: &mut L2CFighterCommon, boma: &mut Battl
             *FIGHTER_STATUS_KIND_LOSE,
             *FIGHTER_STATUS_KIND_ENTRY
         ])) {
-        VarModule::off_flag(boma.object(), vars::common::AGT_USED);
+        VarModule::set_int(boma.object(), vars::common::AGT_USED_COUNTER, 0);
     }
 }
 

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -393,12 +393,26 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     }
 }
 
-// Aerial Glide Toss helper (keep airdodge if you AGT)
+// Aerial Glide Toss helper
 pub unsafe fn aerial_glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    
+    // Keep airdodge if you AGT (cant AGT again until you land)
     if boma.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
     && boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW) {
         WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
+        VarModule::on_flag(boma.object(), vars::common::AGT_USED);
+    }
+
+    // Reset AGT used flag on landing/ledge/death
+    if VarModule::is_flag(boma.object(), vars::common::AGT_USED)
+    && (!boma.is_situation(*SITUATION_KIND_AIR) ||
+        boma.is_status_one_of(&[
+            *FIGHTER_STATUS_KIND_DEAD,
+            *FIGHTER_STATUS_KIND_REBIRTH,
+            *FIGHTER_STATUS_KIND_WIN,
+            *FIGHTER_STATUS_KIND_LOSE,
+            *FIGHTER_STATUS_KIND_ENTRY
+        ])) {
+        VarModule::off_flag(boma.object(), vars::common::AGT_USED);
     }
 }
 

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -393,30 +393,6 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     }
 }
 
-// Aerial Glide Toss helper
-pub unsafe fn aerial_glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    // Keep airdodge if you AGT
-    if boma.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
-    && boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW)
-    && MotionModule::frame(boma) == 1.0 {
-        WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
-        VarModule::inc_int(boma.object(), vars::common::AGT_USED_COUNTER);
-    }
-
-    // Reset AGT used counter on landing/ledge/death
-    if VarModule::get_int(boma.object(), vars::common::AGT_USED_COUNTER) > 0
-    && (!boma.is_situation(*SITUATION_KIND_AIR) ||
-        boma.is_status_one_of(&[
-            *FIGHTER_STATUS_KIND_DEAD,
-            *FIGHTER_STATUS_KIND_REBIRTH,
-            *FIGHTER_STATUS_KIND_WIN,
-            *FIGHTER_STATUS_KIND_LOSE,
-            *FIGHTER_STATUS_KIND_ENTRY
-        ])) {
-        VarModule::set_int(boma.object(), vars::common::AGT_USED_COUNTER, 0);
-    }
-}
-
 #[utils::export(common::opff)]
 pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
@@ -448,7 +424,6 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     hitfall(boma, status_kind, situation_kind, fighter_kind, cat);
     respawn_taunt(boma, status_kind);
     teeter_cancel(fighter, boma);
-    aerial_glide_toss(fighter, boma);
 
     freeze_stages(boma);
 }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -393,6 +393,15 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     }
 }
 
+// Aerial Glide Toss helper (keep airdodge if you AGT)
+pub unsafe fn aerial_glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    
+    if boma.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+    && boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW) {
+        WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR);
+    }
+}
+
 #[utils::export(common::opff)]
 pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
     if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
@@ -424,6 +433,7 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     hitfall(boma, status_kind, situation_kind, fighter_kind, cat);
     respawn_taunt(boma, status_kind);
     teeter_cancel(fighter, boma);
+    aerial_glide_toss(fighter, boma);
 
     freeze_stages(boma);
 }

--- a/fighters/common/src/opff/var_resets.rs
+++ b/fighters/common/src/opff/var_resets.rs
@@ -9,29 +9,28 @@ use smash::app::lua_bind::*;
 use smash::lib::lua_const::*;
 use smash::hash40;
 
-const DAMAGE_STATUSES : &'static [i32] = &[*FIGHTER_STATUS_KIND_DEAD,
-                                            *FIGHTER_STATUS_KIND_REBIRTH,
-                                            *FIGHTER_STATUS_KIND_WIN,
-                                            *FIGHTER_STATUS_KIND_LOSE,
-                                            *FIGHTER_STATUS_KIND_ENTRY];
+unsafe fn var_resets(boma: &mut BattleObjectModuleAccessor) {
+    let damage_statuses = &[*FIGHTER_STATUS_KIND_DEAD,
+                                        *FIGHTER_STATUS_KIND_REBIRTH,
+                                        *FIGHTER_STATUS_KIND_WIN,
+                                        *FIGHTER_STATUS_KIND_LOSE,
+                                        *FIGHTER_STATUS_KIND_ENTRY];
 
-const DEATH_STATUSES : &'static [i32] = &[*FIGHTER_STATUS_KIND_DAMAGE,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                                            *FIGHTER_STATUS_KIND_DAMAGE_FALL];
+    let death_statuses = &[*FIGHTER_STATUS_KIND_DAMAGE,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+                                        *FIGHTER_STATUS_KIND_DAMAGE_FALL];
 
-unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
-    
     // Up Special Cancel
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_CANCEL) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DAMAGE_STATUSES)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(damage_statuses)
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_CANCEL);
         }
     }
@@ -39,8 +38,8 @@ unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     // Side Special Cancel
     if VarModule::is_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DAMAGE_STATUSES)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(damage_statuses)
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL);
         }
     }
@@ -48,15 +47,15 @@ unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     // Side Special Cancel (doesn't reset on hit)
     if VarModule::is_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL_NO_HIT)
     && (!boma.is_situation(*SITUATION_KIND_AIR)
-    || boma.is_status_one_of(DEATH_STATUSES)) {
+    || boma.is_status_one_of(death_statuses)) {
         VarModule::off_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL_NO_HIT);
     }
 
     // Aerial Special Used
     if VarModule::is_flag(boma.object(), vars::common::AIR_SPECIAL_USED) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DAMAGE_STATUSES)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(damage_statuses)
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::AIR_SPECIAL_USED);
         }
     }
@@ -64,7 +63,7 @@ unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     // Up Special Wall Jump
     if VarModule::is_flag(boma.object(), vars::common::SPECIAL_WALL_JUMP) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::SPECIAL_WALL_JUMP);
         }
     }
@@ -72,8 +71,8 @@ unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     // Up Special Interrupt
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DAMAGE_STATUSES)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(damage_statuses)
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT);
         }
     }
@@ -81,30 +80,26 @@ unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     // Up Special Intterupt Airtime
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT_AIRTIME) {
         if !boma.is_situation(*SITUATION_KIND_AIR)
-        || boma.is_status_one_of(DAMAGE_STATUSES)
-        || boma.is_status_one_of(DEATH_STATUSES) {
+        || boma.is_status_one_of(damage_statuses)
+        || boma.is_status_one_of(death_statuses) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT_AIRTIME);
         }
     }
-}
 
-unsafe fn special_motion_reset(boma: &mut BattleObjectModuleAccessor) {
+    // Special Motion Reset
     if !boma.is_situation(*SITUATION_KIND_AIR)
-    || boma.is_status_one_of(DEATH_STATUSES) {
+    || boma.is_status_one_of(death_statuses) {
         VarModule::off_flag(boma.object(), vars::common::SPECIAL_STALL);
         VarModule::off_flag(boma.object(), vars::common::SPECIAL_STALL_USED);
     }
-}
 
-unsafe fn aerial_glide_toss_reset(boma: &mut BattleObjectModuleAccessor) {
+    // Aerial Glide Toss Reset
     if !boma.is_situation(*SITUATION_KIND_AIR)
-    || boma.is_status_one_of(DEATH_STATUSES) {
+    || boma.is_status_one_of(death_statuses) {
         VarModule::set_int(boma.object(), vars::common::AGT_USED_COUNTER, 0);
     }
 }
 
 pub unsafe fn run(boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
-    special_cancel_flag_reset(boma);
-    special_motion_reset(boma);
-    aerial_glide_toss_reset(boma);
+    var_resets(boma);
 }

--- a/fighters/common/src/opff/var_resets.rs
+++ b/fighters/common/src/opff/var_resets.rs
@@ -10,13 +10,13 @@ use smash::lib::lua_const::*;
 use smash::hash40;
 
 unsafe fn var_resets(boma: &mut BattleObjectModuleAccessor) {
-    let damage_statuses = &[*FIGHTER_STATUS_KIND_DEAD,
+    let death_statuses = &[*FIGHTER_STATUS_KIND_DEAD,
                                         *FIGHTER_STATUS_KIND_REBIRTH,
                                         *FIGHTER_STATUS_KIND_WIN,
                                         *FIGHTER_STATUS_KIND_LOSE,
                                         *FIGHTER_STATUS_KIND_ENTRY];
 
-    let death_statuses = &[*FIGHTER_STATUS_KIND_DAMAGE,
+    let damage_statuses = &[*FIGHTER_STATUS_KIND_DAMAGE,
                                         *FIGHTER_STATUS_KIND_DAMAGE_AIR,
                                         *FIGHTER_STATUS_KIND_DAMAGE_FLY,
                                         *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,

--- a/fighters/common/src/opff/var_resets.rs
+++ b/fighters/common/src/opff/var_resets.rs
@@ -9,156 +9,102 @@ use smash::app::lua_bind::*;
 use smash::lib::lua_const::*;
 use smash::hash40;
 
+const DAMAGE_STATUSES : &'static [i32] = &[*FIGHTER_STATUS_KIND_DEAD,
+                                            *FIGHTER_STATUS_KIND_REBIRTH,
+                                            *FIGHTER_STATUS_KIND_WIN,
+                                            *FIGHTER_STATUS_KIND_LOSE,
+                                            *FIGHTER_STATUS_KIND_ENTRY];
 
-unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32) {
+const DEATH_STATUSES : &'static [i32] = &[*FIGHTER_STATUS_KIND_DAMAGE,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+                                            *FIGHTER_STATUS_KIND_DAMAGE_FALL];
+
+unsafe fn special_cancel_flag_reset(boma: &mut BattleObjectModuleAccessor) {
     
     // Up Special Cancel
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_CANCEL) {
-        if situation_kind != *SITUATION_KIND_AIR
-            || [*SITUATION_KIND_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE,
-                *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY ,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                *FIGHTER_STATUS_KIND_DAMAGE_FALL,
-                *FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DAMAGE_STATUSES)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_CANCEL);
         }
     }
 
     // Side Special Cancel
     if VarModule::is_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL) {
-        if situation_kind != *SITUATION_KIND_AIR
-            || [*SITUATION_KIND_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE,
-                *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY ,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                *FIGHTER_STATUS_KIND_DAMAGE_FALL,
-                *FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DAMAGE_STATUSES)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL);
         }
     }
 
     // Side Special Cancel (doesn't reset on hit)
     if VarModule::is_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL_NO_HIT)
-    && (!boma.is_situation(*SITUATION_KIND_AIR) ||
-        boma.is_status_one_of(&[
-            *FIGHTER_STATUS_KIND_DEAD,
-            *FIGHTER_STATUS_KIND_REBIRTH,
-            *FIGHTER_STATUS_KIND_WIN,
-            *FIGHTER_STATUS_KIND_LOSE,
-            *FIGHTER_STATUS_KIND_ENTRY
-        ])) {
+    && (!boma.is_situation(*SITUATION_KIND_AIR)
+    || boma.is_status_one_of(DEATH_STATUSES)) {
         VarModule::off_flag(boma.object(), vars::common::SIDE_SPECIAL_CANCEL_NO_HIT);
     }
 
     // Aerial Special Used
     if VarModule::is_flag(boma.object(), vars::common::AIR_SPECIAL_USED) {
-        if situation_kind != *SITUATION_KIND_AIR
-             || [*SITUATION_KIND_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE,
-                *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY ,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                *FIGHTER_STATUS_KIND_DAMAGE_FALL,
-                *FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DAMAGE_STATUSES)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::AIR_SPECIAL_USED);
         }
     }
 
     // Up Special Wall Jump
     if VarModule::is_flag(boma.object(), vars::common::SPECIAL_WALL_JUMP) {
-        if situation_kind != SITUATION_KIND_AIR
-            || [*FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::SPECIAL_WALL_JUMP);
         }
     }
 
     // Up Special Interrupt
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT) {
-        if situation_kind != *SITUATION_KIND_AIR
-            || [*FIGHTER_STATUS_KIND_DAMAGE,
-                *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                *FIGHTER_STATUS_KIND_DAMAGE_FALL,
-                *FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DAMAGE_STATUSES)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT);
         }
     }
 
     // Up Special Intterupt Airtime
     if VarModule::is_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT_AIRTIME) {
-        if situation_kind != *SITUATION_KIND_AIR
-            || [*FIGHTER_STATUS_KIND_DAMAGE,
-                *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-                *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-                *FIGHTER_STATUS_KIND_DAMAGE_FALL,
-                *FIGHTER_STATUS_KIND_DEAD,
-                *FIGHTER_STATUS_KIND_REBIRTH,
-                *FIGHTER_STATUS_KIND_WIN,
-                *FIGHTER_STATUS_KIND_LOSE,
-                *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+        if !boma.is_situation(*SITUATION_KIND_AIR)
+        || boma.is_status_one_of(DAMAGE_STATUSES)
+        || boma.is_status_one_of(DEATH_STATUSES) {
             VarModule::off_flag(boma.object(), vars::common::UP_SPECIAL_INTERRUPT_AIRTIME);
         }
     }
 }
 
-unsafe fn special_motion_reset(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32) {
-    if situation_kind == *SITUATION_KIND_GROUND
-        || [*FIGHTER_STATUS_KIND_DEAD,
-            *FIGHTER_STATUS_KIND_REBIRTH,
-            *FIGHTER_STATUS_KIND_WIN,
-            *FIGHTER_STATUS_KIND_LOSE,
-            *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind) {
+unsafe fn special_motion_reset(boma: &mut BattleObjectModuleAccessor) {
+    if !boma.is_situation(*SITUATION_KIND_AIR)
+    || boma.is_status_one_of(DEATH_STATUSES) {
         VarModule::off_flag(boma.object(), vars::common::SPECIAL_STALL);
         VarModule::off_flag(boma.object(), vars::common::SPECIAL_STALL_USED);
     }
 }
 
+unsafe fn aerial_glide_toss_reset(boma: &mut BattleObjectModuleAccessor) {
+    if !boma.is_situation(*SITUATION_KIND_AIR)
+    || boma.is_status_one_of(DEATH_STATUSES) {
+        VarModule::set_int(boma.object(), vars::common::AGT_USED_COUNTER, 0);
+    }
+}
+
 pub unsafe fn run(boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
-    special_cancel_flag_reset(boma, status_kind, situation_kind);
-    special_motion_reset(boma, status_kind, situation_kind)
+    special_cancel_flag_reset(boma);
+    special_motion_reset(boma);
+    aerial_glide_toss_reset(boma);
 }

--- a/romfs/source/fighter/toonlink/param/vl.prcxml
+++ b/romfs/source/fighter/toonlink/param/vl.prcxml
@@ -27,7 +27,7 @@
   </list>
   <list hash="param_toonlinkbomb">
     <struct index="0">
-      <float hash="toonlinkbomb_throw_speed_mul">0.85</float>
+      <float hash="toonlinkbomb_throw_speed_mul">0.95</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Changes ~~two~~ three important aspects of AGT:
1. You can no longer cancel an airdodge at any time into the item throw. It's now a 3-frame window at the very start of airdodge, frames 1-3.
2. If you cancel airdodge into item throw, you don't burn your use of airdodge, and can use it again without having to land.
3. If you use your airdodge to AGT again, it will have diminishing returns distance and speed wise each time you AGT, eventually carrying none of the airdodge's speed into the item throw

Additionally this PR also increases Toon Link's bomb throw speed multiplier, it was very low to facilitate bomb regrabs, but with this mechanic it allowed him to chain AGTs for free and fly around. Since the throw speed was also too low for when you wanted to actually throw the bomb anyway, it was agreed to increase it after some discussion, instead of reworking AGTs with some sort of staling mechanic.

Discussion: https://discord.com/channels/659964948365049887/950977159088975883/982277295416967168
Toon Link flight before adjusting his throw strength: https://streamable.com/3xhwja
Regular example showing off the new possibilities and limitations: https://streamable.com/cf4jnq

Resolves #615