### PR TITLE
blujay's stage hazards removal

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -14,6 +14,7 @@ pub mod change_status;
 pub mod is_flag;
 pub mod controls;
 pub mod jumps;
+pub mod stage_hazards;
 
 pub fn install() {
     effect::install();
@@ -30,6 +31,7 @@ pub fn install() {
     controls::install();
     momentum_transfer::install();
     jumps::install();
+    stage_hazards::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/common/src/function_hooks/stage_hazards.rs
+++ b/fighters/common/src/function_hooks/stage_hazards.rs
@@ -40,6 +40,7 @@ static HAZARDLESS_STAGE_IDS: &[u32] = &[
     0x68, // wario ware,
     0x6e, // halberd
     0x77, // summit
+    0xcb, // find mii (StreetPass)
     0xb9, // reset bomb forest
     0xec, // skyloft,
     0x107, // wrecking crew

--- a/fighters/common/src/function_hooks/stage_hazards.rs
+++ b/fighters/common/src/function_hooks/stage_hazards.rs
@@ -1,0 +1,70 @@
+#![feature(proc_macro_hygiene)]
+
+use skyline::{hook, install_hook};
+
+extern "C" {
+    #[link_name = "_ZN3app5stage12get_stage_idEv"]
+    fn get_stage_id() -> u32;
+}
+
+#[skyline::hook(offset = 0x5209a0)]
+unsafe fn area_manager_process(manager: *const u64) {
+    let mut start = *manager.add(1);
+    let end = *manager.add(2);
+    while start != end {
+        let current = *(start as *const u64);
+        if *(current as *mut u8).add(0x20) == 0x1b && get_stage_id() == 0x8f {
+            *(current as *mut bool).add(0x21) = false;
+            *((current + 0x40) as *mut f32) = 0.0;
+            *((current + 0x40) as *mut f32).add(1) = 0.0;
+            *((current + 0x40) as *mut f32).add(2) = 0.0;
+            *((current + 0x40) as *mut f32).add(3) = 0.0;
+            *((current + 0x40) as *mut f32).add(4) = 0.0;
+            *((current + 0x40) as *mut f32).add(5) = 0.0;
+            *((current + 0x40) as *mut f32).add(6) = 0.0;
+            *((current + 0x40) as *mut f32).add(7) = 0.0;
+        }
+        start = start + 0x8;
+    }
+    call_original!(manager)
+}
+
+#[skyline::hook(offset = 0x30f6160)]
+unsafe fn stub() {}
+
+static HAZARDLESS_STAGE_IDS: &[u32] = &[
+    0x3b, // venom
+    0x3e, // brinstar
+    0x59, // lylat    
+    0x62, // skyworld
+    0x68, // wario ware,
+    0x6e, // halberd
+    0x77, // summit
+    0xb9, // reset bomb forest
+    0xec, // skyloft,
+    0x107, // wrecking crew
+    0x10d, // wuhu island
+    0x119, // duck hunt
+];
+
+#[skyline::hook(offset = 0x178a090, inline)]
+unsafe fn init_stage(ctx: &mut skyline::hooks::InlineCtx) {
+    if HAZARDLESS_STAGE_IDS.contains(&*ctx.registers[1].w.as_ref()) {
+        *ctx.registers[3].w.as_mut() = 0;
+    }
+}
+
+#[skyline::hook(offset = 0x3a9160, inline)]
+unsafe fn handle_movement_grav_update(ctx: &mut skyline::hooks::InlineCtx) {
+    let battle_object_world = *(((skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64) + 0x52b6558) as *const u64);
+    *(battle_object_world as *mut u8).add(0x59) = 0x1;
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        stub,
+        area_manager_process,
+        init_stage,
+        handle_movement_grav_update,
+    );
+}

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -281,17 +281,6 @@ extern "C" {
     pub fn stage_id() -> i32;
 }
 
-pub unsafe fn freeze_stages(boma: &mut BattleObjectModuleAccessor) {
-
-    // determine the current stage id
-    //println!("stage id: {}", stage_id());
-
-    // warioware
-    if (stage_id() == 104) {
-        smash::app::FighterUtil::set_stage_pause_for_final(true, boma);
-    }
-}
-
 pub unsafe fn hitfall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, fighter_kind: i32, cat: [i32 ; 4]) {
     if boma.kind() == *FIGHTER_KIND_GAOGAEN
     && boma.is_situation(*SITUATION_KIND_AIR)
@@ -435,7 +424,5 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     respawn_taunt(boma, status_kind);
     teeter_cancel(fighter, boma);
     clear_taunt(fighter);
-
-    freeze_stages(boma);
 }
     


### PR DESCRIPTION
work done by @blu-dev to remove hazards for certain stages permanently.

- venom
- brinstar
- lylat    
- skyworld
- wario ware,
- halberd
- summit
- reset bomb forest
- skyloft,
- wrecking crew
- wuhu island
- duck hunt
- find mii

fixes #651 