### PR TITLE
Fixed luigi fully invince downb

### DIFF
--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -135,6 +135,10 @@ unsafe fn game_speciallw(fighter: &mut L2CAgentBase) {
 unsafe fn game_specialairlw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);
+    }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_LW_FLAG_RISE);


### PR DESCRIPTION
adds a command to remove luigi downb invince when in the air so he can't have a permanently invincible downb

fixes #719  