### PR TITLE
Rosalina Teleport downb

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -303,6 +303,25 @@ pub mod vars {
         }
     }
 
+    pub mod rosetta {
+        pub mod instance {
+            // ints
+            pub const COOLDOWN: i32 = 0x0100;
+            pub const ROSA_X: i32 = 0x0101;
+            pub const ROSA_Y: i32 = 0x0102;
+            pub const TICO_X: i32 = 0x0103;
+            pub const TICO_Y: i32 = 0x0104;
+			
+			// flag
+            pub const IS_TICO_DEAD: i32 = 0x0105;
+        }
+        pub mod status {
+            // int
+            /// Used for determining what luma does
+            pub const INVIS_FRAMES: i32 = 0x1100;
+        }
+    }
+
     pub mod elight {
         pub mod instance {
             // flags

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -311,6 +311,9 @@ pub mod vars {
             pub const ROSA_Y: i32 = 0x0102;
             pub const TICO_X: i32 = 0x0103;
             pub const TICO_Y: i32 = 0x0104;
+            pub const TICO_RAYCAST: i32 = 0x0106;
+            pub const TICO_X_DIST: i32 = 0x0107;
+            pub const TICO_Y_DIST: i32 = 0x0108;
 			
 			// flag
             pub const IS_TICO_DEAD: i32 = 0x0105;

--- a/fighters/rosetta/src/lib.rs
+++ b/fighters/rosetta/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,8 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
+    use opff::*;
+	smashline::install_agent_frame_callback!(tico_callback);
 }

--- a/fighters/rosetta/src/lib.rs
+++ b/fighters/rosetta/src/lib.rs
@@ -43,5 +43,5 @@ pub fn install(is_runtime: bool) {
     status::install();
     opff::install(is_runtime);
     use opff::*;
-	smashline::install_agent_frame_callback!(tico_callback);
+	smashline::install_agent_frames!(tico_frame);
 }

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -25,11 +25,13 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
 					VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
 				};
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, 
-					(GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32, y: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32}, &Vector2f{ x: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32, y: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32}, false)) as i32
-				);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X)-VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X)));
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y)-VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y)));
+				let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
+				let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
+				let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
+				let tico_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, (GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: rosa_x, y: rosa_y}, &Vector2f{ x: tico_x, y: tico_y}, false)) as i32);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (rosa_x-tico_x) as i32);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (rosa_y-tico_y) as i32);
 				//Teleport!
 				if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
 					if frame == 12.0 {
@@ -40,8 +42,8 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
 						VisibilityModule::set_whole(boma, false);
 						JostleModule::set_status(boma, false);	
-						let new_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
-						let new_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
+						let new_x = tico_x;
+						let new_y = tico_y;
 						let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
 						PostureModule::set_pos(boma, &pos);
 						PostureModule::init_pos(boma, &pos, true, true);
@@ -73,7 +75,7 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 					};
 				};
 				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
-					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN,  VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN)-1);
+					VarModule::dec_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN);
 				};
 				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
 					gimmick_flash(boma);

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -14,58 +14,63 @@ unsafe fn launch_star_cancel(boma: &mut BattleObjectModuleAccessor, status_kind:
 
 //Rosalina Teleport
 unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
-			let fighter_kind = smash::app::utility::get_kind(boma);
-			let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
-			let frame = MotionModule::frame(boma);
-			if !smash::app::sv_information::is_ready_go(){
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
-				VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
-			};
-			//Teleport!
-			if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
-				if frame == 12.0 {
-					macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-					VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
+				let fighter_kind = smash::app::utility::get_kind(boma);
+				let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
+				let frame = MotionModule::frame(boma);
+				if !smash::app::sv_information::is_ready_go(){
+					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
+					VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
 				};
-				if frame > 16.0 && frame < 19.0 {
-					HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
-					VisibilityModule::set_whole(boma, false);
-					JostleModule::set_status(boma, false);	
-					let new_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
-					let new_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
-					let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
-					PostureModule::set_pos(boma, &pos);
-					PostureModule::init_pos(boma, &pos, true, true);
-					VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, 
+					(GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32, y: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32}, &Vector2f{ x: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32, y: VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32}, false)) as i32
+				);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X)-VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X)));
+				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y)-VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y)));
+				//Teleport!
+				if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
+					if frame == 12.0 {
+						macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
+					};
+					if frame > 16.0 && frame < 19.0 {
+						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
+						VisibilityModule::set_whole(boma, false);
+						JostleModule::set_status(boma, false);	
+						let new_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
+						let new_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
+						let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
+						PostureModule::set_pos(boma, &pos);
+						PostureModule::init_pos(boma, &pos, true, true);
+						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
+					};
+					if frame == 25.0 {
+						macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
+					};
+					if frame > 25.0{
+						VisibilityModule::set_whole(boma, true);
+						JostleModule::set_status(boma, true);	
+						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
+						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+					};
+					if frame > 37.0{
+						CancelModule::enable_cancel(boma);
+					};
+				} else {
+					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
+					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);
 				};
-				if frame == 25.0 {
-					macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-					VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
+				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
+					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN,  VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN)-1);
 				};
-				if frame > 25.0{
-					VisibilityModule::set_whole(boma, true);
-					JostleModule::set_status(boma, true);	
-					VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
-					HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
+					smash::app::FighterUtil::flash_eye_info(boma);
+					macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 0.325, true);
+					macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("havel"), 0, 0, 0, 0, 0, 0, 0.325, true);
 				};
