### PR TITLE
Turnaround special/B-reverse reimplementation

### DIFF
--- a/fighters/brave/src/opff.rs
+++ b/fighters/brave/src/opff.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 
 unsafe fn nspecial_cancels(fighter: &mut L2CFighterCommon) {
     //PM-like neutral-b canceling
@@ -14,9 +14,6 @@ unsafe fn nspecial_cancels(fighter: &mut L2CFighterCommon) {
 }
 
 unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START]){
-        common::opff::check_b_reverse(fighter);
-    }
     //PM-like down-b canceling
     if fighter.is_status(*FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_CANCEL)
     && fighter.is_situation(*SITUATION_KIND_AIR)
@@ -24,12 +21,6 @@ unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
     {
         WorkModule::set_int(fighter.module_accessor, *STATUS_KIND_NONE, *FIGHTER_BRAVE_STATUS_SPECIAL_LW_HOLD_INT_NEXT_STATUS);
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_AIR_ESCAPE);
-    }
-}
-
-unsafe fn uspecial_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI){
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -69,7 +60,6 @@ pub unsafe fn brave_frame_wrapper(fighter: &mut L2CFighterCommon) {
 
     nspecial_cancels(fighter);
     dspecial_cancels(fighter);
-    uspecial_b_rev(fighter);
     dash_cancel_frizz(fighter);
     woosh_cancel(fighter);
 

--- a/fighters/captain/src/opff.rs
+++ b/fighters/captain/src/opff.rs
@@ -1,6 +1,6 @@
 use super::*;
  
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 
 unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
     if fighter.is_situation(*SITUATION_KIND_AIR)
@@ -12,27 +12,6 @@ unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
     && fighter.get_num_used_jumps() == fighter.get_jump_count_max()
     {
         WorkModule::dec_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_JUMP_COUNT);
-    }
-}
-
-unsafe fn falcon_punch_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_motion(Hash40::new("special_air_n")) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
-unsafe fn falcon_kick_b_reverse(fighter: &mut L2CFighterCommon) {
-    let frame = fighter.motion_frame();
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW)
-    && 1.0 < frame && frame < 5.0
-    && fighter.is_stick_backward() {
-        PostureModule::reverse_lr(fighter.module_accessor);
-        PostureModule::update_rot_y_lr(fighter.module_accessor);
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::B_REVERSED) {
-            return;
-        }
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_AIR);
-        VarModule::on_flag(fighter.battle_object, vars::common::instance::B_REVERSED);
     }
 }
 
@@ -52,7 +31,5 @@ pub unsafe fn captain_frame_wrapper(fighter: &mut L2CFighterCommon) {
     common::opff::fighter_common_opff(fighter);
 
     air_falcon_kick_jump_reset(fighter);
-    falcon_punch_b_reverse(fighter);
-    falcon_kick_b_reverse(fighter);
     repeated_falcon_punch_turnaround(fighter);
 }

--- a/fighters/cloud/src/opff.rs
+++ b/fighters/cloud/src/opff.rs
@@ -1,7 +1,7 @@
 use super::*;
 use globals::*;
 
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 
 unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_CLOUD_STATUS_KIND_SPECIAL_LW_END)
@@ -12,17 +12,9 @@ unsafe fn dspecial_cancels(fighter: &mut L2CFighterCommon) {
     }
 }
 
-// Cloud Limit Charge start and release B-Reverse
-unsafe fn limit_charge_start_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 #[utils::macros::opff(FIGHTER_KIND_CLOUD)]
 pub unsafe fn cloud_frame_wrapper(fighter: &mut L2CFighterCommon) {
     common::opff::fighter_common_opff(fighter);
 
     dspecial_cancels(fighter);
-    limit_charge_start_b_rev(fighter);
 }

--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -60,8 +60,6 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
             VarModule::off_flag(boma.object(), vars::common::instance::CAN_ESCAPE_TUMBLE);
         }
 
-        VarModule::off_flag(boma.object(), vars::common::instance::B_REVERSED);
-
         // Walk through other fighters
         JostleModule::set_team(boma, 0);
 

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -16,6 +16,7 @@ pub mod is_flag;
 pub mod controls;
 pub mod jumps;
 pub mod stage_hazards;
