### PR TITLE
Drift DI rework

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -225,6 +225,11 @@ pub mod vars {
 
             pub const DOWN_STAND_FB_KIND: i32 = 0x1000;
 
+            // floats
+
+            pub const INITIAL_KNOCKBACK_VEL_X: i32 = 0x1000;
+            pub const INITIAL_KNOCKBACK_VEL_Y: i32 = 0x1001;
+
         }
     }
 

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -17,9 +17,7 @@
     <struct hash="drift_di">
         <float hash="speed_mul_base">0.005</float>
         <float hash="speed_mul_add_max">0.0025</float>
-        <float hash="speed_lerp_min">0.35</float>
-        <float hash="speed_lerp_max">1.5</float>
-        <float hash="drift_reduction_mul_at_100">0.25</float>
+        <float hash="speed_lerp_max">3.0</float>
     </struct>
     <float hash="glide_toss_cancel_frame">6</float>
     <float hash="waveland_pass_neutral_sens">-0.66</float>


### PR DESCRIPTION
- DDI now uses your *initial* horizontal knockback velocity (IHKBV) to calculate your DDI value, rather than recalculating every frame throughout the entirety of hitstun.
- DDI now scales linearly based on your IHKBV
   - The higher your IHKBV, the lower your DDI strength
- DDI is now **disabled** once you are hit with high enough IHKBV
  - Meaning DDI should no longer impact survivability

The nitty gritty:
- Base DDI strength is 0.0075 units/frame, at 0.0 IHKBV
- This decreases linearly until 3.0 IHKBV
- At 3.0 IHKBV or more, your DDI strength is 0.0