### PR TITLE
Add RoA wavedash macro + wavedash improvements

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -238,6 +238,7 @@ bitflags! {
 
     pub struct CatHdr: i32 {
         const TiltAttack = 0x1;
+        const Wavedash = 0x2;
     }
 
     pub struct PadFlag: i32 {

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -79,6 +79,9 @@ unsafe extern "C" fn status_pre_JumpSquat_param(fighter: &mut L2CFighterCommon, 
 unsafe fn status_JumpSquat(fighter: &mut L2CFighterCommon) -> L2CValue {
     let lr_update = fighter.sub_status_JumpSquat_check_stick_lr_update();
     fighter.status_JumpSquat_common(lr_update);
+    if fighter.is_cat_flag(CatHdr::Wavedash) {
+        VarModule::on_flag(fighter.battle_object, vars::common::status::ENABLE_AIR_ESCAPE_JUMPSQUAT);
+    }
     fighter.sub_shift_status_main(L2CValue::Ptr(status_JumpSquat_Main as *const () as _))
 }
 

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -128,7 +128,9 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_air_transition_group_check_air_attack_hook,
             sub_transition_group_check_air_lasso,
             sub_transition_group_check_ground_jump_mini_attack,
-            sub_transition_group_check_air_escape
+            sub_transition_group_check_air_escape,
+            sub_transition_group_check_ground_escape,
+            sub_transition_group_check_ground_guard
         );
     }
 }
@@ -267,6 +269,22 @@ unsafe fn sub_transition_group_check_air_escape(fighter: &mut L2CFighterCommon) 
         }
     }
     false.into()
+}
+
+#[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_escape)]
+unsafe fn sub_transition_group_check_ground_escape(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_cat_flag(Cat1::JumpButton) || fighter.is_cat_flag(Cat1::Jump) {
+        return false.into()
+    }
+    call_original!(fighter)
+}
+
+#[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_guard)]
+unsafe fn sub_transition_group_check_ground_guard(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_cat_flag(Cat1::JumpButton) || fighter.is_cat_flag(Cat1::Jump) {
+        return false.into()
+    }
+    call_original!(fighter)
 }
 
 pub fn install() {

--- a/utils/src/modules/input.rs
+++ b/utils/src/modules/input.rs
@@ -425,7 +425,8 @@ fn exec_internal(input_module: &mut InputModule, control_module: u64, call_origi
             ControlModule::get_button((*input_module.owner).module_accessor)
         )
     };
-
+    
+    // TiltAttack cat flag
     let tilt_attack_offset = CatHdr::TiltAttack.bits().trailing_zeros() as usize;
     if triggered_buttons.intersects(Buttons::TiltAttack) {
         if input_module.hdr_cat.valid_frames[tilt_attack_offset] == 0 {
@@ -434,10 +435,24 @@ fn exec_internal(input_module: &mut InputModule, control_module: u64, call_origi
             };
         }
     }
-
     if input_module.hdr_cat.valid_frames[tilt_attack_offset] != 0
     && !(input_module.hdr_cat.valid_frames[tilt_attack_offset] == 1 && buttons.intersects(Buttons::TiltAttack)) {
         input_module.hdr_cat.valid_frames[tilt_attack_offset] -= 1;
+    }
+
+    // Wavedash cat flag
+    let wavedash_offset = CatHdr::Wavedash.bits().trailing_zeros() as usize;
+    let wavedash_input = (triggered_buttons.intersects(Buttons::Jump) || triggered_buttons.intersects(Buttons::FlickJump)) && triggered_buttons.intersects(Buttons::Guard);
+    if wavedash_input {
+        if input_module.hdr_cat.valid_frames[wavedash_offset] == 0 {
+            input_module.hdr_cat.valid_frames[wavedash_offset] = unsafe {
+                ControlModule::get_command_life_count_max((*input_module.owner).module_accessor) as u8
+            };
+        }
+    }
+    if input_module.hdr_cat.valid_frames[wavedash_offset] != 0
+    && !(input_module.hdr_cat.valid_frames[wavedash_offset] == 1 && wavedash_input) {
+        input_module.hdr_cat.valid_frames[wavedash_offset] -= 1;
     }
 
     call_original();


### PR DESCRIPTION
New wavedash macro:
- Previously, inputting Jump (tap or button) + Shield on the same frame would result in an empty hop
- Now, Jump + Shield = wavedash

Also disabled shielding/rolling while Jump is input, to allow for easier chaining of wavedashes.

Resolves #765 