+pub mod set_fighter_status_data;
 
 pub fn install() {
     energy::install();
@@ -34,6 +35,7 @@ pub fn install() {
     momentum_transfer::install();
     jumps::install();
     stage_hazards::install();
+    set_fighter_status_data::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/common/src/function_hooks/set_fighter_status_data.rs
+++ b/fighters/common/src/function_hooks/set_fighter_status_data.rs
@@ -53,9 +53,13 @@ unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, ar
         || (boma.kind() == *FIGHTER_KIND_PALUTENA
             && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
         {
-            new_status_attr = *FIGHTER_STATUS_ATTR_START_TURN as u32;
+            // if b-reverse flag does not already exist in status_attr bitmask
+            if status_attr & *FIGHTER_STATUS_ATTR_START_TURN as u32 == 0 {
+                // add b-reverse flag to status_attr bitmask
+                new_status_attr = status_attr + *FIGHTER_STATUS_ATTR_START_TURN as u32;
+            }
         }
-        
+
     }
 
     original!()(boma, arg2, treaded_kind, arg4, arg5, arg6, log_mask_flag, new_status_attr, power_up_attack_bit, arg10)

--- a/fighters/common/src/function_hooks/set_fighter_status_data.rs
+++ b/fighters/common/src/function_hooks/set_fighter_status_data.rs
@@ -1,0 +1,65 @@
+use super::*;
+use globals::*;
+
+//=================================================================
+//== FighterStatusModuleImpl::set_fighter_status_data
+//=================================================================
+#[skyline::hook(replace=FighterStatusModuleImpl::set_fighter_status_data)]
+unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, arg2: bool, treaded_kind: i32, arg4: bool, arg5: bool, arg6: bool, log_mask_flag: u64, status_attr: u32, power_up_attack_bit: u32, arg10: u32) {
+    let id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
+    let mut new_status_attr = status_attr;
+
+    if boma.is_fighter() {
+        if (boma.kind() == *FIGHTER_KIND_BRAVE
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START, *FIGHTER_STATUS_KIND_SPECIAL_HI]))
+        || (boma.kind() == *FIGHTER_KIND_CAPTAIN
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_CLOUD
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_DONKEY
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N]))
+        || (boma.kind() == *FIGHTER_KIND_IKE
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S]))
+        || (boma.kind() == *FIGHTER_KIND_KIRBY
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S]))
+        || (boma.kind() == *FIGHTER_KIND_KROOL
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START]))
+        || (boma.kind() == *FIGHTER_KIND_LINK
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST]))
+        || (boma.kind() == *FIGHTER_KIND_LITTLEMAC
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START, *FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_START]))
+        || (boma.kind() == *FIGHTER_KIND_MARIO
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT]))
+        || (boma.kind() == *FIGHTER_KIND_MIIGUNNER
+            && boma.is_status_one_of(&[*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_GROUND, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_AIR, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_GROUND, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_AIR]))
+        || (boma.kind() == *FIGHTER_KIND_PACMAN
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N]))
+        || (boma.kind() == *FIGHTER_KIND_PIKMIN
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_RICHTER
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_SAMUS
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1G, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1A, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S2G, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S2A]))
+        || (boma.kind() == *FIGHTER_KIND_SIMON
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_TOONLINK
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_YOUNGLINK
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        || (boma.kind() == *FIGHTER_KIND_ZELDA
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2]))
+        || (boma.kind() == *FIGHTER_KIND_PALUTENA
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
+        {
+            new_status_attr = *FIGHTER_STATUS_ATTR_START_TURN as u32;
+        }
+    }
+
+    original!()(boma, arg2, treaded_kind, arg4, arg5, arg6, log_mask_flag, new_status_attr, power_up_attack_bit, arg10)
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        set_fighter_status_data_hook,
+    );
+}

--- a/fighters/common/src/function_hooks/set_fighter_status_data.rs
+++ b/fighters/common/src/function_hooks/set_fighter_status_data.rs
@@ -10,6 +10,8 @@ unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, ar
     let mut new_status_attr = status_attr;
 
     if boma.is_fighter() {
+
+        // this handles turnaround special/b-reversible moves
         if (boma.kind() == *FIGHTER_KIND_BRAVE
             && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_START, *FIGHTER_STATUS_KIND_SPECIAL_HI]))
         || (boma.kind() == *FIGHTER_KIND_CAPTAIN
@@ -53,6 +55,7 @@ unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, ar
         {
             new_status_attr = *FIGHTER_STATUS_ATTR_START_TURN as u32;
         }
+        
     }
 
     original!()(boma, arg2, treaded_kind, arg4, arg5, arg6, log_mask_flag, new_status_attr, power_up_attack_bit, arg10)

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -383,25 +383,6 @@ pub unsafe fn teeter_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     }
 }
 
