### PR TITLE
Lingering ledge intangibility

### DIFF
--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -147,6 +147,7 @@ unsafe fn sub_escape_air_common(fighter: &mut L2CFighterCommon) {
         fighter.sub_escape_air_uniq(L2CValue::Bool(false));
     }
     fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(sub_escape_air_uniq as *const () as _));
+    HitModule::set_xlu_frame_global(fighter.module_accessor, 0, 0);
 }
 
 unsafe fn force_ground_attach(fighter: &mut L2CFighterCommon) {

--- a/fighters/common/src/general_statuses/cliff.rs
+++ b/fighters/common/src/general_statuses/cliff.rs
@@ -19,7 +19,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             status_end_CliffEscape,
             status_end_CliffJump1,
             status_end_CliffJump2,
-            status_end_CliffJump3
+            status_end_CliffJump3,
+            sub_cliff_uniq_process_exit_Common
         );
     }
 }
@@ -98,4 +99,22 @@ unsafe fn status_end_CliffJump2(fighter: &mut L2CFighterCommon) -> L2CValue {
 unsafe fn status_end_CliffJump3(fighter: &mut L2CFighterCommon) -> L2CValue {
     VarModule::set_vec3(fighter.object(), vars::common::instance::LEDGE_POS, Vector3f {x: 0.0, y: 0.0, z: 0.0});
     call_original!(fighter)
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_cliff_uniq_process_exit_Common)]
+unsafe fn sub_cliff_uniq_process_exit_Common(fighter: &mut L2CFighterCommon, isleavecliff: L2CValue) {
+    let is_leave_cliff = isleavecliff.get_i32();
+    if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF) {
+        let cliff_no_catch_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("cliff_no_catch_frame"));
+        WorkModule::set_int(fighter.module_accessor, cliff_no_catch_frame, *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_NO_CATCH_FRAME);
+        // Uncomment to remove lingering ledge intan
+        //HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+    }
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
+    if is_leave_cliff != 0 {
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
+        GroundModule::leave_cliff(fighter.module_accessor);
+        // Uncomment to remove lingering ledge intan
+        //HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+    }
 }

--- a/fighters/common/src/general_statuses/cliff.rs
+++ b/fighters/common/src/general_statuses/cliff.rs
@@ -107,14 +107,18 @@ unsafe fn sub_cliff_uniq_process_exit_Common(fighter: &mut L2CFighterCommon, isl
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF) {
         let cliff_no_catch_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("cliff_no_catch_frame"));
         WorkModule::set_int(fighter.module_accessor, cliff_no_catch_frame, *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_NO_CATCH_FRAME);
-        // Uncomment to remove lingering ledge intan
-        //HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+        // Allows lingering ledge intan on ledgedrop
+        if fighter.global_table[STATUS_KIND] != FIGHTER_STATUS_KIND_FALL {
+            HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+        }
     }
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
     if is_leave_cliff != 0 {
         WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
         GroundModule::leave_cliff(fighter.module_accessor);
-        // Uncomment to remove lingering ledge intan
-        //HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+        // Allows lingering ledge intan on ledgedrop
+        if fighter.global_table[STATUS_KIND] != FIGHTER_STATUS_KIND_FALL {
+            HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+        }
     }
 }

--- a/fighters/common/src/general_statuses/cliff.rs
+++ b/fighters/common/src/general_statuses/cliff.rs
@@ -102,23 +102,22 @@ unsafe fn status_end_CliffJump3(fighter: &mut L2CFighterCommon) -> L2CValue {
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_cliff_uniq_process_exit_Common)]
-unsafe fn sub_cliff_uniq_process_exit_Common(fighter: &mut L2CFighterCommon, isleavecliff: L2CValue) {
-    let is_leave_cliff = isleavecliff.get_i32();
+unsafe fn sub_cliff_uniq_process_exit_Common(fighter: &mut L2CFighterCommon, is_leave_cliff: L2CValue) {
     if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF) {
         let cliff_no_catch_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("cliff_no_catch_frame"));
         WorkModule::set_int(fighter.module_accessor, cliff_no_catch_frame, *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_NO_CATCH_FRAME);
         // Allows lingering ledge intan on ledgedrop
         if fighter.global_table[STATUS_KIND] != FIGHTER_STATUS_KIND_FALL {
-            HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+            HitModule::set_xlu_frame_global(fighter.module_accessor, 0, 0);
         }
     }
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
-    if is_leave_cliff != 0 {
+    if is_leave_cliff.get_bool() {
         WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CATCH_CLIFF);
         GroundModule::leave_cliff(fighter.module_accessor);
         // Allows lingering ledge intan on ledgedrop
         if fighter.global_table[STATUS_KIND] != FIGHTER_STATUS_KIND_FALL {
-            HitModule::set_xlu_frame_global(fighter.module_accessor, is_leave_cliff, 0);
+            HitModule::set_xlu_frame_global(fighter.module_accessor, 0, 0);
         }
     }
 }

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -60,12 +60,12 @@
   <float hash="catch_dash_brake_mul">1</float>
   <int hash="shield_setoff_catch_frame">0</int>
   <int hash="invalid_capture_frame">35</int>
-  <int hash="cliff_catch_move_frame">3</int>
+  <int hash="cliff_catch_move_frame">0</int>
   <int hash="cliff_no_catch_frame">25</int>
   <int hash="damage_cliff_no_catch_frame">25</int>
-  <int hash="cliff_wait_air_xlu_max_frame">10</int>
-  <int hash="cliff_wait_damage_xlu_max_frame">1</int>
-  <int hash="cliff_wait_xlu_min_frame">37</int>
+  <int hash="cliff_wait_air_xlu_max_frame">0</int>
+  <int hash="cliff_wait_damage_xlu_max_frame">0</int>
+  <int hash="cliff_wait_xlu_min_frame">29</int>
   <float hash="cliff_robbed_speed_x">-0.5</float>
   <float hash="cliff_robbed_speed_y">17.5</float>
   <int hash="cliff_robbed_no_control_frame">40</int>


### PR DESCRIPTION
This brings back Melee/PM's lingering ledge intangibility feature:
- The remainder of your ledge iframes now persist throughout any action after you ledgedrop
- However, airdodge will now clear your iframes, meaning **intangible ledgedashes will not be possible**

Other slight ledge changes to accompany this:
- Also reduces ledge iframes from 47 -> 37
- Also gets rid of "2-framing" entirely
   - Your ledgegrab animation will be a consistent 8 frames regardless of if you grab ledge from above or below