### PR TITLE
Charizard Dtaunt windbox size reduction

### DIFF
--- a/fighters/plizardon/src/acmd/other.rs
+++ b/fighters/plizardon/src/acmd/other.rs
@@ -7,9 +7,9 @@ unsafe fn plizardon_appeal_lw_r_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 35.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 0, 100, 90, 0, 37.0, 0.0, 15.0, 0.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, true, true, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 0, 80, 70, 0, 10.0, 0.0, 17.0, 0.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, true, true, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
     }
-    wait(lua_state, 20.0);
+    wait(lua_state, 5.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -22,9 +22,9 @@ unsafe fn plizardon_appeal_lw_l_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 35.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 0, 100, 90, 0, 37.0, 0.0, 15.0, 0.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, true, true, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 0, 80, 70, 0, 10.0, 0.0, 17.0, 0.0, None, None, None, 0.0, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, true, true, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
     }
-    wait(lua_state, 20.0);
+    wait(lua_state, 5.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }


### PR DESCRIPTION
Charizard's current Dtaunt has a massive windbox that makes it an effective edge guarding tool. This coupled with the fact that it lasts for 20 frames, makes this a very non interactive edge guarding tool that is a bit ridiculous on this character. I will test in game to make sure the new windbox size and placement makes sense as I'm more or less taking an educated guess at its placement.

Old
![2022060500374500-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/101300494/172043864-8f4de83c-5634-42e8-b71a-9991915db33b.jpg)

New
![2022060504172700-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/101300494/172043911-df3dcc0d-5476-4ecb-bcb7-51f29a3b84c3.jpg)