-#[utils::export(common::opff)]
-pub unsafe fn check_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.global_table[CURRENT_FRAME].get_i32() == 0 {
-        if fighter.is_stick_backward() {
-            PostureModule::reverse_lr(fighter.module_accessor);
-            PostureModule::update_rot_y_lr(fighter.module_accessor);
-        }
-    }
-    if fighter.global_table[CURRENT_FRAME].get_i32() == 3 {
-        if fighter.is_stick_backward()
-        && !VarModule::is_flag(fighter.battle_object, vars::common::instance::B_REVERSED) {
-            PostureModule::reverse_lr(fighter.module_accessor);
-            PostureModule::update_rot_y_lr(fighter.module_accessor);
-            KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            VarModule::on_flag(fighter.battle_object, vars::common::instance::B_REVERSED);
-        }
-    }
-}
-
 pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32, curr_frame: f32) {
     tumble_exit(boma, cat[0], status_kind, situation_kind);
     non_tumble_di(fighter, lua_state, l2c_agent, boma, status_kind);

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -58,13 +58,6 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
             }
         }
     } 
-}
-
-// DK Giant Punch charge B-Reverse
-unsafe fn giant_punch_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
-        common::opff::check_b_reverse(fighter);
-    }
 }
 
 // DK Headbutt aerial stall
@@ -129,7 +122,6 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     barrel_timer(fighter, boma, id);
     barrel_reset(fighter, id, status_kind);
     barrel_training(fighter, id, status_kind);
-    giant_punch_b_reverse(fighter);
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
     barrel_pull(fighter, boma, status_kind, situation_kind);
     headbutt_aerial_stall(fighter, boma, id, status_kind, situation_kind, frame);

--- a/fighters/ganon/src/opff.rs
+++ b/fighters/ganon/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -31,29 +31,6 @@ unsafe fn aerial_wiz_foot_jump_reset_bounce(boma: &mut BattleObjectModuleAccesso
 //     }
 // }
 
-// Warlock Punch B-Reverse
-// unsafe fn warlock_punch_b_reverse(fighter: &mut L2CFighterCommon) {
-//     if fighter.is_motion(Hash40::new("special_air_n")) {
-//         common::opff::check_b_reverse(fighter);
-//     }
-// }
-
-// Wizard's Foot B-Reverse
-// unsafe fn wizards_foot_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
-//     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-//         if frame > 1.0 && frame < 5.0 {
-//             if stick_x * facing < 0.0 {
-//                 PostureModule::reverse_lr(boma);
-//                 PostureModule::update_rot_y_lr(boma);
-//                 if  !VarModule::is_flag(boma.object(), vars::common::B_REVERSED) {
-//                     KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION_AIR);
-//                     VarModule::on_flag(boma.object(), vars::common::B_REVERSED);
-//                 }
-//             }
-//         }
-//     }
-// }
-
 // Repeated Warlock Punch turnaround
 // unsafe fn repeated_warlock_punch_turnaround(boma: &mut BattleObjectModuleAccessor, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
 //     if status_kind == *FIGHTER_GANON_STATUS_KIND_SPECIAL_N_TURN {
@@ -67,9 +44,7 @@ unsafe fn aerial_wiz_foot_jump_reset_bounce(boma: &mut BattleObjectModuleAccesso
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aerial_wiz_foot_jump_reset_bounce(boma, status_kind, situation_kind);
-    // wizards_foot_b_reverse(boma, id, status_kind, stick_x, facing, frame);
     // dtaunt_counter(boma, motion_kind, frame);
-    // warlock_punch_b_reverse(fighter);
     // repeated_warlock_punch_turnaround(boma, status_kind, stick_x, facing, frame);
 }
 

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -14,13 +14,6 @@ unsafe fn aether_drift(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
             let motion_vec = x_motion_vec(0.3, stick_x);
             KineticModule::add_speed_outside(boma, *KINETIC_OUTSIDE_ENERGY_TYPE_WIND_NO_ADDITION, &motion_vec);
         }
-    }
-}
-
-// Ike Quick Draw B-Reverse
-unsafe fn quickdraw_b_reverse(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -393,7 +386,6 @@ unsafe fn fair_wrist_bend(boma: &mut BattleObjectModuleAccessor) {
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aether_drift(boma, status_kind, situation_kind, stick_x, facing);
-    quickdraw_b_reverse(fighter);
     quickdraw_jump_attack_cancels(boma, id, status_kind, situation_kind, cat[0], stick_x, facing);
     quickdraw_instakill(fighter, boma);
     quickdraw_attack_arm_bend(boma);

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -41,15 +41,6 @@ unsafe fn hammer_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, stat
         }
     }
 }
