### PR TITLE
Aesthetic wavedash improvements

### DIFF
--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -11,8 +11,13 @@ use globals::*;
 //=================================================================
 #[skyline::hook(replace=MotionModule::change_motion)]
 unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: bool, arg6: f32, arg7: bool, arg8: bool) -> u64 {
+    let mut start_frame = arg3;
     change_motion_ecb_shift_check(boma);
-    original!()(boma, motion_hash, arg3, arg4, arg5, arg6, arg7, arg8)
+    if motion_hash == Hash40::new("landing_heavy") {
+        start_frame = 1.0;
+    }
+    println!("rate: {}", arg4);
+    original!()(boma, motion_hash, start_frame, arg4, arg5, arg6, arg7, arg8)
 }
 
 #[skyline::hook(replace=MotionModule::change_motion_inherit_frame)]

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -13,10 +13,11 @@ use globals::*;
 unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: bool, arg6: f32, arg7: bool, arg8: bool) -> u64 {
     let mut start_frame = arg3;
     change_motion_ecb_shift_check(boma);
+    // Starts heavy landing animation on frame 2
+    // This is a purely aesthetic change, makes for snappier landings
     if motion_hash == Hash40::new("landing_heavy") {
         start_frame = 1.0;
     }
-    println!("rate: {}", arg4);
     original!()(boma, motion_hash, start_frame, arg4, arg5, arg6, arg7, arg8)
 }
 

--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -77,6 +77,10 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
     // For articles
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
 
