### PR TITLE
waveland platdrop consistency improvements

### DIFF
--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -133,7 +133,7 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
     if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
     && VarModule::is_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP)
     && GroundModule::is_passable_ground(boma)
-    && boma.prev_stick_y() > 0.0 && boma.stick_y() < pass_thresh
+    && boma.prev_stick_y() > -0.3 && boma.stick_y() < pass_thresh
     && boma.is_prev_status_one_of(&[
         *FIGHTER_STATUS_KIND_ESCAPE_AIR,
         *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -129,11 +129,11 @@ unsafe fn non_tumble_di(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agen
 
 // plat drop if you input down during a waveland (airdodge landing lag)
 unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, status_kind: i32) {
-    let flick_y_sens = ParamModule::get_float(boma.object(), ParamType::Common, "general_flick_y_sens");
+    let pass_thresh = ParamModule::get_float(boma.object(), ParamType::Common, "waveland_pass_neutral_sens");
     if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
     && VarModule::is_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP)
     && GroundModule::is_passable_ground(boma)
-    && boma.prev_stick_y() > -0.3 && boma.stick_y() < -0.6
+    && boma.prev_stick_y() > 0.0 && boma.stick_y() < pass_thresh
     && boma.is_prev_status_one_of(&[
         *FIGHTER_STATUS_KIND_ESCAPE_AIR,
         *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE
@@ -144,7 +144,7 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
     }
 
     if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
-        && boma.stick_y() > ParamModule::get_float(boma.object(), ParamType::Common, "waveland_pass_neutral_sens")
+        && boma.stick_y() > pass_thresh
     {
         VarModule::on_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP);
     }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -133,7 +133,7 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
     if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
     && VarModule::is_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP)
     && GroundModule::is_passable_ground(boma)
-    && boma.prev_stick_y() > -0.3 && boma.stick_y() < -0.6
+    && boma.is_flick_y(flick_y_sens)
     && boma.is_prev_status_one_of(&[
         *FIGHTER_STATUS_KIND_ESCAPE_AIR,
         *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -143,12 +143,8 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
         return;
     }
 
-    if boma.is_status_one_of(&[
-        *FIGHTER_STATUS_KIND_ESCAPE_AIR,
-        *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE,
-        *FIGHTER_STATUS_KIND_LANDING
-    ])
-    && boma.stick_y() > ParamModule::get_float(boma.object(), ParamType::Common, "waveland_pass_neutral_sens")
+    if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
+        && boma.stick_y() > ParamModule::get_float(boma.object(), ParamType::Common, "waveland_pass_neutral_sens")
     {
         VarModule::on_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP);
     }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -133,7 +133,7 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
     if boma.is_status(*FIGHTER_STATUS_KIND_LANDING)
     && VarModule::is_flag(boma.object(), vars::common::ENABLE_WAVELAND_PLATDROP)
     && GroundModule::is_passable_ground(boma)
-    && boma.is_flick_y(flick_y_sens)
+    && boma.prev_stick_y() > -0.3 && boma.stick_y() < -0.6
     && boma.is_prev_status_one_of(&[
         *FIGHTER_STATUS_KIND_ESCAPE_AIR,
         *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -21,7 +21,7 @@
         <float hash="speed_lerp_max">1.5</float>
     </struct>
     <float hash="glide_toss_cancel_frame">6</float>
-    <float hash="waveland_pass_neutral_sens">-0.3</float>
+    <float hash="waveland_pass_neutral_sens">-0.66</float>
     <int hash="air_escape_snap_frame">5</int>
     <float hash="waveland_distance_threshold">6</float>
     <struct hash="dacus_enable">


### PR DESCRIPTION
- removing escape air and escape air slide from the statuses where ENABLE_WAVELAND_PLATDROP gets turned on. This means that you will have to be in LANDING for at least 1 frame before you can platdrop, but it also means stick jumpers shouldnt get this by accident.
- using is_flick means that you can platdrop by flicking upwards too, which is an issue, so now we use a different stick check.