### PR TITLE
Allow runbrake to teeter cancel

### DIFF
--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -378,7 +378,6 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
         *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL,
         *FIGHTER_STATUS_KIND_LANDING_DAMAGE_LIGHT]
     )
-    && GroundModule::get_correct(boma) == *GROUND_CORRECT_KIND_GROUND
     && (KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL)
     - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND)
     - KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN)).abs() > 0.0) {

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -370,6 +370,7 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     && boma.is_status_one_of(
     &[*FIGHTER_STATUS_KIND_WAIT,
         *FIGHTER_STATUS_KIND_DASH,
+        *FIGHTER_STATUS_KIND_RUN_BRAKE,
         *FIGHTER_STATUS_KIND_APPEAL,
         *FIGHTER_STATUS_KIND_LANDING,
         *FIGHTER_STATUS_KIND_LANDING_LIGHT,


### PR DESCRIPTION
Just another status that makes sense to be able to go into teeter, and as it did in Melee.
Brief discussion about this: https://discord.com/channels/659964948365049887/950977159088975883/982409581210787901