### PR TITLE
Fix JC usmash logic

### DIFF
--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -135,16 +135,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
-    // Walks through and clears all item throw commands.
-    if fighter.global_table[CMD_CAT3].get_i32() & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_ALL != 0 {
-        let up = fighter.global_table[STICK_Y].get_f32() >= 0.2;
-        for x in 0..7 {
-            if x != 0 && x != 3 || !up {
-                ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, x);
-            }
-        }
-    }
-    if fighter.sub_transition_group_check_ground_item().get_bool() {
+    if fighter.global_table[STICK_Y].get_f32() >= 0.2 && fighter.sub_transition_group_check_ground_item().get_bool() {
         return 0.into();
     }
     let cat1 = fighter.global_table[CMD_CAT1].get_i32();

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -135,33 +135,37 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
-    if !fighter.sub_transition_group_check_ground_item().get_bool() {
-        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
-            && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
-            && fighter.is_situation(*SITUATION_KIND_GROUND) {
-            fighter.change_status(
-                L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
-                L2CValue::Bool(true)
-            );
-        } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
-            // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-            if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
-            && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
-                if fighter.global_table[0x58].get_bool() != false && {
-                    let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
-                    callable(fighter).get_bool()
-                } {
-                    return L2CValue::I32(0);
-                }
-                // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
-                if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
-                    && fighter.is_situation(*SITUATION_KIND_GROUND) {
-                    fighter.change_status(
-                        L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
-                        L2CValue::Bool(true)
-                    );
-                }
+    let cat3 = fighter.global_table[CMD_CAT3].get_i32();
+    if cat3 & (*FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI | *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI4) != 0 {
+        if fighter.sub_transition_group_check_ground_item().get_bool() {
+            return 0.into();
+        }
+    }
+    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
+        && fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status(
+            L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
+            L2CValue::Bool(true)
+        );
+    } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
+        // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
+        && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+            if fighter.global_table[0x58].get_bool() != false && {
+                let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
+                callable(fighter).get_bool()
+            } {
+                return L2CValue::I32(0);
+            }
+            // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
+            if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
+                && fighter.is_situation(*SITUATION_KIND_GROUND) {
+                fighter.change_status(
+                    L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
+                    L2CValue::Bool(true)
+                );
             }
         }
     }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -127,7 +127,6 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         return 0.into();
     }
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
-    && !ItemModule::is_have_item(fighter.module_accessor, 0)
     && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 {
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_CATCH),
@@ -135,34 +134,33 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
-    if fighter.global_table[STICK_Y].get_f32() >= 0.2 && fighter.sub_transition_group_check_ground_item().get_bool() {
-        return 0.into();
-    }
-    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
-        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
-        && fighter.is_situation(*SITUATION_KIND_GROUND) {
-        fighter.change_status(
-            L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
-            L2CValue::Bool(true)
-        );
-    } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
-        // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
-        && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
-            if fighter.global_table[0x58].get_bool() != false && {
-                let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
-                callable(fighter).get_bool()
-            } {
-                return L2CValue::I32(0);
-            }
-            // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
-            if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
-                && fighter.is_situation(*SITUATION_KIND_GROUND) {
-                fighter.change_status(
-                    L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
-                    L2CValue::Bool(true)
-                );
+    if !fighter.sub_transition_group_check_ground_item().get_bool() {
+        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
+            && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
+            && fighter.is_situation(*SITUATION_KIND_GROUND) {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
+                L2CValue::Bool(true)
+            );
+        } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
+            // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+            if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
+            && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+                if fighter.global_table[0x58].get_bool() != false && {
+                    let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
+                    callable(fighter).get_bool()
+                } {
+                    return L2CValue::I32(0);
+                }
+                // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
+                if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
+                    && fighter.is_situation(*SITUATION_KIND_GROUND) {
+                    fighter.change_status(
+                        L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
+                        L2CValue::Bool(true)
+                    );
+                }
             }
         }
     }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -137,35 +137,38 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
     }
     let cat3 = fighter.global_table[CMD_CAT3].get_i32();
     if cat3 & (*FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI | *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI4) != 0 {
-        if fighter.sub_transition_group_check_ground_item().get_bool() {
-            return 0.into();
+        if fighter.global_table[STICK_Y].get_f32().abs() < 0.2 {
+            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI);
+            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4);
         }
     }
