### PR TITLE
Suicide throw adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -216,6 +216,8 @@ pub mod vars {
 
             pub const IS_JAB_LOCK_ROLL: i32 = 0x1000;
 
+            pub const SUICIDE_THROW_CAN_CLATTER: i32 = 0x1000;
+
             // ints
 
             pub const DOWN_STAND_FB_KIND: i32 = 0x1000;

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -79,7 +79,16 @@ pub unsafe fn airdodge_refresh_on_hit_disable(boma: &mut BattleObjectModuleAcces
 }
 
 pub unsafe fn suicide_throw_mashout(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_THROWN) && LinkModule::get_parent_status_kind(boma, *LINK_NO_CAPTURE) == *FIGHTER_STATUS_KIND_THROW_KIRBY as u64 {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_THROWN) {
+        // add suicide throws here
+        if !((boma.get_grabber_boma().kind() == *FIGHTER_KIND_KIRBY
+            && [hash40("throw_f"), hash40("throw_b")].contains(&LinkModule::get_parent_motion_kind(boma, *LINK_NO_CAPTURE)))
+        || (boma.get_grabber_boma().kind() == *FIGHTER_KIND_ROBOT
+            && LinkModule::get_parent_motion_kind(boma, *LINK_NO_CAPTURE) == hash40("throw_hi")))
+        {
+            return;
+        }
+        
         get_fighter_common_from_accessor(boma.get_grabber_boma()).clear_lua_stack();
         get_fighter_common_from_accessor(boma.get_grabber_boma()).push_lua_stack(&mut L2CValue::new_int(*FIGHTER_KINETIC_ENERGY_ID_MOTION as u64));
         // if in descent of suicide throw

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -14,6 +14,7 @@ use smash::app::sv_animcmd::*;
 use smash_script::*;
 use crate::misc::*;
 use globals::*;
+use crate::util::get_fighter_common_from_accessor;
 
 unsafe fn hitstun_overlay_orange(boma: &mut BattleObjectModuleAccessor, id: usize) {
     let cmb_vec1 = Vector4f{x: 0.949, y: 0.5137, z: 0.08643, w: 0.69};
@@ -79,31 +80,40 @@ pub unsafe fn airdodge_refresh_on_hit_disable(boma: &mut BattleObjectModuleAcces
 
 pub unsafe fn suicide_throw_mashout(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_THROWN) && LinkModule::get_parent_status_kind(boma, *LINK_NO_CAPTURE) == *FIGHTER_STATUS_KIND_THROW_KIRBY as u64 {
-        if fighter.global_table[CURRENT_FRAME].get_i32() <= 0 {
-            let throw_frame = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.throw_frame");
-            let damage_frame_mul = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.damage_frame_mul");
-            let recovery_frame = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.recovery_frame");
-            let clatter_frame_base = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_base");
-            let clatter_frame_max = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_max");
-            let clatter_frame_min = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_min");
-            let thrown_damage = DamageModule::damage(boma, 0);
-            let thrower_damage = DamageModule::damage(boma.get_grabber_boma(), 0);
-            let damage_difference = thrower_damage - thrown_damage;
-            let clatter_frame_add = damage_difference * damage_frame_mul;
-            let mut clatter_frame = clatter_frame_base + clatter_frame_add;
+        get_fighter_common_from_accessor(boma.get_grabber_boma()).clear_lua_stack();
+        get_fighter_common_from_accessor(boma.get_grabber_boma()).push_lua_stack(&mut L2CValue::new_int(*FIGHTER_KINETIC_ENERGY_ID_MOTION as u64));
+        // if in descent of suicide throw
+        if GroundModule::get_correct(boma.get_grabber_boma()) == *GROUND_CORRECT_KIND_AIR
+        && (app::sv_kinetic_energy::get_speed_y(get_fighter_common_from_accessor(boma.get_grabber_boma()).lua_state_agent) < -0.5 || KineticModule::get_kinetic_type(boma.get_grabber_boma()) == *FIGHTER_KINETIC_TYPE_FALL) {
+            if !VarModule::is_flag(boma.object(), vars::common::status::SUICIDE_THROW_CAN_CLATTER) {
+                // allow mashing to begin
+                let throw_frame = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.throw_frame");
+                let damage_frame_mul = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.damage_frame_mul");
+                let recovery_frame = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.recovery_frame");
+                let clatter_frame_base = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_base");
+                let clatter_frame_max = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_max");
+                let clatter_frame_min = ParamModule::get_float(fighter.object(), ParamType::Common, "suicide_throw.clatter_frame_min");
+                let thrown_damage = DamageModule::damage(boma, 0);
+                let thrower_damage = DamageModule::damage(boma.get_grabber_boma(), 0);
+                let damage_difference = thrower_damage - thrown_damage;
+                let clatter_frame_add = damage_difference * damage_frame_mul;
+                let mut clatter_frame = clatter_frame_base + clatter_frame_add;
 
-            if clatter_frame < clatter_frame_min {
-                clatter_frame = clatter_frame_min;
+                if clatter_frame < clatter_frame_min {
+                    clatter_frame = clatter_frame_min;
+                }
+                if clatter_frame > clatter_frame_max {
+                    clatter_frame = clatter_frame_max;
+                }
+                
+                ControlModule::start_clatter(boma, throw_frame, recovery_frame, clatter_frame, 127, 0, false, false);
+                VarModule::on_flag(boma.object(), vars::common::status::SUICIDE_THROW_CAN_CLATTER);
             }
-            if clatter_frame > clatter_frame_max {
-                clatter_frame = clatter_frame_max;
-            }
-            
-            ControlModule::start_clatter(boma, throw_frame, recovery_frame, clatter_frame, 127, 0, false, false);
-        }
-        else {
-            if ControlModule::get_clatter_time(boma, 0) <= 0.0 {
-                fighter.change_status(FIGHTER_STATUS_KIND_CAPTURE_JUMP.into(), false.into());
+            else {
+                // can only mash out during descent, before thrower reaches ground
+                if ControlModule::get_clatter_time(boma, 0) <= 0.0 {
+                    fighter.change_status(FIGHTER_STATUS_KIND_CAPTURE_JUMP.into(), false.into());
+                }
             }
         }
     }

--- a/fighters/kirby/src/acmd/throws.rs
+++ b/fighters/kirby/src/acmd/throws.rs
@@ -169,7 +169,7 @@ unsafe fn throwlw_game(fighter: &mut L2CAgentBase) {
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
         AttackModule::clear_all(boma);
         let opponent_boma = fighter.get_grabbed_opponent_boma();
-        VarModule::on_flag(opponent_boma.object(), vars::common::instance::DISABLE_GROUND_BOUNCE);
+        VarModule::on_flag(opponent_boma.object(), vars::common::instance::IS_KNOCKDOWN_THROW);
         FT_MOTION_RATE(fighter, 0.75);
     }
     frame(lua_state, 68.0); {

--- a/fighters/kirby/src/acmd/throws.rs
+++ b/fighters/kirby/src/acmd/throws.rs
@@ -96,6 +96,18 @@ unsafe fn throwf_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
     }
+    frame(lua_state, 50.0);
+    if is_excute(fighter) {
+        // reduce fthrow bounce height
+        KineticModule::unable_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_AIR_BRAKE);
+    }
+    frame(lua_state, 55.0);
+    if is_excute(fighter) {
+        // enable aerial drift before fthrow anim is over
+        KineticModule::enable_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        KineticModule::enable_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    }
 }
 
 #[acmd_script( agent = "kirby", script = "game_throwb", category = ACMD_GAME , low_priority)]
@@ -123,13 +135,58 @@ unsafe fn throwb_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "kirby", script = "game_throwlw", category = ACMD_GAME , low_priority)]
+unsafe fn throwlw_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 2.0, 270, 100, 126, 0, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+    }
+    frame(lua_state, 9.0);
+    for _ in 0..9 {
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.0, 270, 100, 10, 0, 5.8, 0.0, 4.0, 3.2, None, None, None, 0.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+            AttackModule::set_catch_only_all(boma, true, false);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        wait(lua_state, 2.0);
+    }
+    frame(lua_state, 56.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.0, 90, 100, 0, 10, 5.8, 0.0, 4.0, 2.4, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        AttackModule::set_catch_only_all(boma, true, false);
+        CHECK_FINISH_CAMERA(fighter, 8, 4);
+        //FighterCutInManager::set_throw_finish_zoom_rate(boma, 1.8);
+        //FighterCutInManager::set_throw_finish_offset(boma, 0, 0, 0);
+    }
+    frame(lua_state, 58.0);
+    if is_excute(fighter) {
+        ModelModule::set_joint_translate(boma, Hash40::new("throw"), &Vector3f{x: 0.0, y: 0.0, z: -1.0}, false, false);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
+        AttackModule::clear_all(boma);
+        let opponent_boma = fighter.get_grabbed_opponent_boma();
+        VarModule::on_flag(opponent_boma.object(), vars::common::instance::DISABLE_GROUND_BOUNCE);
+        FT_MOTION_RATE(fighter, 0.75);
+    }
+    frame(lua_state, 68.0); {
+        if is_excute(fighter) {
+            CancelModule::enable_cancel(boma);
+        }
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         game_catch,
         game_catchdash,
         game_catchturn,
         throwf_game,
-        throwb_game
+        throwb_game,
+        throwlw_game
     );
 }
 

--- a/fighters/kirby/src/acmd/throws.rs
+++ b/fighters/kirby/src/acmd/throws.rs
@@ -146,7 +146,7 @@ unsafe fn throwlw_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 9.0);
     for _ in 0..9 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.0, 270, 100, 10, 0, 5.8, 0.0, 4.0, 3.2, None, None, None, 0.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 0.5, 270, 100, 10, 0, 5.8, 0.0, 4.0, 3.2, None, None, None, 0.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
             AttackModule::set_catch_only_all(boma, true, false);
         }
         wait(lua_state, 2.0);
