### PR TITLE
Robin - Elwind1 cancel adjustment

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -574,6 +574,13 @@ pub mod vars {
         }
     }
 
+    pub mod robin {
+        pub mod status {
+            // flags
+            pub const ELWIND1_CANCEL: i32 = 0x1100;
+        }
+    }
+
     pub mod roy {
         pub mod instance {
             // flags

--- a/fighters/robin/src/acmd/specials.rs
+++ b/fighters/robin/src/acmd/specials.rs
@@ -10,13 +10,16 @@ unsafe fn reflet_special_hi_game(fighter: &mut L2CAgentBase) {
         ArticleModule::generate_article(boma, *FIGHTER_REFLET_GENERATE_ARTICLE_ELWIND, false, 0);
         WorkModule::on_flag(boma, *FIGHTER_REFLET_STATUS_SPECIAL_HI_FLAG_JUMP);
     }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
+    }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
         if (ControlModule::check_button_on_trriger(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on_trriger(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
             WorkModule::on_flag(boma,  *FIGHTER_REFLET_STATUS_SPECIAL_HI_FLAG_TRY_2ND);
         }
         else{
-            VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
             MotionModule::set_rate(boma, 1.3);
         }
     }
@@ -41,13 +44,16 @@ unsafe fn reflet_special_air_hi_game(fighter: &mut L2CAgentBase) {
         ArticleModule::generate_article(boma, *FIGHTER_REFLET_GENERATE_ARTICLE_ELWIND, false, 0);
         WorkModule::on_flag(boma, *FIGHTER_REFLET_STATUS_SPECIAL_HI_FLAG_JUMP);
     }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
+    }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
         if (ControlModule::check_button_on_trriger(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
             WorkModule::on_flag(boma,  *FIGHTER_REFLET_STATUS_SPECIAL_HI_FLAG_TRY_2ND);
         }
         else{
-            VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
             MotionModule::set_rate(boma, 1.3);
         }
     }

--- a/fighters/robin/src/opff.rs
+++ b/fighters/robin/src/opff.rs
@@ -43,10 +43,16 @@ unsafe fn elwind1_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
             // burn an extra bar of Elwind on upB1 (totals 2 bars)
             WorkModule::dec_int(boma, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT);
         }
-        if MotionModule::frame(boma) >= 8.0 && VarModule::is_flag(boma.object(), vars::common::instance::UP_SPECIAL_CANCEL) {
-            CancelModule::enable_cancel(boma);
-            if boma.is_situation(*SITUATION_KIND_AIR) {
-                fighter.sub_air_check_fall_common();
+        if boma.motion_frame() > 7.0 {
+            if VarModule::is_flag(boma.object(), vars::robin::status::ELWIND1_CANCEL) {
+                if boma.is_situation(*SITUATION_KIND_AIR) {
+                    fighter.sub_air_check_fall_common();
+                }
+            }
+            if boma.motion_frame() <= 11.0 && boma.is_button_trigger(Buttons::Guard) {
+                VarModule::on_flag(boma.object(), vars::robin::status::ELWIND1_CANCEL);
+                ControlModule::clear_command(boma, true);
+                CancelModule::enable_cancel(boma);
             }
         }
     }


### PR DESCRIPTION
Canceling Elwind1 into a fully actionable state now requires a shield press between frames 10-13.