### PR TITLE
Roll and Spotdodge Normalization

### DIFF
--- a/romfs/source/fighter/common/param/fighter_param_motion.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param_motion.prcxml
@@ -2,8 +2,16 @@
 <struct>
   <list hash="fighter_param_motion_table">
     <struct index="0">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -19,8 +27,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="1">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -36,8 +52,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="2">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -53,7 +77,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="3">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -69,8 +102,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="4">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -86,8 +127,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="5">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -103,8 +152,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="6">
-      <float hash="escape_attack_frame">24</float>
-      <float hash="escape_f_cancel_frame">31</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">45</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -120,8 +177,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="7">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -137,8 +202,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="8">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -154,8 +227,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="9">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -170,8 +251,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="10">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">47</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -187,8 +276,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="11">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">59</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -204,8 +301,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="12">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">54</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -221,8 +326,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="13">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">47</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -238,8 +351,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="14">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -255,8 +376,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="15">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -272,8 +401,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="16">
-      <float hash="escape_attack_frame">24</float>
-      <float hash="escape_f_cancel_frame">31</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -289,8 +426,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="17">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">55</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -306,8 +451,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="18">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -323,8 +476,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="19">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">47</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -340,8 +501,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="20">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">43</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -357,8 +526,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="21">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -374,8 +551,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="22">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -391,8 +576,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="23">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -407,8 +600,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="24">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">53</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -424,8 +625,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="25">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -441,8 +650,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="26">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -458,8 +675,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="27">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -475,8 +700,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="28">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -492,8 +725,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="29">
-      <float hash="escape_attack_frame">24</float>
-      <float hash="escape_f_cancel_frame">31</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -509,8 +750,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="30">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">58</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -526,8 +775,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="31">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -543,8 +800,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="32">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -560,8 +825,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="33">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -577,8 +850,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="34">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">55</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -594,8 +875,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="35">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_frame">45</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
@@ -612,8 +901,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="36">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_frame">45</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
@@ -630,8 +927,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="37">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -646,8 +951,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="38">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -663,8 +976,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="39">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">58</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -680,8 +1001,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="40">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -697,8 +1026,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="41">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -714,8 +1051,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="42">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -731,8 +1076,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="43">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -748,8 +1101,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="44">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -764,8 +1125,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="45">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -781,8 +1150,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="46">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -798,8 +1175,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="47">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -815,8 +1200,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="48">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">53</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -832,8 +1225,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="49">
-      <float hash="escape_attack_frame">24</float>
-      <float hash="escape_f_cancel_frame">31</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -849,8 +1250,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="50">
-      <float hash="escape_attack_frame">25</float>
-      <float hash="escape_f_cancel_frame">32</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">45</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -866,8 +1275,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="51">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -883,8 +1300,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="52">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">54</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -900,8 +1325,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="53">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -917,8 +1350,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="54">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -934,8 +1375,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="55">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -951,8 +1400,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="56">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">53</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -968,8 +1425,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="57">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_hit_xlu_frame">2</float>
@@ -989,8 +1454,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="58">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1006,8 +1479,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="59">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1039,8 +1520,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="61">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1056,8 +1545,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="62">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">53</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1073,8 +1570,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="63">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1090,8 +1595,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="64">
-      <float hash="escape_attack_frame">29</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1107,8 +1620,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="65">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1124,8 +1645,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="66">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1141,8 +1670,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="67">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">45</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1158,8 +1695,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="68">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1175,8 +1720,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="69">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1192,7 +1745,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="70">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">47</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1208,7 +1770,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="71">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1224,7 +1795,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="72">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1240,7 +1820,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="73">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1256,7 +1845,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="74">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_frame">50</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
@@ -1273,7 +1871,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="75">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1288,7 +1895,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="76">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1301,7 +1917,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="77">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1332,7 +1957,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="79">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1348,8 +1982,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="80">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">48</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1365,8 +2007,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="81">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1382,8 +2032,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="82">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1399,8 +2057,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="83">
-      <float hash="escape_attack_frame">27</float>
-      <float hash="escape_f_cancel_frame">34</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">54</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1416,8 +2082,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="84">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">49</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1433,8 +2107,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="85">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1450,8 +2132,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="86">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1467,8 +2157,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="87">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">51</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1484,8 +2182,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="88">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_penalty_hit_xlu_frame">2</float>
@@ -1503,8 +2209,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="89">
-      <float hash="escape_attack_frame">27</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
       <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">52</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1520,7 +2234,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="90">
-      <float hash="escape_attack_frame">29</float>
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
+      <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_cancel_frame">50</float>
       <float hash="escape_air_slide_back_distance">1</float>
@@ -1536,7 +2259,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="91">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1548,7 +2280,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="92">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>
@@ -1560,7 +2301,16 @@
       <float hash="landing_speed_mul_escape_air_slide">0.957</float>
     </struct>
     <struct index="93">
+      <float hash="escape_n_hit_xlu_frame">3</float>
+      <float hash="escape_n_hit_normal_frame">15</float>
       <float hash="escape_attack_frame">26</float>
+      <float hash="escape_n_cancel_frame">26</float>
+      <float hash="escape_f_hit_xlu_frame">4</float>
+      <float hash="escape_f_hit_normal_frame">13</float>
+      <float hash="escape_f_cancel_frame">33</float>
+      <float hash="escape_b_hit_xlu_frame">4</float>
+      <float hash="escape_b_hit_normal_frame">13</float>
+      <float hash="escape_b_cancel_frame">33</float>
       <float hash="escape_air_stiff_start_frame">500</float>
       <float hash="escape_air_slide_back_distance">1</float>
       <int hash="escape_air_slide_back_end_frame">0</int>


### PR DESCRIPTION
Every character's roll and spotdoge except Bayonetta and Mythra have been standardized to the following
Spotdodge: Intangible frames 3-17, FAF on frame 26
Forward Roll: Intangible frames 4-16, FAF on frame 33
Back Roll: Intangible frames 4-16, FAF on frame 33

Resolves #648 