-				if frame > 37.0{
-					CancelModule::enable_cancel(boma);
+				if status_kind == *FIGHTER_STATUS_KIND_DEAD {
+					VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);
 				};
-			} else {
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);
-			};
-			if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN,  VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN)-1);
-			};
-			if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
-				smash::app::FighterUtil::flash_eye_info(boma);
-				macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 0.325, true);
-				macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("havel"), 0, 0, 0, 0, 0, 0, 0.325, true);
-			};
-			if status_kind == *FIGHTER_STATUS_KIND_DEAD {
-				VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);
-			};
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -86,17 +91,12 @@ pub unsafe fn rosetta_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
         moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }
-#[smashline::weapon_frame_callback]
-pub fn tico_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
+#[weapon_frame( agent = WEAPON_KIND_ROSETTA_TICO )]
+fn tico_frame(weapon: &mut L2CFighterBase) {
     unsafe { 
-        if weapon.kind() != WEAPON_KIND_ROSETTA_TICO {
-            return
-        } else {
 			let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
 			let rosetta = utils::util::get_battle_object_from_id(owner_id);
 			let rosetta_boma = &mut *(*rosetta).module_accessor;
-			VarModule::set_int(rosetta, vars::rosetta::instance::TICO_X, PostureModule::pos_x(weapon.module_accessor) as i32);
-			VarModule::set_int(rosetta, vars::rosetta::instance::TICO_Y, PostureModule::pos_y(weapon.module_accessor) as i32);
 			if weapon.is_status(*WEAPON_ROSETTA_TICO_STATUS_KIND_DEAD) || weapon.is_status(*WEAPON_ROSETTA_TICO_STATUS_KIND_NONE) {
 				VarModule::on_flag(rosetta, vars::rosetta::instance::IS_TICO_DEAD);
 			};
@@ -127,7 +127,9 @@ pub fn tico_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
 					VarModule::set_int(rosetta, vars::rosetta::status::INVIS_FRAMES, 0);
 					HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
 				};
+			} else {
+				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_X, PostureModule::pos_x(weapon.module_accessor) as i32);
+				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_Y, PostureModule::pos_y(weapon.module_accessor) as i32);
 			};
-		};
-    }
+	};
 }

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -59,6 +59,14 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 				} else {
 					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
 					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);
+					if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+						JostleModule::set_status(boma, true);	
+						VisibilityModule::set_whole(boma, true);
+						if frame > 37.0{
+							CancelModule::enable_cancel(boma);
+						};
+					};
 				};
 				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
 					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN,  VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN)-1);

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -3,13 +3,17 @@ utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
- 
+//Launch Star Cancel
 unsafe fn launch_star_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
     if status_kind == *FIGHTER_ROSETTA_STATUS_KIND_SPECIAL_HI_JUMP {
         if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_ROSETTA_STATUS_KIND_SPECIAL_HI_END, false);
         }
     }
+}
+
+extern "Rust" {
+    fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
 }
 
 //Rosalina Teleport
@@ -72,9 +76,7 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN,  VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN)-1);
 				};
 				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
-					smash::app::FighterUtil::flash_eye_info(boma);
-					macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 0.325, true);
-					macros::EFFECT_FOLLOW(fighter, Hash40::new("sys_smash_flash"), Hash40::new("havel"), 0, 0, 0, 0, 0, 0, 0.325, true);
+					gimmick_flash(boma);
 				};
 				if status_kind == *FIGHTER_STATUS_KIND_DEAD {
 					VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);

--- a/fighters/rosetta/src/status.rs
+++ b/fighters/rosetta/src/status.rs
@@ -1,0 +1,24 @@
+use super::*;
+/// Prevents down b being reused
+unsafe extern "C" fn should_use_special_lw_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
+        false.into()
+    } else {
+        true.into()
+    }
+}
+
+#[smashline::fighter_init]
+fn rosetta_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        // set the callbacks on fighter init
+        if fighter.kind() == *FIGHTER_KIND_ROSETTA {
+            fighter.global_table[globals::USE_SPECIAL_LW_CALLBACK].assign(&L2CValue::Ptr(should_use_special_lw_callback as *const () as _));
+        }
+    }
+}
+
+
+pub fn install() {
+    smashline::install_agent_init_callbacks!(rosetta_init);
+}

--- a/fighters/rosetta/src/status.rs
+++ b/fighters/rosetta/src/status.rs
@@ -1,7 +1,9 @@
 use super::*;
 /// Prevents down b being reused
 unsafe extern "C" fn should_use_special_lw_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
+    if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST) == 1 ||
+	(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) > 130 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) < -130)||
+	(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) > 70 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) < -70){
         false.into()
     } else {
         true.into()


### PR DESCRIPTION
Rosalina downb now acts as a teleport, swapping her and Luma's position.
Frames 17-24 - invulnerable (teleporting)
Frame 38 - Actionable

Rosalina cannot use downb for 300 frames (5 seconds) afterwards, and her being able to use it again is indicated by a flash on her hands and on the HUD. If you're too far away, Rosalina cannot teleport.

https://user-images.githubusercontent.com/69305550/177057739-f0bee2e4-5758-48f0-8e09-984b94f8e265.mp4
