### PR TITLE
fixing Shorthop-Button-cancelling behavior

### DIFF
--- a/fighters/common/src/function_hooks/jumps.rs
+++ b/fighters/common/src/function_hooks/jumps.rs
@@ -15,7 +15,9 @@ unsafe fn fullhop_initial_y_speed_hook(ctx: &mut skyline::hooks::InlineCtx) {
 
 #[skyline::hook(replace = L2CFighterCommon_sub_check_button_jump)]
 unsafe extern "C" fn sub_check_button_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_cat_flag(CatHdr::ShorthopFootstool) && fighter.is_situation(*SITUATION_KIND_GROUND) {
+    if fighter.is_cat_flag(CatHdr::ShorthopFootstool) 
+        && fighter.is_situation(*SITUATION_KIND_GROUND) 
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_SQUAT_BUTTON) {
         return true.into();
     }
     call_original!(fighter)


### PR DESCRIPTION
Making sure jumps using shorthop are locked behind the appropriate transition term.