-    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
-        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
-        && fighter.is_situation(*SITUATION_KIND_GROUND) {
-        fighter.change_status(
-            L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
-            L2CValue::Bool(true)
-        );
-    } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
-        // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
-        && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
-            if fighter.global_table[0x58].get_bool() != false && {
-                let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
-                callable(fighter).get_bool()
-            } {
-                return L2CValue::I32(0);
-            }
-            // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
-            if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
-                && fighter.is_situation(*SITUATION_KIND_GROUND) {
-                fighter.change_status(
-                    L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
-                    L2CValue::Bool(true)
-                );
+    if !fighter.sub_transition_group_check_ground_item().get_bool() {
+        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
+            && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
+            && fighter.is_situation(*SITUATION_KIND_GROUND) {
+            fighter.change_status(
+                L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
+                L2CValue::Bool(true)
+            );
+        } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
+            // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+            if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
+            && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+                if fighter.global_table[0x58].get_bool() != false && {
+                    let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
+                    callable(fighter).get_bool()
+                } {
+                    return L2CValue::I32(0);
+                }
+                // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
+                if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
+                    && fighter.is_situation(*SITUATION_KIND_GROUND) {
+                    fighter.change_status(
+                        L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
+                        L2CValue::Bool(true)
+                    );
+                }
             }
         }
     }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -135,40 +135,43 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
-    let cat3 = fighter.global_table[CMD_CAT3].get_i32();
-    if cat3 & (*FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI | *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI4) != 0 {
-        if fighter.global_table[STICK_Y].get_f32().abs() < 0.2 {
-            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI);
-            ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, *FIGHTER_PAD_CMD_CAT3_ITEM_LIGHT_THROW_HI4);
+    // Walks through and clears all item throw commands.
+    if fighter.global_table[CMD_CAT3].get_i32() & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_ALL != 0 {
+        let up = fighter.global_table[STICK_Y].get_f32() >= 0.2;
+        for x in 0..7 {
+            if x != 0 && x != 3 || !up {
+                ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY3, x);
+            }
         }
     }
-    if !fighter.sub_transition_group_check_ground_item().get_bool() {
-        let cat1 = fighter.global_table[CMD_CAT1].get_i32();
-        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
-            && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
-            && fighter.is_situation(*SITUATION_KIND_GROUND) {
-            fighter.change_status(
-                L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
-                L2CValue::Bool(true)
-            );
-        } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
-            // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
-            if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
-            && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
-                if fighter.global_table[0x58].get_bool() != false && {
-                    let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
-                    callable(fighter).get_bool()
-                } {
-                    return L2CValue::I32(0);
-                }
-                // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
-                if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
-                    && fighter.is_situation(*SITUATION_KIND_GROUND) {
-                    fighter.change_status(
-                        L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
-                        L2CValue::Bool(true)
-                    );
-                }
+    if fighter.sub_transition_group_check_ground_item().get_bool() {
+        return 0.into();
+    }
+    let cat1 = fighter.global_table[CMD_CAT1].get_i32();
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI)
+        && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_HI != 0
+        && fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status(
+            L2CValue::I32(*FIGHTER_STATUS_KIND_SPECIAL_HI),
+            L2CValue::Bool(true)
+        );
+    } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
+        // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+        if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
+        && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
+            if fighter.global_table[0x58].get_bool() != false && {
+                let callable: extern "C" fn(&mut L2CFighterCommon) -> L2CValue = std::mem::transmute(fighter.global_table[0x58].get_ptr());
+                callable(fighter).get_bool()
+            } {
+                return L2CValue::I32(0);
+            }
+            // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
+            if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
+                && fighter.is_situation(*SITUATION_KIND_GROUND) {
+                fighter.change_status(
+                    L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
+                    L2CValue::Bool(true)
+                );
             }
         }
     }
@@ -226,10 +229,7 @@ unsafe fn status_JumpSquat_common(fighter: &mut L2CFighterCommon, lr_update: L2C
         PostureModule::set_stick_lr(fighter.module_accessor, 0.0);
         PostureModule::update_rot_y_lr(fighter.module_accessor);
     }
