### PR TITLE
Ignore OSX-generated .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ plugin/hdr_version.txt
 scripts/artifacts/upgrade_deletions.txt
 **/upgrade/
 **/upgrade_artifacts/
+.DS_Store


### PR DESCRIPTION
Now that building is possible on Mac