-
-// Hammer Flip B-Reverse
-unsafe fn hammer_flip_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
-
 
 // Magic Series
 unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -307,7 +298,6 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     final_cutter_cancel(boma, id, status_kind, cat[0], frame);
     hammer_fastfall_landcancel(boma, status_kind, situation_kind, cat[1], stick_y);
-    hammer_flip_b_reverse(fighter);
 
 
     // Frame Data

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -9,13 +9,6 @@ unsafe fn jetpack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32
         if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_AIR_END, true);
         }
-    }
-}
-
-// Propellerpack B-Reverse
-unsafe fn propellerpack_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START]) {
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -35,7 +28,6 @@ unsafe fn crownerang_item_grab(boma: &mut BattleObjectModuleAccessor, status_kin
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     jetpack_cancel(boma, status_kind, cat[0]);
     //crownerang_item_grab(boma, status_kind, cat[0]);
-    propellerpack_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_KROOL )]

--- a/fighters/link/src/opff.rs
+++ b/fighters/link/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -11,13 +11,6 @@ unsafe fn bow_fastfall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
                 WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
             }
         }
-    }
-}
-
-// Link Remote Bomb pull and detonation B-Reverse
-unsafe fn bomb_n_deton_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_LINK_STATUS_KIND_SPECIAL_LW_BLAST]) {
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -101,7 +94,6 @@ pub unsafe extern "Rust" fn links_common(fighter: &mut smash::lua2cpp::L2CFighte
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_fastfall(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_n_deton_b_reverse(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LINK )]

--- a/fighters/littlemac/src/opff.rs
+++ b/fighters/littlemac/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -47,20 +47,6 @@ unsafe fn straight_lunge_cancels(boma: &mut BattleObjectModuleAccessor, status_k
     }
 }
 
-// B-Reverse Straight Lunge charge
-unsafe fn straight_lunge_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START]) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
-// B-Reverse Rising Uppercut
-unsafe fn rising_uppercut_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_START]) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 // Tech Roll distance help
 unsafe fn tech_roll_help(boma: &mut BattleObjectModuleAccessor, motion_kind: u64, facing: f32, frame: f32) {
     if frame < 5.0 {
@@ -92,8 +78,6 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     normal_side_special(boma, status_kind);
     straight_lunge_cancels(boma, status_kind, situation_kind, cat[0], cat[1], frame);
-    straight_lunge_charge_b_rev(fighter);
-    rising_uppercut_b_rev(fighter);
     tech_roll_help(boma, motion_kind, facing, frame);
     nspecial_cancels(boma, status_kind, situation_kind, cat[0]);
 }

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -95,13 +95,6 @@ unsafe fn up_b_wall_jump(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
     }
 }
 
