### PR TITLE
Remove random tripping

### DIFF
--- a/fighters/common/Cargo.toml
+++ b/fighters/common/Cargo.toml
@@ -13,3 +13,4 @@ smashline = { git = "https://github.com/blu-dev/smashline.git", branch = "develo
 utils = { package = "dynamic", path = "../../dynamic" }
 ninput = { git = "https://github.com/blu-dev/ninput" }
 interpolation = "0.2.0" # for f32::lerp
+smash2 = { package = "smash", git = "https://github.com/blu-dev/smash-rs" }

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -1,0 +1,18 @@
+use super::*;
+use utils::ext::*;
+use std::arch::asm;
+
+
+#[skyline::hook(offset = 0x3dc160)]
+unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut smash2::app::AttackData) {
+    // if a hitbox does not intentionally trip 100% of time, remove random trip chance
+    if data.slip < 1.0 {
+        // -1.0 trip chance prevents any tripping whatsoever
+        data.slip = -1.0;
+    }
+    call_original!(module, id, group, data)
+}
+
+pub fn install() {
+    skyline::install_hooks!(attack_module_set_attack);
+}

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -16,6 +16,7 @@ pub mod is_flag;
 pub mod controls;
 pub mod jumps;
 pub mod stage_hazards;
+pub mod attack;
 
 pub fn install() {
     energy::install();
@@ -34,6 +35,7 @@ pub fn install() {
     momentum_transfer::install();
     jumps::install();
     stage_hazards::install();
+    attack::install();
 
     unsafe {
         // Handles getting rid of the kill zoom


### PR DESCRIPTION
Removed the mechanic that allowed any move to have a random trip chance.

Tripping has been changed into an all-or-nothing mechanic; either a move trips 100% of the time, or doesn't trip at all.

Currently, the only tripping moves that remain are Kazuya's Stature Smash, Pichu's ftilt, and Diddy's banana.