### PR TITLE
Dr. Mario - remove multihit upB variant

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -546,7 +546,6 @@ pub mod vars {
             pub const IS_SPECIAL_S_ELECTRIC_BLANKET: i32 = 0x1100;
 
             pub const IS_SPECIAL_HI_UNABLE_CANCEL:   i32 = 0x1100;
-            pub const IS_SPECIAL_HI_SWEETSPOT_HIT:   i32 = 0x1101;
         }
     }
 

--- a/fighters/mariod/src/acmd/specials.rs
+++ b/fighters/mariod/src/acmd/specials.rs
@@ -565,7 +565,6 @@ unsafe fn mariod_special_hi_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_UNABLE_CANCEL);
-        VarModule::off_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT);
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
@@ -579,55 +578,22 @@ unsafe fn mariod_special_hi_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 5.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_MOVE_TRANS);
-        if VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 1, Hash40::new("top"), 12.0, 50, 102, 0, 30, 6.0, 0.0, 6.0, 9.0, None, None, None, 1.25, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        }
-        else{
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 366, 100, 35, 0, 6.25, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 366, 100, 35, 0, 5.0, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
+        AttackModule::clear_all(boma);
+        ATTACK(fighter, 0, 1, Hash40::new("top"), 12.0, 50, 102, 0, 30, 6.0, 0.0, 6.0, 9.0, None, None, None, 1.25, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 7.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            ATTACK(fighter, 0, 1, Hash40::new("top"), 6.0, 74, 66, 0, 64, 4.0, 0.0, 6.5, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
-        }
+        ATTACK(fighter, 0, 1, Hash40::new("top"), 6.0, 74, 66, 0, 64, 4.0, 0.0, 6.5, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 1, Hash40::new("top"), 2.0, 366, 100, 25, 0, 6.25, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 1, Hash40::new("top"), 2.0, 366, 100, 25, 0, 5.0, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
-    }
-    frame(lua_state, 19.0);
-    if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-        }
-    }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-        }
-        else{
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 80, 150, 0, 40, 8.75, 0.0, 5.5, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 80, 150, 0, 40, 4.0, 0.0, 4.0, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
+        AttackModule::clear_all(boma);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    
 }
 
 #[acmd_script( agent = "mariod", script = "effect_specialhi" , category = ACMD_EFFECT , low_priority)]
@@ -675,7 +641,6 @@ unsafe fn mariod_special_air_hi_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_UNABLE_CANCEL);
-        VarModule::off_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT);
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
@@ -688,48 +653,17 @@ unsafe fn mariod_special_air_hi_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 6.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            ATTACK(fighter, 0, 1, Hash40::new("top"), 6.0, 74, 66, 0, 64, 4.0, 0.0, 6.5, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
-        }
-        else{
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 366, 100, 55, 0, 6.25, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 366, 100, 55, 0, 5.0, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
+        ATTACK(fighter, 0, 1, Hash40::new("top"), 6.0, 74, 66, 0, 64, 4.0, 0.0, 6.5, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 1, Hash40::new("top"), 2.0, 366, 100, 40, 0, 6.25, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 1, Hash40::new("top"), 2.0, 366, 100, 40, 0, 5.0, 0.0, 6.5, 4.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
-    }
-    frame(lua_state, 19.0);
-    if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-        }
-    }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT) {
-            AttackModule::clear_all(boma);
-        }
-        else{
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 80, 150, 0, 40, 5.5, 0.0, 8.75, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 80, 150, 0, 40, 3.5, 0.0, 4.0, 4.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_PUNCH);
-        }
+        AttackModule::clear_all(boma);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
     }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    
 }
 
 #[acmd_script( agent = "mariod", script = "effect_specialairhi" , category = ACMD_EFFECT , low_priority)]

--- a/fighters/mariod/src/opff.rs
+++ b/fighters/mariod/src/opff.rs
@@ -19,7 +19,7 @@ unsafe fn super_sheet_stall(boma: &mut BattleObjectModuleAccessor, status_kind: 
     }
 }
 
-unsafe fn up_special_cancel_and_sweetspot_detection(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+unsafe fn up_special_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI{
         if frame < 3.0 {
             if facing * stick_x < 0.0 {
@@ -32,19 +32,12 @@ unsafe fn up_special_cancel_and_sweetspot_detection(boma: &mut BattleObjectModul
                 StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
             }
         }
-        if (situation_kind == *SITUATION_KIND_GROUND && (frame >= 3.0 && frame < 5.0))
-        || (situation_kind == *SITUATION_KIND_AIR && (frame >= 2.0 && frame < 6.0)) {
-            if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT){
-                // Detect if you've hit the sweetspot
-                VarModule::on_flag(boma.object(), vars::mariod::status::IS_SPECIAL_HI_SWEETSPOT_HIT);
-            }
-        }
     }
 }
 
 pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     //super_sheet_stall(boma, status_kind, situation_kind, frame);
-    up_special_cancel_and_sweetspot_detection(boma, status_kind, situation_kind, stick_x, facing, frame);
+    up_special_cancel(boma, status_kind, situation_kind, stick_x, facing, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_MARIOD )]


### PR DESCRIPTION
Changing hitbox properties based on hitting the initial sweetspot or not was unnecessary bloat.

UpB is now a single hit sweetspot + weak late hit, like before. The combo hitbox for grounded upB cancel is still there though.