-    // Since the game no longer clears the buffer using change_status, we have to do it instead.
-    ControlModule::reset_trigger(fighter.module_accessor);
-    ControlModule::clear_command(fighter.module_accessor, false);
-    // All so we can keep our current stick flick.
+    // Commented out so we can keep our current stick flick.
     // ControlModule::reset_flick_y(fighter.module_accessor);
     // ControlModule::reset_flick_sub_y(fighter.module_accessor);
     // fighter.global_table[FLICK_Y].assign(&0xFE.into());

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -135,7 +135,8 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
-    if fighter.global_table[STICK_Y].get_f32() >= 0.2 && fighter.sub_transition_group_check_ground_item().get_bool() {
+    // Checks if the stick is upwards and if it's been flicked for less than 5 frames before throwing the item.
+    if fighter.global_table[STICK_Y].get_f32() >= 0.2 && fighter.global_table[FLICK_Y].get_i32() < 5 && fighter.sub_transition_group_check_ground_item().get_bool() {
         return 0.into();
     }
     let cat1 = fighter.global_table[CMD_CAT1].get_i32();

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -127,6 +127,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         return 0.into();
     }
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
+    && !ItemModule::is_have_item(fighter.module_accessor, 0)
     && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 {
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_CATCH),
@@ -144,7 +145,7 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
                 L2CValue::Bool(true)
             );
         } else if !fighter.sub_transition_specialflag_hoist().get_bool() {
-            let cat2 = fighter.global_table[CMD_CAT2].get_i32();
+            // let cat2 = fighter.global_table[CMD_CAT2].get_i32();
             if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START)
             && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_CSTICK_ON) {
                 if fighter.global_table[0x58].get_bool() != false && {
@@ -153,7 +154,8 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
                 } {
                     return L2CValue::I32(0);
                 }
-                if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0
+                // if cat2 & *FIGHTER_PAD_CMD_CAT2_FLAG_ATTACK_DASH_ATTACK_HI4 != 0 // original
+                if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_HI4 != 0 // check if there is a valid stick flick using the original flag
                     && fighter.is_situation(*SITUATION_KIND_GROUND) {
                     fighter.change_status(
                         L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
@@ -217,9 +219,13 @@ unsafe fn status_JumpSquat_common(fighter: &mut L2CFighterCommon, lr_update: L2C
         PostureModule::set_stick_lr(fighter.module_accessor, 0.0);
         PostureModule::update_rot_y_lr(fighter.module_accessor);
     }
-    ControlModule::reset_flick_y(fighter.module_accessor);
-    ControlModule::reset_flick_sub_y(fighter.module_accessor);
-    fighter.global_table[FLICK_Y].assign(&0xFE.into());
+    // Since the game no longer clears the buffer using change_status, we have to do it instead.
+    ControlModule::reset_trigger(fighter.module_accessor);
+    ControlModule::clear_command(fighter.module_accessor, false);
+    // All so we can keep our current stick flick.
+    // ControlModule::reset_flick_y(fighter.module_accessor);
+    // ControlModule::reset_flick_sub_y(fighter.module_accessor);
+    // fighter.global_table[FLICK_Y].assign(&0xFE.into());
 
     // not a conditional enable, so it's not in potential_enables
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_FALL);

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -155,7 +155,6 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_air_transition_group_check_air_attack_hook,
             // sub_transition_group_check_air_lasso,
             sub_transition_group_check_ground_jump_mini_attack,
-            sub_transition_group_check_ground_jump,
             sub_transition_group_check_air_escape,
             sub_transition_group_check_ground_escape,
             sub_transition_group_check_ground_guard
@@ -271,19 +270,6 @@ unsafe fn sub_transition_group_check_ground_jump_mini_attack(fighter: &mut L2CFi
         && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
         && fighter.sub_check_button_jump().get_bool() {
             fighter.change_status_jump_mini_attack(false.into());
-            return true.into();
-        }
-    }
-    false.into()
-}
-
-// Vanilla lmao
-#[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_jump)]
-unsafe fn sub_transition_group_check_ground_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
-        if fighter.sub_check_button_jump().get_bool()
-        || fighter.sub_check_button_frick().get_bool() {
-            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), true.into());
             return true.into();
         }
     }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -277,12 +277,13 @@ unsafe fn sub_transition_group_check_ground_jump_mini_attack(fighter: &mut L2CFi
     false.into()
 }
 
+// Vanilla lmao
 #[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_jump)]
 unsafe fn sub_transition_group_check_ground_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
         if fighter.sub_check_button_jump().get_bool()
         || fighter.sub_check_button_frick().get_bool() {
-            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), false.into());
+            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), true.into());
             return true.into();
         }
     }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -155,6 +155,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_air_transition_group_check_air_attack_hook,
             // sub_transition_group_check_air_lasso,
             sub_transition_group_check_ground_jump_mini_attack,
+            sub_transition_group_check_ground_jump,
             sub_transition_group_check_air_escape,
             sub_transition_group_check_ground_escape,
             sub_transition_group_check_ground_guard
@@ -270,6 +271,18 @@ unsafe fn sub_transition_group_check_ground_jump_mini_attack(fighter: &mut L2CFi
         && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N != 0
         && fighter.sub_check_button_jump().get_bool() {
             fighter.change_status_jump_mini_attack(false.into());
+            return true.into();
+        }
+    }
+    false.into()
+}
+
+#[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_jump)]
+unsafe fn sub_transition_group_check_ground_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        if fighter.sub_check_button_jump().get_bool()
+        || fighter.sub_check_flick_jump().get_bool() {
+            fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), false.into());
             return true.into();
         }
     }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -281,7 +281,7 @@ unsafe fn sub_transition_group_check_ground_jump_mini_attack(fighter: &mut L2CFi
 unsafe fn sub_transition_group_check_ground_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
         if fighter.sub_check_button_jump().get_bool()
-        || fighter.sub_check_flick_jump().get_bool() {
+        || fighter.sub_check_button_frick().get_bool() {
             fighter.change_status(FIGHTER_STATUS_KIND_JUMP_SQUAT.into(), false.into());
             return true.into();
         }


### PR DESCRIPTION
In Vanilla, if you have up held on the left stick for any amount of time, enter jumpsquat, let go of jump and press A, you will always get usmash.
Now you must flick the stick to get a JC usmash. (this makes stuff like buffered uairs easier)

Resolves #918 