-// F.L.U.D.D. B-Reverse
-unsafe fn fludd_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT]) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32) {
     //PM-like down-b canceling
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
@@ -181,7 +174,6 @@ unsafe fn noknok_training(fighter: &mut L2CFighterCommon, id: usize, status_kind
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     //dair_mash_rise(fighter, boma, id, motion_kind, situation_kind, frame);
     up_b_wall_jump(fighter, boma, id, status_kind, situation_kind, cat[0], frame);
-    fludd_b_reverse(fighter);
     dspecial_cancels(boma, status_kind, situation_kind, cat[0]);
     //double_fireball(fighter, boma);
     noknok_timer(fighter, boma, id);

--- a/fighters/metaknight/src/opff.rs
+++ b/fighters/metaknight/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -76,7 +76,7 @@ unsafe fn laser_blaze_ff_land_cancel(boma: &mut BattleObjectModuleAccessor, situ
     }
 }
 
-unsafe fn missile_land_cancel_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
+unsafe fn missile_land_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
     if [*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_GROUND,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_AIR,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_GROUND,
@@ -84,7 +84,6 @@ unsafe fn missile_land_cancel_b_rev(fighter: &mut L2CFighterCommon, boma: &mut B
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -121,7 +120,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     nspecial_cancels(boma, status_kind, situation_kind, cat[0], cat[1]);
     absorb_vortex_jc_turnaround_shinejump_cancel(boma, status_kind, situation_kind, cat[0], stick_x, facing, frame);
     laser_blaze_ff_land_cancel(boma, situation_kind, motion_kind, cat[1], stick_y);
-    missile_land_cancel_b_rev(fighter, boma, id, status_kind, situation_kind);
+    missile_land_cancel(fighter, boma, id, status_kind, situation_kind);
 	cannon_jump_kick_actionability(boma, id, status_kind, frame);
 	arm_rocket_airdash(boma, id, status_kind, frame);
 

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -29,17 +29,9 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
     }
 }
 
-// Pac-Man Bonus Fruit charge B-Reverse
-unsafe fn bonus_fruit_charge_b_rev(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind);
     bonus_fruit_toss_ac(boma, status_kind, situation_kind, cat[0], frame);
-    bonus_fruit_charge_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PACMAN )]

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -6,7 +6,6 @@ use globals::*;
  
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     palutena_teleport_cancel(boma, id, status_kind, situation_kind, cat[0]);
-    palutena_counter_b_reverse(boma, id, status_kind, situation_kind, stick_x, facing, frame, cat[0]);
     aegis_reflector_timer(fighter, boma, id);
     aegis_reflector_reset(fighter, id, status_kind);
     aegis_reflector_training(fighter, id, status_kind);
@@ -66,22 +65,6 @@ pub unsafe fn palutena_teleport_cancel(boma: &mut BattleObjectModuleAccessor, id
     }
     else {
         VarModule::off_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-    }
-}
-
-pub unsafe fn palutena_counter_b_reverse(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, stick_x: f32, facing: f32, frame: f32, cat1: i32) {
-    if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-        if frame < 5.0 {
-            if stick_x * facing < 0.0 {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                if frame > 1.0 && frame < 5.0 &&  !VarModule::is_flag(boma.object(), vars::common::instance::B_REVERSED) {
-                    let b_reverse = Vector3f{x: -1.0, y: 1.0, z: 1.0};
-                    KineticModule::mul_speed(boma, &b_reverse, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                    VarModule::on_flag(boma.object(), vars::common::instance::B_REVERSED);
-                }
-            }
-        }
     }
 }
 

--- a/fighters/pikmin/src/opff.rs
+++ b/fighters/pikmin/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -12,13 +12,6 @@ unsafe fn winged_pikmin_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
         if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR) {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ESCAPE_AIR, true);
         }
-    }
-}
-
-// Olimar Pikmin Order B-Reverse
-unsafe fn pikmin_order_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -133,7 +126,6 @@ unsafe fn pikmin_antenna_indicator(fighter: &mut L2CFighterCommon) {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     winged_pikmin_cancel(boma, status_kind, cat[0]);
-    pikmin_order_b_reverse(fighter);
     solimar_scaling(boma, status_kind, frame);
     pikmin_antenna_indicator(fighter);
 }

--- a/fighters/richter/src/opff.rs
+++ b/fighters/richter/src/opff.rs
@@ -1,17 +1,10 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
-// Richter Holy Water B-Reverse
-unsafe fn holy_water_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon) {
-    holy_water_b_rev(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_RICHTER )]

--- a/fighters/samus/src/opff.rs
+++ b/fighters/samus/src/opff.rs
@@ -1,10 +1,10 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
  
