### PR TITLE
Prevent grab input from triggering attack/shield on ground

### DIFF
--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -279,7 +279,7 @@ unsafe fn sub_transition_group_check_air_escape(fighter: &mut L2CFighterCommon) 
 
 #[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_attack)]
 unsafe fn sub_transition_group_check_ground_attack(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_cat_flag(Cat1::Catch) {
+    if fighter.is_button_on(Buttons::Catch) {
         return false.into()
     }
     call_original!(fighter)
@@ -289,7 +289,7 @@ unsafe fn sub_transition_group_check_ground_attack(fighter: &mut L2CFighterCommo
 unsafe fn sub_transition_group_check_ground_escape(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_cat_flag(Cat1::JumpButton)
     || fighter.is_cat_flag(Cat1::Jump)
-    || fighter.is_cat_flag(Cat1::Catch) {
+    || fighter.is_button_on(Buttons::Catch) {
         return false.into()
     }
     call_original!(fighter)
@@ -299,7 +299,7 @@ unsafe fn sub_transition_group_check_ground_escape(fighter: &mut L2CFighterCommo
 unsafe fn sub_transition_group_check_ground_guard(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_cat_flag(Cat1::JumpButton)
     || fighter.is_cat_flag(Cat1::Jump)
-    || fighter.is_cat_flag(Cat1::Catch) {
+    || fighter.is_button_on(Buttons::Catch) {
         return false.into()
     }
     call_original!(fighter)

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -139,6 +139,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_air_transition_group_check_air_attack_hook,
             // sub_transition_group_check_air_lasso,
             sub_transition_group_check_ground_jump_mini_attack,
+            sub_transition_group_check_ground_attack,
             sub_transition_group_check_air_escape,
             sub_transition_group_check_ground_escape,
             sub_transition_group_check_ground_guard,
@@ -276,9 +277,19 @@ unsafe fn sub_transition_group_check_air_escape(fighter: &mut L2CFighterCommon) 
     false.into()
 }
 
+#[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_attack)]
+unsafe fn sub_transition_group_check_ground_attack(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_cat_flag(Cat1::Catch) {
+        return false.into()
+    }
+    call_original!(fighter)
+}
+
 #[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_escape)]
 unsafe fn sub_transition_group_check_ground_escape(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_cat_flag(Cat1::JumpButton) || fighter.is_cat_flag(Cat1::Jump) {
+    if fighter.is_cat_flag(Cat1::JumpButton)
+    || fighter.is_cat_flag(Cat1::Jump)
+    || fighter.is_cat_flag(Cat1::Catch) {
         return false.into()
     }
     call_original!(fighter)
@@ -286,7 +297,9 @@ unsafe fn sub_transition_group_check_ground_escape(fighter: &mut L2CFighterCommo
 
 #[skyline::hook(replace = L2CFighterCommon_sub_transition_group_check_ground_guard)]
 unsafe fn sub_transition_group_check_ground_guard(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_cat_flag(Cat1::JumpButton) || fighter.is_cat_flag(Cat1::Jump) {
+    if fighter.is_cat_flag(Cat1::JumpButton)
+    || fighter.is_cat_flag(Cat1::Jump)
+    || fighter.is_cat_flag(Cat1::Catch) {
         return false.into()
     }
     call_original!(fighter)


### PR DESCRIPTION
Grab button can no longer cause an attack or shield on the ground

Resolves #1011 