### PR TITLE
Remove flutter input from Yoshi dair

### DIFF
--- a/fighters/yoshi/src/opff.rs
+++ b/fighters/yoshi/src/opff.rs
@@ -31,48 +31,8 @@ unsafe fn egg_roll_jc_waveland(boma: &mut BattleObjectModuleAccessor, status_kin
     }
 }
 
-
-// Flutter Kick
-/*unsafe fn flutter_kick(boma: &mut BattleObjectModuleAccessor, id: usize, situation_kind: i32, motion_kind: u64, frame: f32) {
-    if motion_kind == hash40("attack_air_lw") {
-        let motion_vec = Vector3f{x: 0.0, y: 1.275, z: 0.0};
-        if  !VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN) {
-            if frame <= 44.0 {
-                if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL)
-                    || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)
-                    /*|| ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_ATTACK)*/ {
-                    VarModule::on_flag(boma.object(), vars::common::AERIAL_COMMAND_RISING);
-                    KineticModule::add_speed_outside(boma, *KINETIC_OUTSIDE_ENERGY_TYPE_WIND_NO_ADDITION, &motion_vec);
-
-                    if VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISING) &&  !VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN) {
-                        // Reset momentum on the rise initialization
-                        if  !VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_MOMENTUM_RESET){
-                            // Reset momentum
-                            KineticModule::clear_speed_energy_id(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                            KineticModule::clear_speed_energy_id(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
-                            KineticModule::clear_speed_energy_id(boma, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
-                            VarModule::on_flag(boma.object(), vars::common::AERIAL_COMMAND_MOMENTUM_RESET);
-                        }
-                    }
-
-                }
-            }
-        }
-    }
-    if VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISING) && (motion_kind != hash40("attack_air_lw") || (motion_kind == hash40("attack_air_lw") && frame > 44.0)) {
-        VarModule::on_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN);
-        VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_RISING);
-        VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_MOMENTUM_RESET);
-    }
-    if situation_kind == *SITUATION_KIND_GROUND && VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN) {
-        VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN);
-        VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_MOMENTUM_RESET);
-    }
-}*/
-
 pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     egg_roll_jc_waveland(boma, status_kind, situation_kind, cat[0], stick_x, facing);
-    //flutter_kick(boma, id, situation_kind, motion_kind, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_YOSHI )]

--- a/fighters/yoshi/src/opff.rs
+++ b/fighters/yoshi/src/opff.rs
@@ -33,7 +33,7 @@ unsafe fn egg_roll_jc_waveland(boma: &mut BattleObjectModuleAccessor, status_kin
 
 
 // Flutter Kick
-unsafe fn flutter_kick(boma: &mut BattleObjectModuleAccessor, id: usize, situation_kind: i32, motion_kind: u64, frame: f32) {
+/*unsafe fn flutter_kick(boma: &mut BattleObjectModuleAccessor, id: usize, situation_kind: i32, motion_kind: u64, frame: f32) {
     if motion_kind == hash40("attack_air_lw") {
         let motion_vec = Vector3f{x: 0.0, y: 1.275, z: 0.0};
         if  !VarModule::is_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN) {
@@ -68,11 +68,11 @@ unsafe fn flutter_kick(boma: &mut BattleObjectModuleAccessor, id: usize, situati
         VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_RISEN);
         VarModule::off_flag(boma.object(), vars::common::AERIAL_COMMAND_MOMENTUM_RESET);
     }
-}
+}*/
 
 pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     egg_roll_jc_waveland(boma, status_kind, situation_kind, cat[0], stick_x, facing);
-    flutter_kick(boma, id, situation_kind, motion_kind, frame);
+    //flutter_kick(boma, id, situation_kind, motion_kind, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_YOSHI )]


### PR DESCRIPTION
Removes the input from Yoshi dair that allows him to fly with a double jump and halt his vertical momentum otherwise. This was supposed to be removed before hitting beta.