+    if x1 == hash40("landing_frame") {
+        return original!()(x0, hash40("landing_frame"), 0) + 1.0;
+    }
+    
     if x1 == hash40("param_trenchmortarbullet") && x2 == hash40("speed_x") {
 		if fighter_kind == *WEAPON_KIND_SNAKE_TRENCHMORTAR_BULLET {
 			return ControlModule::get_stick_x(boma) / 1.5 * PostureModule::lr(boma);

--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -77,6 +77,8 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
     // For articles
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
 
+    // Coupled with "landing_heavy" change in change_motion hook
+    // Because we start heavy landing anims on f2 rather than f1, we need to tell the game to make your heavy landing FAF f5 rather than f4
     if x1 == hash40("landing_frame") {
         return original!()(x0, hash40("landing_frame"), 0) + 1.0;
     }

--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -78,7 +78,7 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
 
     // Coupled with "landing_heavy" change in change_motion hook
-    // Because we start heavy landing anims on f2 rather than f1, we need to tell the game to make your heavy landing FAF f5 rather than f4
+    // Because we start heavy landing anims on f2 rather than f1, we need to push back the heavy landing FAF by 1 frame so it is accurate to the defined per-character param
     if x1 == hash40("landing_frame") {
         return original!()(x0, hash40("landing_frame"), 0) + 1.0;
     }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -439,8 +439,9 @@ unsafe fn sub_status_JumpSquat_check_stick_lr_update(fighter: &mut L2CFighterCom
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_jump_squat_uniq_process_init_param)]
 unsafe fn sub_jump_squat_uniq_process_init_param(fighter: &mut L2CFighterCommon, motion_hash: L2CValue) {
-    println!("sub_jump_squat_uniq_process_init_param");
     let jump_squat_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("jump_squat_frame"), 0) as f32;
+    // This cuts a single frame off of the end of the specified characters' jumpsquat animations
+    // This is a purely aesthetic change, makes for snappier jumps
     let end_frame = if [*FIGHTER_KIND_SAMUS,
         *FIGHTER_KIND_FOX,
         *FIGHTER_KIND_PIKACHU,
@@ -470,11 +471,11 @@ unsafe fn sub_jump_squat_uniq_process_init_param(fighter: &mut L2CFighterCommon,
     else {
         MotionModule::end_frame_from_hash(fighter.module_accessor, motion_hash.get_hash())
     };
-    let mut motion_rate = end_frame / jump_squat_frame;
 
+    // vanilla logic
+    let mut motion_rate = end_frame / jump_squat_frame;
     if motion_rate < 1.0 {
         motion_rate += 0.001;
     }
-    println!("motion rate init: {}", motion_rate);
     MotionModule::change_motion(fighter.module_accessor, motion_hash.get_hash(), 0.0, motion_rate, false, 0.0, false, false);
 }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -4,6 +4,7 @@ use globals::*;
 // This file contains code for wavedashing out of jumpsquat, fullhop buffered aerials/attack canceling
 
 pub fn install() {
+    skyline::nro::add_hook(nro_hook);
     install_status_scripts!(
         //status_pre_JumpSquat,
         status_JumpSquat,
@@ -22,6 +23,15 @@ pub fn install() {
         sub_status_JumpSquat_check_stick_lr_update
     );
 }
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            sub_jump_squat_uniq_process_init_param
+        );
+    }
+}
+
 /***
 // pre status stuff
 #[common_status_script(status = FIGHTER_STATUS_KIND_JUMP_SQUAT, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE,
@@ -280,9 +290,7 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
         fighter.sub_jump_squat_uniq_check_sub_mini_attack();
     }
 
-    let motion_kind = MotionModule::motion_kind(fighter.module_accessor);
-    let frame = MotionModule::frame(fighter.module_accessor);
-    let update_rate = MotionModule::update_rate(fighter.module_accessor);
+    let frame = VarModule::get_int(fighter.battle_object, vars::common::instance::JUMP_SQUAT_FRAME);
     let cat1 = fighter.global_table[CMD_CAT1].get_i32();
     if (cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_AIR_ESCAPE != 0 || ControlModule::check_button_trigger(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD_HOLD))
     && cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N == 0 {
@@ -291,8 +299,8 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
             VarModule::on_flag(fighter.battle_object, vars::common::instance::ENABLE_AIR_ESCAPE_JUMPSQUAT);
         }
     }
-    let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new_raw(motion_kind)) as u32 as f32;
-    if end_frame <= (frame + update_rate) {
+    let end_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("jump_squat_frame"), 0);
+    if frame >= end_frame {
         StatusModule::set_situation_kind(fighter.module_accessor, app::SituationKind(*SITUATION_KIND_AIR), false);
         let situation_kind = fighter.global_table[SITUATION_KIND].clone();
         fighter.global_table[PREV_SITUATION_KIND].assign(&situation_kind);
@@ -334,9 +342,7 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
 // subroutine for checking for aerial macro
 #[hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon29sub_jump_squat_uniq_check_subEN3lib8L2CValueE")]
 unsafe fn sub_jump_squat_uniq_check_sub(fighter: &mut L2CFighterCommon, flag: L2CValue) {
-    let motion_kind = MotionModule::motion_kind(fighter.module_accessor);
-    let js_frame = VarModule::get_int(fighter.battle_object, vars::common::instance::JUMP_SQUAT_FRAME);
-    VarModule::set_int(fighter.battle_object, vars::common::instance::JUMP_SQUAT_FRAME, js_frame + 1);
+    VarModule::inc_int(fighter.battle_object, vars::common::instance::JUMP_SQUAT_FRAME);
 
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_MINI_JUMP) { return; }
     // flag is basically always going to be the jump button flag
@@ -429,4 +435,46 @@ unsafe fn sub_status_JumpSquat_check_stick_lr_update(fighter: &mut L2CFighterCom
     // only allow jumpsquat to flip you around if your previous status was Dash and your directional input was caused by cstick (cstick input 2 frames within jumpsquat)
     // allows for cstick IRAR
     L2CValue::Bool(prev_status == *FIGHTER_STATUS_KIND_DASH && fighter.is_button_on(Buttons::CStickOverride))
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_jump_squat_uniq_process_init_param)]
+unsafe fn sub_jump_squat_uniq_process_init_param(fighter: &mut L2CFighterCommon, motion_hash: L2CValue) {
+    println!("sub_jump_squat_uniq_process_init_param");
+    let jump_squat_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("jump_squat_frame"), 0) as f32;
+    let end_frame = if [*FIGHTER_KIND_SAMUS,
+        *FIGHTER_KIND_FOX,
+        *FIGHTER_KIND_PIKACHU,
+        *FIGHTER_KIND_LUIGI,
+        *FIGHTER_KIND_NESS,
+        *FIGHTER_KIND_FALCO,
+        *FIGHTER_KIND_POPO,
+        *FIGHTER_KIND_NANA,
+        *FIGHTER_KIND_PICHU,
+        *FIGHTER_KIND_YOUNGLINK,
+        *FIGHTER_KIND_PZENIGAME,
+        *FIGHTER_KIND_DIDDY,
+        *FIGHTER_KIND_LUCAS,
+        *FIGHTER_KIND_WOLF,
+        *FIGHTER_KIND_LITTLEMAC,
+        *FIGHTER_KIND_DUCKHUNT,
+        *FIGHTER_KIND_RYU,
+        *FIGHTER_KIND_KEN,
+        *FIGHTER_KIND_CLOUD,
+        *FIGHTER_KIND_SIMON,
+        *FIGHTER_KIND_RICHTER,
+        *FIGHTER_KIND_DOLLY,
+        *FIGHTER_KIND_EDGE,].contains(&fighter.kind())
+    {
+        MotionModule::end_frame_from_hash(fighter.module_accessor, motion_hash.get_hash()) - 1.0
+    }
+    else {
+        MotionModule::end_frame_from_hash(fighter.module_accessor, motion_hash.get_hash())
+    };
+    let mut motion_rate = end_frame / jump_squat_frame;
+
+    if motion_rate < 1.0 {
+        motion_rate += 0.001;
+    }
+    println!("motion rate init: {}", motion_rate);
+    MotionModule::change_motion(fighter.module_accessor, motion_hash.get_hash(), 0.0, motion_rate, false, 0.0, false, false);
 }


### PR DESCRIPTION
In Ultimate, characters' animation philosophies for jumpsquat/landing animations are quite different than past games. Several characters appear to almost leave the ground on the last frame of their jumpsquat animation, or will be near-airborne on the first frame of their landing animations.
This does not translate well into our engine, with proper wavedashes/wavelands in place; it results in wonky-looking movement.

This change does two things:
1. Shaves off the **first** frame from *all* characters' heavy landing animations
2. Shaves off the **last** frame from *some* characters' jumpsquat animations.

This results in much smoother-looking wavedashes/wavelands, akin to Melee.

Old:
https://user-images.githubusercontent.com/47401664/184538481-b3239ec6-999b-4ef2-9add-c15693fdaece.mp4

New (more noticeable ingame at 60fps):
https://user-images.githubusercontent.com/47401664/184538334-da5ac9cf-0e33-4ba2-88fb-c19c83cee7d6.mp4

Resolves #916 