### PR TITLE
Global ECB fixes/waveland adjustments

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -442,6 +442,7 @@ pub trait BomaExt {
     unsafe fn get_controller_energy(&mut self) -> &mut FighterKineticEnergyController;
     // tech/general subroutine
     unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool;
+    unsafe fn shift_ecb_on_landing(&mut self);
 }
 
 impl BomaExt for BattleObjectModuleAccessor {
@@ -740,14 +741,18 @@ impl BomaExt for BattleObjectModuleAccessor {
         || (MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU))) {
             return false;
         }
-
+    
         // must check this because it is for allowing the player to screw up a perfect WD and be punished with a non-perfect WD (otherwise they'd have like, 8 frames for perfect WD lol)
         if !crate::VarModule::is_flag(self.object(), crate::consts::vars::common::ENABLE_AIR_ESCAPE_MAGNET) {
             return false;
         }
-
+    
+        if self.is_prev_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+            return false;
+        }
+    
         // ecb is top, bottom, left, right
-        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) < crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
+        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) <= crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
             let group = crate::ParamModule::get_int(self.object(), crate::ParamType::Shared, "ecb_group_shift");
             let shift = match group {
                 0 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.small"),
@@ -761,7 +766,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         } else {
             0.0
         };
-
+    
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
         let line_bottom = Vector2f::new(ecb_bottom.x, shift + ecb_bottom.y - crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"));
         let mut out_pos = Vector2f::zero();
@@ -771,6 +776,7 @@ impl BomaExt for BattleObjectModuleAccessor {
             PostureModule::set_pos(self, &Vector3f::new((*pos).x, out_pos.y + 0.01, (*pos).z));
             GroundModule::attach_ground(self, true);
             if change_status {
+                StatusModule::set_situation_kind(self, app::SituationKind(*SITUATION_KIND_GROUND), false);
                 StatusModule::change_status_request(self, *FIGHTER_STATUS_KIND_LANDING, false);
             }
             true
@@ -778,10 +784,24 @@ impl BomaExt for BattleObjectModuleAccessor {
             false
         }
     }
-
+    
     /// gets the current status kind for the fighter
     unsafe fn status(&mut self) -> i32 {
         return StatusModule::status_kind(self);
+    }
+    
+    unsafe fn shift_ecb_on_landing(&mut self) {
+        if self.is_situation(*SITUATION_KIND_GROUND) {
+            if !self.is_prev_situation(*SITUATION_KIND_GROUND) {
+                let mut fighter_pos = Vector3f {
+                    x: PostureModule::pos_x(self),
+                    y: PostureModule::pos_y(self),
+                    z: PostureModule::pos_z(self)
+                };
+                fighter_pos.y += crate::VarModule::get_float(self.object(), crate::consts::vars::common::ECB_Y_OFFSETS);
+                PostureModule::set_pos(self, &fighter_pos);
+            }
+        }
     }
 
 }

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -442,6 +442,7 @@ pub trait BomaExt {
     unsafe fn get_controller_energy(&mut self) -> &mut FighterKineticEnergyController;
     // tech/general subroutine
     unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool;
+    unsafe fn shift_ecb_on_landing(&mut self);
 }
 
 impl BomaExt for BattleObjectModuleAccessor {
@@ -746,8 +747,12 @@ impl BomaExt for BattleObjectModuleAccessor {
             return false;
         }
 
+        if self.is_prev_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+            return false;
+        }
+
         // ecb is top, bottom, left, right
