### PR TITLE
Fix smash stick during dash

### DIFF
--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -185,7 +185,7 @@ unsafe fn grab_jump_refresh(boma: &mut BattleObjectModuleAccessor) {
 
 unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
 
-    if fighter.is_button_on(Buttons::CStickOverride) {
+    if fighter.is_button_trigger(Buttons::CStickOverride) {
         let bidou_buttons = &[
         Buttons::AttackRaw,
         Buttons::SpecialRaw,


### PR DESCRIPTION
Fixes an issue where a smash stick input during dash would cause turnaround/redash, even when A wasn't held

Fixes #941 