### PR TITLE
Drift DI scaling adjustments

### DIFF
--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -64,7 +64,7 @@ unsafe fn map_controls_hook(
     let ret = original!()(mappings, player_idx, out, controller_struct, arg);
     let controller = &mut controller_struct.controller;
 
-    println!("entry_count vs. current: {} vs. {}", entry_count, (*mappings.add(player_idx as usize))._34[0]);
+    //println!("entry_count vs. current: {} vs. {}", entry_count, (*mappings.add(player_idx as usize))._34[0]);
 
     if (*out).buttons.contains(Buttons::CStickOn) && (*mappings.add(player_idx as usize))._34[0] != entry_count {
         (*out).rstick_x = (controller.left_stick_x * (i8::MAX as f32)) as i8;
@@ -214,7 +214,7 @@ unsafe fn parse_inputs(this: &mut ControlModuleInternal) {
         return call_original!(this);
     }
 
-    println!("this.controller_index: {}", this.controller_index);
+    //println!("this.controller_index: {}", this.controller_index);
     // assert!(this.controller_index <= 7);
 
     let inputs = get_mapped_controller_inputs(this.controller_index as usize);

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -266,7 +266,12 @@ unsafe fn drift_di(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
             speed_mul += ratio * speed_mul_add_max;
         }
 
-        let drift_value = boma.stick_x() * speed_mul;
+        let current_damage = DamageModule::damage(boma, 0);
+        println!("Current damage: {}", current_damage);
+        let percent_mul = (current_damage / 100.0) * ParamModule::get_float(fighter.battle_object, ParamType::Common, "drift_di.drift_reduction_mul_at_100");;
+        println!("percent based multiplier: {}", percent_mul);
+
+        let drift_value = boma.stick_x() * speed_mul * percent_mul;
         fighter.set_speed(Vector2f::new(speed_x + drift_value, speed_y), *FIGHTER_KINETIC_ENERGY_ID_DAMAGE);
     }
 }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -268,7 +268,7 @@ unsafe fn drift_di(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 
         let current_damage = DamageModule::damage(boma, 0);
         println!("Current damage: {}", current_damage);
-        let percent_mul = (current_damage / 100.0) * ParamModule::get_float(fighter.battle_object, ParamType::Common, "drift_di.drift_reduction_mul_at_100");;
+        let percent_mul = (1.0 - (current_damage / 100.0) * ParamModule::get_float(fighter.battle_object, ParamType::Common, "drift_di.drift_reduction_mul_at_100")).max(0.0);
         println!("percent based multiplier: {}", percent_mul);
 
         let drift_value = boma.stick_x() * speed_mul * percent_mul;

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -16,9 +16,10 @@
     <float hash="general_flick_y_sens">-0.66</float>
     <struct hash="drift_di">
         <float hash="speed_mul_base">0.005</float>
-        <float hash="speed_mul_add_max">0.005</float>
+        <float hash="speed_mul_add_max">0.0025</float>
         <float hash="speed_lerp_min">0.35</float>
         <float hash="speed_lerp_max">1.5</float>
+        <float hash="drift_reduction_mul_at_100">0.25</float>
     </struct>
     <float hash="glide_toss_cancel_frame">6</float>
     <float hash="waveland_pass_neutral_sens">-0.66</float>


### PR DESCRIPTION
Drift DI now scales down as your percent gets higher, starting from 1.0 and scaling down to 0.75 strength at 100%. It continues to scale lower from there, by 0.25 per 100% damage.
Drift DI when at 0 horizontal knockback is reduced from 0.5 to 0.25