-        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) < crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
+        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) <= crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
             let group = crate::ParamModule::get_int(self.object(), crate::ParamType::Shared, "ecb_group_shift");
             let shift = match group {
                 0 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.small"),
@@ -771,6 +776,7 @@ impl BomaExt for BattleObjectModuleAccessor {
             PostureModule::set_pos(self, &Vector3f::new((*pos).x, out_pos.y + 0.01, (*pos).z));
             GroundModule::attach_ground(self, true);
             if change_status {
+                StatusModule::set_situation_kind(self, app::SituationKind(*SITUATION_KIND_GROUND), false);
                 StatusModule::change_status_request(self, *FIGHTER_STATUS_KIND_LANDING, false);
             }
             true
@@ -782,6 +788,20 @@ impl BomaExt for BattleObjectModuleAccessor {
     /// gets the current status kind for the fighter
     unsafe fn status(&mut self) -> i32 {
         return StatusModule::status_kind(self);
+    }
+
+    unsafe fn shift_ecb_on_landing(&mut self) {
+        if self.is_situation(*SITUATION_KIND_GROUND) {
+            if !self.is_prev_situation(*SITUATION_KIND_GROUND) {
+                let mut fighter_pos = Vector3f {
+                    x: PostureModule::pos_x(self),
+                    y: PostureModule::pos_y(self),
+                    z: PostureModule::pos_z(self)
+                };
+                fighter_pos.y += crate::VarModule::get_float(self.object(), crate::consts::vars::common::ECB_Y_OFFSETS);
+                PostureModule::set_pos(self, &fighter_pos);
+            }
+        }
     }
 
 }

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -793,6 +793,7 @@ impl BomaExt for BattleObjectModuleAccessor {
     unsafe fn shift_ecb_on_landing(&mut self) {
         if self.is_situation(*SITUATION_KIND_GROUND) {
             if !self.is_prev_situation(*SITUATION_KIND_GROUND) {
+                // shift ECB back to normal offset
                 let mut fighter_pos = Vector3f {
                     x: PostureModule::pos_x(self),
                     y: PostureModule::pos_y(self),

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -442,7 +442,6 @@ pub trait BomaExt {
     unsafe fn get_controller_energy(&mut self) -> &mut FighterKineticEnergyController;
     // tech/general subroutine
     unsafe fn handle_waveland(&mut self, require_airdodge: bool, change_status: bool) -> bool;
-    unsafe fn shift_ecb_on_landing(&mut self);
 }
 
 impl BomaExt for BattleObjectModuleAccessor {
@@ -741,18 +740,14 @@ impl BomaExt for BattleObjectModuleAccessor {
         || (MotionModule::frame(self) > 5.0 && !WorkModule::is_flag(self, *FIGHTER_STATUS_ESCAPE_FLAG_HIT_XLU))) {
             return false;
         }
-    
+
         // must check this because it is for allowing the player to screw up a perfect WD and be punished with a non-perfect WD (otherwise they'd have like, 8 frames for perfect WD lol)
         if !crate::VarModule::is_flag(self.object(), crate::consts::vars::common::ENABLE_AIR_ESCAPE_MAGNET) {
             return false;
         }
-    
-        if self.is_prev_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
-            return false;
-        }
-    
+
         // ecb is top, bottom, left, right
-        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) <= crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
+        let shift = if self.is_situation(*SITUATION_KIND_AIR) && self.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) < crate::ParamModule::get_int(self.object(), crate::ParamType::Common, "ecb_shift_air_trans_frame") {
             let group = crate::ParamModule::get_int(self.object(), crate::ParamType::Shared, "ecb_group_shift");
             let shift = match group {
                 0 => crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "ecb_group_shift_amount.small"),
@@ -766,7 +761,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         } else {
             0.0
         };
-    
+
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
         let line_bottom = Vector2f::new(ecb_bottom.x, shift + ecb_bottom.y - crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"));
         let mut out_pos = Vector2f::zero();
@@ -776,7 +771,6 @@ impl BomaExt for BattleObjectModuleAccessor {
             PostureModule::set_pos(self, &Vector3f::new((*pos).x, out_pos.y + 0.01, (*pos).z));
             GroundModule::attach_ground(self, true);
             if change_status {
-                StatusModule::set_situation_kind(self, app::SituationKind(*SITUATION_KIND_GROUND), false);
                 StatusModule::change_status_request(self, *FIGHTER_STATUS_KIND_LANDING, false);
             }
             true
@@ -784,24 +778,10 @@ impl BomaExt for BattleObjectModuleAccessor {
             false
         }
     }
-    
+
     /// gets the current status kind for the fighter
     unsafe fn status(&mut self) -> i32 {
         return StatusModule::status_kind(self);
-    }
-    
-    unsafe fn shift_ecb_on_landing(&mut self) {
-        if self.is_situation(*SITUATION_KIND_GROUND) {
-            if !self.is_prev_situation(*SITUATION_KIND_GROUND) {
-                let mut fighter_pos = Vector3f {
-                    x: PostureModule::pos_x(self),
-                    y: PostureModule::pos_y(self),
-                    z: PostureModule::pos_z(self)
-                };
-                fighter_pos.y += crate::VarModule::get_float(self.object(), crate::consts::vars::common::ECB_Y_OFFSETS);
-                PostureModule::set_pos(self, &fighter_pos);
-            }
-        }
     }
 
 }

--- a/fighters/buddy/src/opff.rs
+++ b/fighters/buddy/src/opff.rs
@@ -14,8 +14,7 @@ unsafe fn blue_eggs_land_cancels(fighter: &mut L2CFighterCommon) {
         if MotionModule::frame(fighter.module_accessor) < (special_n_fire_cancel_frame_ground - landing_lag) {
             MotionModule::set_frame_sync_anim_cmd(fighter.module_accessor, special_n_fire_cancel_frame_ground - landing_lag, true, true, false);
         }
-        let banjo_ecb_shift = ParamModule::get_float(fighter.object(), ParamType::Common, "ecb_group_shift_amount.medium");
-        LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke"), Hash40::new("top"), 0, banjo_ecb_shift, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+        LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
         //fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING, false);
     }
 }

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -11,56 +11,72 @@ use globals::*;
 //=================================================================
 #[skyline::hook(replace=MotionModule::change_motion)]
 unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: bool, arg6: f32, arg7: bool, arg8: bool) -> u64 {
-    
-    if boma.is_fighter() {
-        let fighter_kind = boma.kind();
-        if (fighter_kind == *FIGHTER_KIND_CLOUD && [hash40("special_hi2"), hash40("special_hi2_fall")].contains(&motion_hash.hash))
-        || (fighter_kind == *FIGHTER_KIND_KOOPA && [hash40("special_lw"), hash40("special_air_lw")].contains(&motion_hash.hash))
-        || (fighter_kind == *FIGHTER_KIND_YOSHI && [hash40("special_lw"), hash40("special_air_lw")].contains(&motion_hash.hash)) {
-            // Don't clear hitboxes
-        } else {
-            AttackModule::clear_all(boma);
-        }
-    }
+    change_motion_ecb_shift_check(boma);
     original!()(boma, motion_hash, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 #[skyline::hook(replace=MotionModule::change_motion_inherit_frame)]
 unsafe fn change_motion_inherit_frame_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: f32, arg6: bool, arg7: bool) -> u64 {
-    clear_all(boma);
+    change_motion_ecb_shift_check(boma);
     original!()(boma, motion_hash, arg3, arg4, arg5, arg6, arg7)
 }
 
 #[skyline::hook(replace=MotionModule::change_motion_inherit_frame_keep_rate)]
 unsafe fn change_motion_inherit_frame_keep_rate_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: f32) -> u64 {
-    clear_all(boma);
+    change_motion_ecb_shift_check(boma);
     original!()(boma, motion_hash, arg3, arg4, arg5)
 }
 
 #[skyline::hook(replace=MotionModule::change_motion_force_inherit_frame)]
 unsafe fn change_motion_force_inherit_frame_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: f32) -> u64 {
-    clear_all(boma);
+    change_motion_ecb_shift_check(boma);
     original!()(boma, motion_hash, arg3, arg4, arg5)
 }
 
 #[skyline::hook(replace=MotionModule::change_motion_kind)]
 unsafe fn change_motion_kind_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40) -> u64 {
-    clear_all(boma);
+    change_motion_ecb_shift_check(boma);
     original!()(boma, motion_hash)
 }
 
-unsafe fn clear_all(boma: &mut BattleObjectModuleAccessor) {
-    if boma.is_fighter() {
-        AttackModule::clear_all(boma);
+unsafe fn change_motion_ecb_shift_check(boma: &mut BattleObjectModuleAccessor) {
+    if !boma.is_prev_status_one_of(&[
+        *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
+        *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
+        *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
+        *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+        *FIGHTER_STATUS_KIND_THROWN
+    ])
+    && !boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
+        *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
+        *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
+        *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+        *FIGHTER_STATUS_KIND_ENTRY,
+        *FIGHTER_STATUS_KIND_THROWN,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_DAMAGE_FALL,
+        *FIGHTER_STATUS_KIND_TREAD_DAMAGE_AIR,
+        *FIGHTER_STATUS_KIND_BURY,
+        *FIGHTER_STATUS_KIND_BURY_WAIT,
+        *FIGHTER_STATUS_KIND_ESCAPE_AIR
+    ]) && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_AIR)
+    && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_GROUND) {
+        boma.shift_ecb_on_landing();
     }
 }
 
 pub fn install() {
     skyline::install_hooks!(
-        //change_motion_hook,
-        //change_motion_inherit_frame_hook,
-        //change_motion_inherit_frame_keep_rate_hook,
-        //change_motion_force_inherit_frame_hook,
-        //change_motion_kind_hook,
+        change_motion_hook,
+        change_motion_inherit_frame_hook,
+        change_motion_inherit_frame_keep_rate_hook,
+        change_motion_force_inherit_frame_hook,
+        change_motion_kind_hook,
     );
 }

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -40,6 +40,8 @@ unsafe fn change_motion_kind_hook(boma: &mut BattleObjectModuleAccessor, motion_
 }
 
 unsafe fn change_motion_ecb_shift_check(boma: &mut BattleObjectModuleAccessor) {
+    // Same routine/justification as fake ECB shift in init_settings hook
+    // Only difference is that our status hasn't changed during a change_motion call
     if !boma.is_prev_status_one_of(&[
         *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
         *FIGHTER_STATUS_KIND_CAPTURE_WAIT,

--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -37,6 +37,11 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
 
     if boma.is_fighter() {
         
+        // Handles "fake" ECB shift on landing
+        // Because our aerial ECB shift code currently runs in opff, it runs a frame "late"
+        // which causes characters to appear stuck halfway into the ground on the first frame they land
+        // so we need to re-shift your character back up to the proper height on that single frame
+        // this is a "fake" ECB shift for 1 frame
         if !(&[
             *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
             *FIGHTER_STATUS_KIND_CAPTURE_WAIT,

--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -36,6 +36,36 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
     let fix = super::edge_slipoffs::init_settings_edges(boma, situation, arg3, arg4, ground_cliff_check_kind, arg6, arg7, arg8, arg9, arg10);
 
     if boma.is_fighter() {
+        
+        if !(&[
+            *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
+            *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
+            *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
+            *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+            *FIGHTER_STATUS_KIND_THROWN
+        ]).contains(&StatusModule::prev_status_kind(boma, 1))
+        && !boma.is_prev_status_one_of(&[
+            *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
+            *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
+            *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
+            *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+            *FIGHTER_STATUS_KIND_ENTRY,
+            *FIGHTER_STATUS_KIND_THROWN,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+            *FIGHTER_STATUS_KIND_DAMAGE_FALL,
+            *FIGHTER_STATUS_KIND_TREAD_DAMAGE_AIR,
+            *FIGHTER_STATUS_KIND_BURY,
+            *FIGHTER_STATUS_KIND_BURY_WAIT,
+            *FIGHTER_STATUS_KIND_ESCAPE_AIR
+        ]) && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_AIR)
+        && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_GROUND) {
+            boma.shift_ecb_on_landing();
+        }
 
         // Disable wiggle out of tumble flag during damage_fly states
         if [*FIGHTER_STATUS_KIND_DAMAGE_FLY,

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -136,7 +136,11 @@ unsafe fn status_end_EscapeAir(fighter: &mut L2CFighterCommon) -> L2CValue {
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_LANDING_CLIFF_STOP);
 
-            if !VarModule::is_flag(fighter.battle_object, vars::common::PERFECT_WAVEDASH) && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND && fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) > ParamModule::get_int(fighter.object(), ParamType::Common, "ecb_shift_air_trans_frame") {
+            if !VarModule::is_flag(fighter.battle_object, vars::common::PERFECT_WAVEDASH)  // ECB never shifts during perfect waveland, no need to readjust on landing
+            && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND  // ECB must be touching ground to warrant readjustment
+            && fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) > ParamModule::get_int(fighter.object(), ParamType::Common, "ecb_shift_air_trans_frame")  // ECB doesn't shift during first 10 airborne frames, no need to readjust on landing
+            && StatusModule::prev_status_kind(fighter.module_accessor, 1) != *FIGHTER_STATUS_KIND_DAMAGE_FALL {  // ECB doesn't shift during tumble, no need to readjust on landing
+                // shift character back up to proper landing height (does same thing as ecb_shift_on_landing() boma ext)
                 let mut fighter_pos = Vector3f {
                     x: PostureModule::pos_x(fighter.module_accessor),
                     y: PostureModule::pos_y(fighter.module_accessor),

--- a/fighters/common/src/general_statuses/jump.rs
+++ b/fighters/common/src/general_statuses/jump.rs
@@ -210,10 +210,6 @@ unsafe extern "C" fn status_Jump_sub(fighter: &mut L2CFighterCommon, arg1: L2CVa
 }
 
 unsafe extern "C" fn bind_call_sub_fall_common_uniq(fighter: &mut L2CFighterCommon, arg: L2CValue) -> L2CValue {
-    if !VarModule::is_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET)
-            && VarModule::countdown_int(fighter.battle_object, vars::common::AIR_ESCAPE_MAGNET_FRAME, 0) {
-            VarModule::on_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET);
-        }
     fighter.sub_fall_common_uniq(arg)
 }
 

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -172,6 +172,11 @@ unsafe fn status_end_JumpSquat(fighter: &mut L2CFighterCommon) -> L2CValue {
     //println!("end");
     InputModule::disable_persist(fighter.battle_object);
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_MINI_ATTACK);
+    VarModule::off_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_JUMPSQUAT);
+    VarModule::off_flag(fighter.battle_object, vars::common::CSTICK_OVERRIDE);
+    VarModule::off_flag(fighter.battle_object, vars::common::CSTICK_OVERRIDE_SECOND);
+    VarModule::set_int(fighter.battle_object, vars::common::JUMP_SQUAT_FRAME, 0);
+    VarModule::off_flag(fighter.battle_object, vars::common::IS_TAP_JUMP);
     0.into()
 }
 
@@ -251,17 +256,6 @@ unsafe fn status_JumpSquat_common(fighter: &mut L2CFighterCommon, lr_update: L2C
     if fighter.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD, *FIGHTER_STATUS_KIND_GUARD_DAMAGE, *FIGHTER_STATUS_KIND_GUARD_OFF]) {
         WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH);
     }
-
-    let magnet_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "air_escape_snap_frame");
-    VarModule::set_int(fighter.battle_object, vars::common::AIR_ESCAPE_MAGNET_FRAME, magnet_frame);
-    // println!("magnet_frame {}", magnet_frame);
-    VarModule::off_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET);
-    
-    VarModule::off_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_JUMPSQUAT);
-    VarModule::off_flag(fighter.battle_object, vars::common::CSTICK_OVERRIDE);
-    VarModule::off_flag(fighter.battle_object, vars::common::CSTICK_OVERRIDE_SECOND);
-    VarModule::set_int(fighter.battle_object, vars::common::JUMP_SQUAT_FRAME, 0);
-    VarModule::off_flag(fighter.battle_object, vars::common::IS_TAP_JUMP);
 }
 
 // The main exec block, for some reason it's not found in the exec status

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -121,7 +121,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             damage_fly_common_init, 
             //damage_air_main,
             status_Landing_MainSub,
