### PR TITLE
Turnaround improvements

### DIFF
--- a/fighters/common/src/function_hooks/is_flag.rs
+++ b/fighters/common/src/function_hooks/is_flag.rs
@@ -3,14 +3,14 @@ use globals::*;
 
 #[skyline::hook(replace=WorkModule::is_flag)]
 unsafe fn is_flag_hook(boma: &mut BattleObjectModuleAccessor, flag: i32) -> bool {
-    if flag == *FIGHTER_INSTANCE_WORK_ID_FLAG_FINISH_CAMERA_TARGET {
-        return false;
+    if flag == *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN {
+        return true;
     }
     original!()(boma, flag)
 }
 
 pub fn install() {
     skyline::install_hooks!(
-        //is_flag_hook
+        is_flag_hook
     );
 }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -141,6 +141,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_transition_group_check_ground_jump_mini_attack,
             sub_transition_group_check_air_escape,
             sub_transition_group_check_ground_escape,
+            sub_transition_group_check_ground_guard,
             sub_transition_group_check_ground
         );
     }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -331,7 +331,7 @@ unsafe fn sub_transition_group_check_ground(fighter: &mut L2CFighterCommon, to_s
         let cat1 = fighter.global_table[CMD_CAT1].get_i32();
         if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0
         && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) {
-=            fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
+            fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
             return true.into();
         }
         if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -331,8 +331,7 @@ unsafe fn sub_transition_group_check_ground(fighter: &mut L2CFighterCommon, to_s
         let cat1 = fighter.global_table[CMD_CAT1].get_i32();
         if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_TURN_DASH != 0
         && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) {
-            VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_SMASH_TURN);
-            fighter.change_status(FIGHTER_STATUS_KIND_TURN.into(), true.into());
+=            fighter.change_status(FIGHTER_STATUS_KIND_TURN_DASH.into(), true.into());
             return true.into();
         }
         if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0


### PR DESCRIPTION
- Removes a ""tech"" from vanilla which turned you around *during* your landing animation if you had the stick held backwards right before landing
- Makes regular turnarounds (not smash turns/dashbacks) unable to be buffered, which should prevent any unintentional turnarounds some may have experienced during movement

Resolves #995 