### PR TITLE
Glide Toss rework

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -189,7 +189,7 @@ pub mod vars {
             pub const RAR_LENIENCY: i32 = 0x0006; // Only ever gets set, goes effectively unused.
             pub const CURRENT_MOMENTUM_SPECIALS: i32 = 0x0007;
             pub const DOUBLE_JUMP_TIMER: i32 = 0x0008; // Only used by Lucas, and it's commented out, goes unused.
-            pub const ROLL_DIR: i32 = 0x0009;
+            pub const ROLL_SPEED: i32 = 0x0009;
             pub const LEDGE_POS: i32 = 0x000A;
             pub const LEDGE_POS_X: i32 = 0x000A;
             pub const LEDGE_POS_Y: i32 = 0x000B;

--- a/fighters/bayonetta/src/status.rs
+++ b/fighters/bayonetta/src/status.rs
@@ -4,7 +4,9 @@ use globals::*;
  
 pub fn install() {
     install_status_scripts!(
-        main_attack
+        main_attack,
+        escape_f_end,
+        escape_b_end
     );
 }
 
@@ -157,6 +159,26 @@ unsafe extern "C" fn bayonetta_attack_main_loop(fighter: &mut L2CFighterCommon) 
     }
     else {
         fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+    }
+    0.into()
+}
+
+// FIGHTER_STATUS_KIND_ESCAPE_F //
+
+#[status_script(agent = "bayonetta", status = FIGHTER_STATUS_KIND_ESCAPE_F, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn escape_f_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[STATUS_KIND] != FIGHTER_BAYONETTA_STATUS_KIND_BATWITHIN {
+        fighter.sub_status_end_EscaleFB();
+    }
+    0.into()
+}
+
+// FIGHTER_STATUS_KIND_ESCAPE_B //
+
+#[status_script(agent = "bayonetta", status = FIGHTER_STATUS_KIND_ESCAPE_B, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn escape_b_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[STATUS_KIND] != FIGHTER_BAYONETTA_STATUS_KIND_BATWITHIN {
+        fighter.sub_status_end_EscaleFB();
     }
     0.into()
 }

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -425,10 +425,11 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     let trigger_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("air_escape_passive_trigger_frame")) as f32;
     let curr_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
     let pad = fighter.global_table[PAD_FLAG].get_i32();
+    let agt_window = ParamModule::get_int(fighter.battle_object, ParamType::Common, "glide_toss_cancel_frame");
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ITEM_THROW)
         && pad & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0
         && ItemModule::is_have_item(fighter.module_accessor, 0)
-        && curr_frame <= 5 {
+        && curr_frame <= agt_window {
             fighter.clear_lua_stack();
             lua_args!(fighter, MA_MSC_ITEM_CHECK_HAVE_ITEM_TRAIT, ITEM_TRAIT_FLAG_NO_THROW);
             smash::app::sv_module_access::item(fighter.lua_state_agent);

--- a/fighters/common/src/general_statuses/escape.rs
+++ b/fighters/common/src/general_statuses/escape.rs
@@ -1,0 +1,20 @@
+use super::*;
+use globals::*;
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            sub_status_end_EscaleFB_hook,
+        );
+    }
+}
+
+// this runs as you leave hitlag
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_status_end_EscaleFB)]
+pub unsafe fn sub_status_end_EscaleFB_hook(fighter: &mut L2CFighterCommon) -> L2CValue {
+    0.into()
+}

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -26,6 +26,7 @@ mod downdamage;
 mod crawl;
 mod cliff;
 mod catchcut;
+mod escape;
 // [LUA-REPLACE-REBASE]
 // [SHOULD-CHANGE]
 // Reimplement the whole status script (already done) instead of doing this.
@@ -334,6 +335,7 @@ pub fn install() {
     crawl::install();
     cliff::install();
     catchcut::install();
+    escape::install();
 
     smashline::install_status_scripts!(
         damage_fly_end,

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -197,10 +197,10 @@ unsafe fn glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModu
     }
 
     if boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW)