-pub unsafe fn land_cancel_and_b_reverse(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
+pub unsafe fn missile_land_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32) {
     if [*FIGHTER_STATUS_KIND_SPECIAL_S,
         *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1G,
         *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_S1A,
@@ -13,7 +13,6 @@ pub unsafe fn land_cancel_and_b_reverse(fighter: &mut L2CFighterCommon, boma: &m
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -71,7 +70,7 @@ pub unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kin
 #[no_mangle]
 pub unsafe extern "Rust" fn common_samus(fighter: &mut L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        land_cancel_and_b_reverse(fighter, &mut *info.boma, info.id, info.status_kind, info.situation_kind);
+        missile_land_cancel(fighter, &mut *info.boma, info.id, info.status_kind, info.situation_kind);
         morphball_crawl(&mut *info.boma, info.status_kind, info.frame);
         nspecial_cancels(&mut *info.boma, info.status_kind, info.situation_kind);
     }

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -1,10 +1,10 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
  
-unsafe fn holy_water_ac_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+unsafe fn holy_water_ac(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
         if frame > 19.0 {
             if boma.is_cat_flag(Cat1::AirEscape) && !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_ESCAPE_AIR) {
@@ -13,12 +13,11 @@ unsafe fn holy_water_ac_b_rev(fighter: &mut L2CFighterCommon, boma: &mut BattleO
                 }
             }
         }
-        common::opff::check_b_reverse(fighter);
     }
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    holy_water_ac_b_rev(fighter, boma, id, status_kind, situation_kind, cat[0], frame);
+    holy_water_ac(fighter, boma, id, status_kind, situation_kind, cat[0], frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_SIMON )]

--- a/fighters/toonlink/src/opff.rs
+++ b/fighters/toonlink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -16,13 +16,6 @@ unsafe fn heros_bow_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
     }
 }
 
-// Toon Link Bomb pull B-Reverse
-unsafe fn bomb_pull_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 // Lengthen sword
 unsafe fn sword_length(boma: &mut BattleObjectModuleAccessor) {
 	let long_sword_scale = Vector3f{x: 1.2, y: 1.0, z: 1.0};
@@ -36,7 +29,6 @@ extern "Rust" {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     heros_bow_ff(boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_pull_b_reverse(fighter);
 	sword_length(boma);
     
 

--- a/fighters/younglink/src/opff.rs
+++ b/fighters/younglink/src/opff.rs
@@ -1,5 +1,5 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
 
@@ -22,13 +22,6 @@ unsafe fn fire_arrow_ff(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
                 WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
             }
         }
-    }
-}
-
-// Young Link Bomb pull B-Reverse
-unsafe fn bomb_b_reverse(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
     }
 }
 
@@ -92,7 +85,6 @@ unsafe fn holdable_dair(boma: &mut BattleObjectModuleAccessor, motion_kind: u64,
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     special_s_article_fix(fighter, boma, id, status_kind, situation_kind, frame);
     fire_arrow_ff(fighter, boma, status_kind, situation_kind, cat[1], stick_y);
-    bomb_b_reverse(fighter);
     bombchu_timer(fighter, boma, id);
     bombchu_reset(fighter, id, status_kind);
     bombchu_training(fighter, id, status_kind);

--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -1,18 +1,11 @@
 // opff import
-utils::import_noreturn!(common::opff::{fighter_common_opff, check_b_reverse});
+utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
  
 unsafe fn teleport_tech(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     if boma.is_status(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2) {
         if compare_mask(ControlModule::get_pad_flag(boma), *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER) {
-            if boma.is_stick_backward()
-            && !VarModule::is_flag(boma.object(), vars::common::instance::B_REVERSED) {
-                PostureModule::reverse_lr(boma);
-                PostureModule::update_rot_y_lr(boma);
-                KineticModule::mul_speed(boma, &Vector3f::new(-1.0, 1.0, 1.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-                VarModule::on_flag(boma.object(), vars::common::instance::B_REVERSED);
-            }
             boma.change_status_req(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_3, false);
             ControlModule::clear_command(boma, false);
         }
@@ -73,13 +66,6 @@ unsafe fn neutral_special_cancels(boma: &mut BattleObjectModuleAccessor, status_
     }
 }
 
- 
-unsafe fn phantom_b_rev(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        common::opff::check_b_reverse(fighter);
-    }
-}
-
 unsafe fn dins_fire_land_cancel(boma: &mut BattleObjectModuleAccessor){
     if boma.is_status(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_S_END) && boma.is_situation(*SITUATION_KIND_GROUND) && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
         boma.change_status_req(*FIGHTER_STATUS_KIND_LANDING, false);
@@ -89,7 +75,6 @@ unsafe fn dins_fire_land_cancel(boma: &mut BattleObjectModuleAccessor){
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     teleport_tech(fighter, boma);
     dins_fire_land_cancel(boma);
-    //phantom_b_rev(fighter);
 
     neutral_special_cancels(boma, status_kind, situation_kind, cat[0]);
 }


### PR DESCRIPTION
Turnaround special/B-reverse now uses vanilla logic, rather than our hacky workaround method.

In other words, inputs for turnaround special/B-reverses should now be identical for moves that were not reversible in vanilla.

Should remove the jank with our custom B-reversible moves.

Fixes #890