### PR TITLE
Salty Runback/Quick Exit graphical indicators

### DIFF
--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -70,7 +70,9 @@ unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
-            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_dead2"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 0.75, true, 0, 0, 0, 0, 0, false, false);
+            if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_STANDBY]) {
+                StatusModule::change_status_request(fighter.module_accessor, *FIGHTER_STATUS_KIND_DEAD, false);
+            }
             utils::util::trigger_match_exit();
             true
         } else {

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -8,7 +8,8 @@ use smash::phx::*;
 use smash::hash40;
 use smash::lib::{lua_const::*, L2CValue, L2CAgent};
 use smash::lua2cpp::L2CFighterCommon;
-use smash::lua2cpp::L2CFighterBase;							 
+use smash::lua2cpp::L2CFighterBase;
+use smash_script::macros::*;
 
 pub mod ledges;
 pub mod shields;
@@ -64,13 +65,14 @@ unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
     if fighter.is_button_on(Buttons::StockShare) {
         if fighter.is_button_on(Buttons::AttackRaw) && !fighter.is_button_on(!(Buttons::AttackRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
-            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_damage_elec"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_assist_out"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
             utils::util::trigger_match_reset();
             utils::game_modes::signal_new_game();
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
-            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_score_aura"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_dead2"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 0.5, true, 0, 0, 0, 0, 0, false, false);
+            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.0, 0.0);
             utils::util::trigger_match_exit();
             true
         } else {

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -9,7 +9,6 @@ use smash::hash40;
 use smash::lib::{lua_const::*, L2CValue, L2CAgent};
 use smash::lua2cpp::L2CFighterCommon;
 use smash::lua2cpp::L2CFighterBase;
-use smash_script::macros::*;
 
 pub mod ledges;
 pub mod shields;
@@ -71,8 +70,7 @@ unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
-            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_dead2"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 0.5, true, 0, 0, 0, 0, 0, false, false);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.0, 0.0);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_dead2"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 0.75, true, 0, 0, 0, 0, 0, false, false);
             utils::util::trigger_match_exit();
             true
         } else {

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -63,10 +63,14 @@ pub unsafe fn fighter_common_opff(fighter: &mut L2CFighterCommon) {
 unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
     if fighter.is_button_on(Buttons::StockShare) {
         if fighter.is_button_on(Buttons::AttackRaw) && !fighter.is_button_on(!(Buttons::AttackRaw | Buttons::StockShare)) {
+            app::FighterUtil::flash_eye_info(fighter.module_accessor);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_damage_elec"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
             utils::util::trigger_match_reset();
             utils::game_modes::signal_new_game();
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
+            app::FighterUtil::flash_eye_info(fighter.module_accessor);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_score_aura"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
             utils::util::trigger_match_exit();
             true
         } else {


### PR DESCRIPTION
A distinct graphical indicator will now appear over the player who initiated a Salty Runback. When initiating a Quick Exit, the player will...blow up. In either case, the activating player's character portrait will have an eye flash.

Salty Runback:

https://user-images.githubusercontent.com/47401664/186548017-e12bcaca-bbb2-4f63-bfc7-145aac90a917.mp4

Quick Exit:

https://user-images.githubusercontent.com/47401664/186748019-4e80d04b-8766-4bb2-9847-bc1dee676463.mp4

Resolves #911 
