### PR TITLE
fixing buffered aerials oos and adding standing turnaround grab

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -139,6 +139,7 @@ pub mod vars {
         pub const JUMP_NEXT: i32 = 82;
         pub const IS_JAB_LOCK_ROLL: i32 = 83;
         pub const SHOULD_TRUMP_TETHER: i32 = 84;
+        pub const DID_TURNAROUND_GRAB: i32 = 85;
         
 
         // int

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -100,14 +100,22 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
     }
 
     // begin testing for transitions out of jump squat
-    let situation_kind = fighter.global_table[SITUATION_KIND].get_i32();
-    if fighter.global_table[FIGHTER_KIND].get_i32() != *FIGHTER_KIND_PICKEL || ![*FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_JUMP_SQUAT, *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N3_JUMP_SQUAT].contains(&StatusModule::prev_status_kind(fighter.module_accessor, 0)) {
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH) {
+
+    // if you are jumping oos, we do not want to trigger jc grab. This avoids getting grabs when buffering an aerial oos.
+    // if you are steve, you should not be able to jc grab or airdodge out of his special jump squat states
+    if !(fighter.kind() == *FIGHTER_KIND_PICKEL 
+        && fighter.is_prev_status_one_of(&[*FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_JUMP_SQUAT, *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N3_JUMP_SQUAT])) {
+        
+        // jc grab, jump cancel grab
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
+            && !fighter.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_GUARD, *FIGHTER_STATUS_KIND_GUARD_DAMAGE, *FIGHTER_STATUS_KIND_GUARD_OFF]) {
             fighter.change_status(
                 L2CValue::I32(*FIGHTER_STATUS_KIND_CATCH),
                 L2CValue::Bool(true)
             );
         }
+
+        // airdodge
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR) {
             fighter.change_status(
                 L2CValue::I32(*FIGHTER_STATUS_KIND_ESCAPE_AIR), // We don't want to change to ESCAPE_AIR_SLIDE in case they do a nair dodge
@@ -122,7 +130,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
             L2CValue::Bool(false)
         );
     } else if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FALL)
-            && situation_kind == *SITUATION_KIND_AIR {
+            && fighter.is_situation(*SITUATION_KIND_AIR) {
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_FALL),
             L2CValue::Bool(false)
@@ -131,7 +139,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         let cat1 = fighter.global_table[CMD_CAT1].get_i32();
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
             && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
-            && situation_kind == *SITUATION_KIND_GROUND {
+            && fighter.is_situation(*SITUATION_KIND_GROUND) {
             fighter.change_status(
                 L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
                 L2CValue::Bool(true)
@@ -141,7 +149,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
             if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
                 && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON)
                 && cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0
-                && situation_kind == *SITUATION_KIND_GROUND {
+                && fighter.is_situation(*SITUATION_KIND_GROUND) {
                 fighter.change_status(
                     L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
                     L2CValue::Bool(true)

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -414,12 +414,17 @@ pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
 
 /// checks if the fighter input a turnaround standing grab, ala pivot grab turnaround
 pub unsafe fn grab_turnaround(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_CATCH) 
-        && fighter.motion_frame() < 5.0
-        && fighter.stick_x() * PostureModule::lr(fighter.boma()) < -0.33 {
-
-        PostureModule::reverse_lr(fighter.boma());
-        PostureModule::update_rot_y_lr(fighter.boma());
+    if fighter.is_status(*FIGHTER_STATUS_KIND_CATCH) {
+        if fighter.motion_frame() < 5.0
+            && fighter.stick_x() * PostureModule::lr(fighter.boma()) < -0.33
+            && !VarModule::is_flag(fighter.object(), vars::common::DID_TURNAROUND_GRAB) {
+            
+            PostureModule::reverse_lr(fighter.boma());
+            PostureModule::update_rot_y_lr(fighter.boma());
+            VarModule::on_flag(fighter.object(), vars::common::DID_TURNAROUND_GRAB);
+        }
+    } else {
+        VarModule::off_flag(fighter.object(), vars::common::DID_TURNAROUND_GRAB);
     }
 }
 

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -412,6 +412,17 @@ pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
     }
 }
 
+/// checks if the fighter input a turnaround standing grab, ala pivot grab turnaround
+pub unsafe fn grab_turnaround(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_CATCH) 
+        && fighter.motion_frame() < 5.0
+        && fighter.stick_x() * PostureModule::lr(fighter.boma()) < -0.33 {
+
+        PostureModule::reverse_lr(fighter.boma());
+        PostureModule::update_rot_y_lr(fighter.boma());
+    }
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32, curr_frame: f32) {
     tumble_exit(boma, cat[0], status_kind, situation_kind);
     non_tumble_di(fighter, lua_state, l2c_agent, boma, status_kind);
@@ -426,5 +437,6 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     teeter_cancel(fighter, boma);
 
     freeze_stages(boma);
+    grab_turnaround(fighter);
 }
     


### PR DESCRIPTION
1. This makes it so that if you attempt to buffer an aerial oos, but do not let go of shield (like you can in melee, minus the buffer), you will correctly get an aerial, rather than a jump cancel grab (which is obnoxious).
2. jump cancel grab oos is no longer possible.
3. if you press backwards during the first 5 frames of standing grab, you will get a standing grab facing in the opposite direction. This is similar to how pivot grabs work - if you input a dash grab and then press backwards within the first 5 frames, you transition into pivot grab instead. This works similarly. If you input a standing grab, and then input backwards within the first 5 frames of startup, you get a backwards facing standing grab.