@@ -157,7 +157,7 @@ unsafe fn throwlw_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 56.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.0, 90, 100, 0, 10, 5.8, 0.0, 4.0, 2.4, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.5, 90, 100, 0, 10, 5.8, 0.0, 4.0, 2.4, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         AttackModule::set_catch_only_all(boma, true, false);
         CHECK_FINISH_CAMERA(fighter, 8, 4);
         //FighterCutInManager::set_throw_finish_zoom_rate(boma, 1.8);
@@ -165,7 +165,7 @@ unsafe fn throwlw_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 58.0);
     if is_excute(fighter) {
-        ModelModule::set_joint_translate(boma, Hash40::new("throw"), &Vector3f{x: 0.0, y: 0.0, z: -1.0}, false, false);
+        ModelModule::set_joint_translate(boma, Hash40::new("throw"), &Vector3f{x: 0.0, y: -5.0, z: 6.868900}, false, false);
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
         AttackModule::clear_all(boma);
         let opponent_boma = fighter.get_grabbed_opponent_boma();

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -33,11 +33,11 @@
     <float hash="perfect_pivot_speed_mul">-0.75</float>
     <float hash="late_perfect_pivot_speed_mul">-0.5</float>
     <struct hash="suicide_throw">
-        <float hash="throw_frame">100.0</float>
-        <float hash="damage_frame_mul">0.067</float>
+        <float hash="throw_frame">50.0</float>
+        <float hash="damage_frame_mul">0.07</float>
         <float hash="recovery_frame">1.0</float>
-        <float hash="clatter_frame_base">6.0</float>
-        <float hash="clatter_frame_max">13.0</float>
-        <float hash="clatter_frame_min">1.0</float>
+        <float hash="clatter_frame_base">9.0</float>
+        <float hash="clatter_frame_max">16.0</float>
+        <float hash="clatter_frame_min">2.0</float>
     </struct>
 </struct>


### PR DESCRIPTION
Suicide throws (Kirby fthrow/bthrow, ROB uthrow) are now only able to be mashed out of during their descent, before the thrower reaches the ground. This makes them more reliable when used on-stage for combos.
Mash-out difficulty still scales based on % difference between thrown player and thrower.

Fixes #901 