### PR TITLE
Pac-Man - remove ability to hold fruit by holding B during toss

### DIFF
--- a/fighters/pacman/src/acmd/specials.rs
+++ b/fighters/pacman/src/acmd/specials.rs
@@ -152,8 +152,8 @@ unsafe fn pacman_special_air_lw_failure_game(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
-        pacman_special_n_shoot_game,
-        pacman_special_air_n_shoot_game,
+        //pacman_special_n_shoot_game,
+        //pacman_special_air_n_shoot_game,
         pacman_special_lw_failure_game,
         pacman_special_air_lw_failure_game,
     );


### PR DESCRIPTION
Was a clunky input, often occurred accidentally, and is kinda broken balance-wise