### PR TITLE
Revert dash_s4_frame to 6f

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -2,7 +2,6 @@
 <struct>
   <int hash="precede">5</int>
   <int hash="precede_extension">0</int>
-  <float hash="dash_s4_frame">2</float>
   <int hash="dash_speed_keep_frame">1</int>
   <float hash="dash_escape_frame">1</float>
   <int hash="turn_dash_frame">-1</int>


### PR DESCRIPTION
It has strange bugs, most prominently with auto-turnaround characters (shotos, terry, kazuya)