### PR TITLE
Falco Shine Fix

### DIFF
--- a/fighters/falco/src/opff.rs
+++ b/fighters/falco/src/opff.rs
@@ -37,10 +37,10 @@ unsafe fn shine_jc_turnaround(fighter: &mut L2CFighterCommon) {
         let fighter_gravity = KineticModule::get_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) as *mut FighterKineticEnergyGravity;
         if fighter.is_status (*SITUATION_KIND_AIR) {
             if fighter.motion_frame() <= 1.0 {
-                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.5, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.0, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
             }
             if fighter.motion_frame() > 1.0 && fighter.motion_frame() <= 3.0 {
-                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.5, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.0, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
             }
             if fighter.motion_frame() > 3.0 {
                 smash::app::lua_bind::FighterKineticEnergyGravity::set_accel(fighter_gravity, -0.02666667);


### PR DESCRIPTION
- Fixed error from a previous PR that prevented falco from halting his vertical momentum when using shine
- 
Fixes #847