### PR TITLE
Stick Sensitivity Adjustments

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -3,6 +3,8 @@
   <int hash="precede">5</int>
   <int hash="precede_extension">0</int>
   <float hash="dash_s4_frame">4</float>
+  <float hash="dash_s4_frame_easy">6</float>
+  <float hash="dash_s4_frame_hard">2</float>  
   <int hash="dash_speed_keep_frame">1</int>
   <float hash="dash_escape_frame">1</float>
   <int hash="turn_dash_frame">-1</int>


### PR DESCRIPTION
Corrects behavior on low and high stick sensitivities:

Current Stick Sensitivity is as follows:

Low: Smash attack can occur until frame 5 of analog press
Normal: Smash attack can occur until frame 4 of analog press
High: Smash attack can occur until frame 7 of analog press

The new setting will be as follows:
Low: Smash attack can occur until frame 2 of analog press
Normal: Smash attack can occur until frame 4 of analog press
High: Smash attack can occur until frame 6 of analog press