### PR TITLE
Robin - slight adjustments

### DIFF
--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -222,11 +222,9 @@ pub unsafe fn float_effects(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
                     EffectModule::req_follow(boma, Hash40::new("sys_aura_light"), Hash40::new("bookc"), &Vector3f::zero(), &Vector3f::zero(), 1.5, true, 0, 0, 0, 0, 0, false, false);
                     LAST_EFFECT_SET_COLOR(fighter, 0.0, 1.0, 0.078);  // elwind green
                 }
-                else if timer % 30 == 0 {  // every 30 frames
-                    // drain 2 bars of Elwind
-                    let elwind_meter = WorkModule::get_int(boma, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT);
-                    let float_spend = 2;
-                    WorkModule::set_int(boma, elwind_meter - float_spend, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT);
+                else if timer % 15 == 0 {  // every 15 frames
+                    // drain 1 bar of Elwind
+                    WorkModule::dec_int(boma, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT);
                 }
             }
         }

--- a/fighters/robin/src/opff.rs
+++ b/fighters/robin/src/opff.rs
@@ -14,6 +14,13 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
             }
         }
     }
+    // Allow charge jump cancel even when left stick is down
+    if boma.is_status(*FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_HOLD) {
+        if boma.is_input_jump() && boma.get_num_used_jumps() < boma.get_jump_count_max() {
+            StatusModule::change_status_request_from_script(boma, *FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_JUMP_CANCEL, false);
+            WorkModule::set_int(boma, *FIGHTER_STATUS_KIND_JUMP_AERIAL, *FIGHTER_REFLET_STATUS_SPECIAL_N_HOLD_INT_NEXT_STATUS);
+        }
+    }
 }
 
 // Robin Thunder airdodge cancel


### PR DESCRIPTION
- Float now consumes 1 bar of Elwind every 15 frames, rather than 2 bars every 30 frames.
- Robin can now jump cancel out of aerial Thunder charge when left stick is held down (previously they were the only character with a chargeable move that couldn't do so)

Resolves #224 