### PR TITLE
Reduce wavedash/waveland lengths globally

### DIFF
--- a/romfs/source/fighter/common/param/fighter_param_motion.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param_motion.prcxml
@@ -24,7 +24,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="1">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -49,7 +49,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="2">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -74,7 +74,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="3">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -99,7 +99,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="4">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -124,7 +124,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="5">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -149,7 +149,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="6">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -174,7 +174,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">45</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="7">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -199,7 +199,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="8">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -224,7 +224,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="9">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -248,7 +248,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="10">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -273,7 +273,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="11">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -298,7 +298,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="12">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -323,7 +323,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="13">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -348,7 +348,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="14">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -373,7 +373,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="15">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -398,7 +398,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="16">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -423,7 +423,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="17">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -448,7 +448,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="18">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -473,7 +473,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="19">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -498,7 +498,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="20">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -523,7 +523,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">43</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="21">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -548,7 +548,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="22">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -573,7 +573,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="23">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -597,7 +597,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="24">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -622,7 +622,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="25">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -647,7 +647,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="26">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -672,7 +672,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="27">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -697,7 +697,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="28">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -722,7 +722,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="29">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -747,7 +747,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="30">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -772,7 +772,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="31">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -797,7 +797,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="32">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -822,7 +822,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="33">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -847,7 +847,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="34">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -872,7 +872,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="35">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -898,7 +898,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="36">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -924,7 +924,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="37">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -948,7 +948,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="38">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -973,7 +973,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="39">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -998,7 +998,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="40">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1023,7 +1023,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="41">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1048,7 +1048,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="42">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1073,7 +1073,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="43">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1098,7 +1098,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="44">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1122,7 +1122,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">45</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="45">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1147,7 +1147,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="46">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1172,7 +1172,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="47">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1197,7 +1197,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="48">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1222,7 +1222,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="49">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1247,7 +1247,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="50">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1272,7 +1272,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">45</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="51">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1297,7 +1297,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="52">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1322,7 +1322,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="53">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1347,7 +1347,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="54">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1372,7 +1372,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="55">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1397,7 +1397,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="56">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1422,7 +1422,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="57">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1451,7 +1451,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="58">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1476,7 +1476,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="59">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1500,7 +1500,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="60">
       <float hash="escape_attack_frame">26</float>
@@ -1517,7 +1517,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="61">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1542,7 +1542,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="62">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1567,7 +1567,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="63">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1592,7 +1592,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="64">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1617,7 +1617,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="65">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1642,7 +1642,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="66">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1667,7 +1667,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="67">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1692,7 +1692,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">45</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="68">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1717,7 +1717,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="69">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1742,7 +1742,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="70">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1767,7 +1767,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="71">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1792,7 +1792,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="72">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1817,7 +1817,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="73">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1842,7 +1842,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="74">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1868,7 +1868,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="75">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1892,7 +1892,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="76">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1914,7 +1914,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="77">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1938,7 +1938,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="78">
       <float hash="escape_attack_frame">26</float>
@@ -1954,7 +1954,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="79">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1979,7 +1979,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="80">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2004,7 +2004,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">48</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="81">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2029,7 +2029,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="82">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2054,7 +2054,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="83">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2079,7 +2079,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="84">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2104,7 +2104,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">49</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="85">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2129,7 +2129,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="86">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2154,7 +2154,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="87">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2179,7 +2179,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="88">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2206,7 +2206,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="89">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2231,7 +2231,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="90">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2256,7 +2256,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="91">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2277,7 +2277,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="92">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2298,7 +2298,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
     <struct index="93">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2319,7 +2319,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.957</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
     </struct>
   </list>
 </struct>


### PR DESCRIPTION
Changes the airdodge landing speed multiplier from 0.957 -> 0.832

Previously, the value of 0.957 was meant to emulate the wavedash velocity of a perfect angle wavedash in Melee. The new value of 0.832 is meant to emulate the angle halfway between the perfect angle and the lower diagonal notch on the GC controller.

Resolves #680 