### PR TITLE
Pikachu - disable Quick Attack Jump Cancel after Quick Attack 2

### DIFF
--- a/fighters/pikachu/src/opff.rs
+++ b/fighters/pikachu/src/opff.rs
@@ -6,7 +6,14 @@ use globals::*;
  
 // Disable QA jump cancels if not directly QA into the ground
 unsafe fn disable_qa_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if status_kind == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_WARP {
+        // only allow QAC from QA1
+        if WorkModule::get_int(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_INT_QUICK_ATTACK_COUNT) > 1 {
+            VarModule::on_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC);
+        }
+    }
     if status_kind == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END {
+        // only allow QAC from QA into ground
         if situation_kind == *SITUATION_KIND_AIR && frame > 1.0 {
             VarModule::on_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC);
         }
@@ -15,30 +22,25 @@ unsafe fn disable_qa_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status
 
 // Reset JC disable flag
 unsafe fn reset_jc_disable_flag(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
-    if situation_kind == *SITUATION_KIND_GROUND && status_kind != *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL {
+    if situation_kind == *SITUATION_KIND_GROUND
+    && ![*FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_WARP, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END, *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL].contains(&status_kind)
+    && VarModule::is_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC) {
         VarModule::off_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC);
     }
 }
 
 // JC Quick Attack/Agility
 unsafe fn jc_qa_agility(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
-    let prev_status_kind = StatusModule::prev_status_kind(boma, 0);
-    if status_kind == *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL {
-        if frame > 3.0 {
-            if situation_kind == *SITUATION_KIND_GROUND {
-                if [*FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_WARP,
-                    *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END].contains(&prev_status_kind) {
-                    if  !VarModule::is_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC) {
-                        if boma.is_input_jump() {
-                            if facing * stick_x < 0.0 {
-                                PostureModule::reverse_lr(boma);
-                            }
-                            StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_JUMP_SQUAT, true);
-                        }
-                    }
-                }
-            }
+    if status_kind == *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL
+    && frame > 3.0
+    && situation_kind == *SITUATION_KIND_GROUND
+    && StatusModule::prev_status_kind(boma, 0) == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END
+    && !VarModule::is_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC)
+    && boma.is_input_jump() {
+        if facing * stick_x < 0.0 {
+            PostureModule::reverse_lr(boma);
         }
+        StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_JUMP_SQUAT, true);
     }
 }
 


### PR DESCRIPTION
Quick Attack can only be jump canceled when landing after the first warp.

Resolves #739 