-            status_pre_Landing,
+            //status_pre_Landing,
             status_pre_LandingLight,
             status_LandingAttackAirSub,
             status_pre_landing_fall_special,
@@ -154,18 +154,6 @@ pub unsafe fn status_pre_Landing(fighter: &mut L2CFighterCommon) -> L2CValue {
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_pre_LandingLight)]
 pub unsafe fn status_pre_LandingLight(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let id = VarModule::get_int(fighter.battle_object, vars::common::COSTUME_SLOT_NUMBER) as usize;
-    let mut fighter_pos = Vector3f {
-        x: PostureModule::pos_x(fighter.module_accessor),
-        y: PostureModule::pos_y(fighter.module_accessor),
-        z: PostureModule::pos_z(fighter.module_accessor)
-    };
-    fighter_pos.y += VarModule::get_float(fighter.object(), vars::common::ECB_Y_OFFSETS);
-    VarModule::set_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR, GroundModule::get_distance_to_floor(fighter.module_accessor, &fighter_pos, fighter_pos.y, true));
-    let dist = VarModule::get_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR);
-    if dist < 0.1 {
-        PostureModule::set_pos(fighter.module_accessor, &fighter_pos);
-    }
     if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD) {
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE);
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE_F);
@@ -176,18 +164,6 @@ pub unsafe fn status_pre_LandingLight(fighter: &mut L2CFighterCommon) -> L2CValu
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_LandingAttackAirSub)]
 pub unsafe fn status_LandingAttackAirSub(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let id = VarModule::get_int(fighter.battle_object, vars::common::COSTUME_SLOT_NUMBER) as usize;
-    let mut fighter_pos = Vector3f {
-        x: PostureModule::pos_x(fighter.module_accessor),
-        y: PostureModule::pos_y(fighter.module_accessor),
-        z: PostureModule::pos_z(fighter.module_accessor)
-    };
-    fighter_pos.y += VarModule::get_float(fighter.object(), vars::common::ECB_Y_OFFSETS);
-    VarModule::set_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR, GroundModule::get_distance_to_floor(fighter.module_accessor, &fighter_pos, fighter_pos.y, true));
-    let dist = VarModule::get_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR);
-    if dist < 0.1 {
-        PostureModule::set_pos(fighter.module_accessor, &fighter_pos);
-    }
     if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD) {
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE);
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE_F);
@@ -198,18 +174,6 @@ pub unsafe fn status_LandingAttackAirSub(fighter: &mut L2CFighterCommon) -> L2CV
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_pre_landing_fall_special)]
 pub unsafe fn status_pre_landing_fall_special(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let id = VarModule::get_int(fighter.battle_object, vars::common::COSTUME_SLOT_NUMBER) as usize;
-    let mut fighter_pos = Vector3f {
-        x: PostureModule::pos_x(fighter.module_accessor),
-        y: PostureModule::pos_y(fighter.module_accessor),
-        z: PostureModule::pos_z(fighter.module_accessor)
-    };
-    fighter_pos.y += VarModule::get_float(fighter.object(), vars::common::ECB_Y_OFFSETS);
-    VarModule::set_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR, GroundModule::get_distance_to_floor(fighter.module_accessor, &fighter_pos, fighter_pos.y, true));
-    let dist = VarModule::get_float(fighter.battle_object, vars::common::GET_DIST_TO_FLOOR);
-    if dist < 0.1 {
-        PostureModule::set_pos(fighter.module_accessor, &fighter_pos);
-    }
     if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD) {
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE);
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_ESCAPE_F);