+    && boma.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_F, *FIGHTER_STATUS_KIND_ESCAPE_B])
     && VarModule::is_flag(boma.object(), vars::common::instance::CAN_GLIDE_TOSS)
     && fighter.global_table[CURRENT_FRAME].get_i32() == 0
     {
-        println!("item throw f1");
         let roll_speed = VarModule::get_float(boma.object(), vars::common::instance::ROLL_SPEED);
         fighter.clear_lua_stack();
         lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, roll_speed);

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -181,33 +181,6 @@ unsafe fn run_squat(boma: &mut BattleObjectModuleAccessor, status_kind: i32, sti
     }
 }
 
-//=================================================================
-//== GLIDE TOSS
-//=================================================================
-unsafe fn glide_toss(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, facing: f32) {
-    if boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_F, *FIGHTER_STATUS_KIND_ESCAPE_B])
-    {
-        let max_ditcit_frame = ParamModule::get_int(boma.object(), ParamType::Common, "glide_toss_cancel_frame");
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        let speed_motion = app::sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
-        VarModule::set_flag(boma.object(), vars::common::instance::CAN_GLIDE_TOSS, fighter.global_table[CURRENT_FRAME].get_i32() < max_ditcit_frame);
-        VarModule::set_float(boma.object(), vars::common::instance::ROLL_SPEED, speed_motion);
-        return;
-    }
-
-    if boma.is_status(*FIGHTER_STATUS_KIND_ITEM_THROW)
-    && boma.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_ESCAPE_F, *FIGHTER_STATUS_KIND_ESCAPE_B])
-    && VarModule::is_flag(boma.object(), vars::common::instance::CAN_GLIDE_TOSS)
-    && fighter.global_table[CURRENT_FRAME].get_i32() == 0
-    {
-        let roll_speed = VarModule::get_float(boma.object(), vars::common::instance::ROLL_SPEED);
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, roll_speed);
-        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
-    }
-}
-
 unsafe fn shield_lock_tech(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32) {
     // airdodge with second shield button while holding another shield button
     if boma.is_situation(*SITUATION_KIND_AIR)
@@ -384,7 +357,6 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mu
     non_tumble_di(fighter, lua_state, l2c_agent, boma, status_kind);
     dash_drop(boma, status_kind);
     run_squat(boma, status_kind, stick_y); // Must be done after dash_drop()
-    glide_toss(fighter, boma, status_kind, facing);
     shield_lock_tech(boma, status_kind, situation_kind, cat[0]);
     drift_di(fighter, boma, status_kind, situation_kind);
     waveland_plat_drop(boma, cat[1], status_kind);

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -19,7 +19,7 @@
         <float hash="speed_mul_add_max">0.0025</float>
         <float hash="speed_lerp_max">3.0</float>
     </struct>
-    <float hash="glide_toss_cancel_frame">6</float>
+    <int hash="glide_toss_cancel_frame">5</int>
     <float hash="waveland_pass_neutral_sens">-0.66</float>
     <int hash="air_escape_snap_frame">5</int>
     <float hash="waveland_distance_threshold">5</float>

--- a/romfs/source/fighter/common/param/item.prcxml
+++ b/romfs/source/fighter/common/param/item.prcxml
@@ -2,6 +2,6 @@
 <struct>
   <int hash="damage_drop_item">100</int>
   <int hash="damage_drop_item_empty">100</int>
-  <int hash="escape_throw_item_frame">6</int>
+  <int hash="escape_throw_item_frame">5</int>
   <float hash="superleaf_fall_limit_speed">0</float>
 </struct>


### PR DESCRIPTION
Glide Tossing no longer applies artificial speed to your character when canceling roll into an item throw. Now, your roll's animation speed on the last frame before being canceled is carried over into your item throw animation. Due to characters' varying roll animations, this means the timing for a "good" Glide Toss will vary for each character & roll direction. Generally, the later into the roll you input a Glide Toss, the further you'll slide.

Additionally, the grounded Glide Toss window has been made consistent with the Aerial Glide Toss window, at 5 frames.

Also fixes an issue where the autoturn characters would sometimes get boosted in the wrong direction when Glide Tossing.

Fixes #953 