--- a/fighters/common/src/opff/momentum_transfer_line.rs
+++ b/fighters/common/src/opff/momentum_transfer_line.rs
@@ -22,10 +22,6 @@ use smash::hash40;
 //===================================================================
 pub unsafe fn momentum_transfer_helper(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, fighter_kind: i32, curr_frame: f32) {
 
-	if situation_kind == *SITUATION_KIND_AIR && ![*FIGHTER_STATUS_KIND_JUMP_SQUAT, *FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_ESCAPE_AIR].contains(&status_kind) {
-		VarModule::on_flag(fighter.battle_object, vars::common::ENABLE_AIR_ESCAPE_MAGNET);
-	}
-
 	if (fighter_kind == *FIGHTER_KIND_PFUSHIGISOU && status_kind == *FIGHTER_PFUSHIGISOU_STATUS_KIND_SPECIAL_LW_OUT)
 		|| (fighter_kind == *FIGHTER_KIND_PLIZARDON && status_kind == *FIGHTER_PLIZARDON_STATUS_KIND_SPECIAL_LW_OUT)
 		|| (fighter_kind == *FIGHTER_KIND_PZENIGAME && status_kind == *FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_LW_OUT)

--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -112,6 +112,9 @@ unsafe fn ecb_shifts(boma: &mut BattleObjectModuleAccessor) {
                 VarModule::set_float(boma.object(), vars::common::ECB_Y_OFFSETS, sh_amount);
                 offset = sh_amount;
             }
+            else {
+                offset = 0.0;
+            }
 
         } else if boma.is_situation(*SITUATION_KIND_GROUND) {
             offset = 0.0;
@@ -119,6 +122,9 @@ unsafe fn ecb_shifts(boma: &mut BattleObjectModuleAccessor) {
             offset = VarModule::get_float(boma.object(), vars::common::ECB_Y_OFFSETS);
         }
         GroundModule::set_rhombus_offset(boma, &Vector2f::new(0.0, offset));
+    }
+    else {
+        GroundModule::set_rhombus_offset(boma, &Vector2f::zero());
     }
     
 }


### PR DESCRIPTION
Fixes some long-standing jank with our ECB shifts. Namely, characters will not be stuck halfway into the ground on the first frame of certain landing states. Bugs with Snake's dthrow should be fixed as well, among other things.
Fixes #484

Perfect wavedashes now use the character's last frame of their jumpsquat animation to determine proximity to the ground, rather than the first frame of their airdodge animation.
Perfect wavelands now use the character's last frame of their jump/fall animation to determine proximity to the ground, rather than the first frame of their airdodge animation.
This allows them to snap to the ground more consistently than before; for example, wavedashing on an edge toward stage will not cause certain characters to fall off the edge anymore.
Fixes #302
Fixes #714 

Also removed the snapping lockout for an upwards airdodge initiated within the first 5 frames of airtime. It was an arbitrary rule that didn't make sense.
Resolves #247