### PR TITLE
Common parameter adjustments

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -102,6 +102,7 @@
   <float hash="damage_fly_length_mul_min">1</float>
   <int hash="damage_fly_attack_frame">999</int>
   <int hash="damage_fly_escape_frame">999</int>
+  <float hash="damage_fly_reflect_speed_mul">0.8</float>
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <float hash="dead_down_damage_speed">999</float>
   <float hash="bury_jump_y_speed_mul">1.15</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -102,8 +102,8 @@
   <float hash="damage_fly_length_mul_min">1</float>
   <int hash="damage_fly_attack_frame">999</int>
   <int hash="damage_fly_escape_frame">999</int>
-  <float hash="damage_fly_reflect_speed_mul">0.8</float>
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
+  <int hash="damage_fly_reflect_disable_escape_frame">999</int>
   <float hash="dead_down_damage_speed">999</float>
   <float hash="bury_jump_y_speed_mul">1.15</float>
   <float hash="mewtwo_thrown_reaction_frame_mul">1</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -13,6 +13,7 @@
   <int hash="re_dash_frame">17</int>
   <float hash="run_stick_x">0.62</float>
   <float hash="run_motion_rate_max">4</float>
+  <float hash="turn_run_stop_brake_mul">1</float>
   <float hash="squat_stick_y">-0.625</float>
   <float hash="squat_damage_reaction_mul">0.7</float>
   <int hash="jump_flick_y">4</int>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -2,16 +2,22 @@
 <struct>
   <int hash="precede">5</int>
   <int hash="precede_extension">0</int>
+  <float hash="turn_stick_x">-0.25</float>
+  <float hash="dash_stick_x">0.73</float>
   <float hash="dash_s4_frame">4</float>
   <float hash="dash_s4_frame_easy">6</float>
   <float hash="dash_s4_frame_hard">2</float>  
   <int hash="dash_speed_keep_frame">1</int>
   <float hash="dash_escape_frame">1</float>
   <int hash="turn_dash_frame">-1</int>
-  <float hash="run_stick_x">0.625</float>
+  <int hash="re_dash_frame">17</int>
+  <float hash="run_stick_x">0.62</float>
   <float hash="run_motion_rate_max">4</float>
+  <float hash="squat_stick_y">-0.625</float>
   <float hash="squat_damage_reaction_mul">0.7</float>
+  <int hash="jump_flick_y">4</int>
   <int hash="jump_initial_frame">5</int>
+  <float hash="jump_run_stick_y">0.635</float>
   <int hash="tread_jump_after_xlu_frame">0</int>
   <int hash="tread_jump_disable_frame_after_attack">8</int>
   <float hash="shield_max">60</float>
@@ -36,6 +42,8 @@
   <int hash="guard_damage_just_shield_disable_frame">1</int>
   <int hash="escape_flick_y">3</int>
   <float hash="escape_stick_y">-0.75</float>
+  <int hash="escape_fb_flick_x">3</int>
+  <float hash="escape_fb_stick_x">0.75</float>
   <float hash="escape_air_slide_landing_speed_max">4</float>
   <int hash="hit_stop_delay_flick">2</int>
   <float hash="hit_stop_delay_flick_mul">5</float>
@@ -56,6 +64,8 @@
     <float index="9">0.01</float>
   </list>
   <float hash="mini_jump_attack_mul">1</float>
+  <float hash="status_start_turn_stick_x">0</float>
+  <int hash="special_air_n_turn_frame">15</int>
   <byte hash="special_command_life_max">10</byte>
   <byte hash="super_special_command_life_max">20</byte>
   <float hash="catch_dash_brake_mul">1</float>
@@ -81,7 +91,8 @@
   <float hash="wall_jump_x_speed_dec">0.7</float>
   <int hash="wall_jump_disable_frame">1</int>
   <int hash="wall_jump_interval_frame">1</int>
-  <float hash="damage_ground_mul">1.1</float>
+  <int hash="attach_wall_disable_frame">999</int>
+  <float hash="damage_ground_mul">1</float>
   <float hash="damage_air_brake">0.051</float>
   <float hash="damage_fly_speed_y_mul_base_accel">0.09</float>
   <float hash="damage_fly_speed_y_mul">5</float>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1546,7 +1546,7 @@
       <float hash="air_speed_x_stable">1.09</float>
       <float hash="air_brake_x">0.01125</float>
       <float hash="air_speed_y_stable">2.49</float>
-      <float hash="damage_fly_top_air_accel_y">0.18</float>
+      <float hash="damage_fly_top_air_accel_y">0.15</float>
       <float hash="damage_fly_top_speed_y_stable">2.49</float>
       <float hash="dive_speed_y">3.441</float>
       <float hash="weight">86</float>


### PR DESCRIPTION
Adjusted some engine parameters to make movement smoother, and to make some actions more intentional to input.

- Turn sensitivity -0.2 -> -0.25
- Dash & fsmash sensitivity 0.85 -> 0.73
- Frames between consecutive dashes 15 -> 17
- Run sensitivity 0.625 -> 0.62
- Run turn friction multiplier 2.0 -> 1.0
- Crouch & tether drop sensitivity -0.66 -> -0.625
- Tap jump input window 3 -> 4
- Dash/run tap jump sensitivity 0.5625 -> 0.635
- Roll input window 4 -> 3
- Roll sensitivity 0.7 -> 0.75
- B-Reverse or turnaround B sensitivity 0.3 -> 0.0
- B-Reverse or turnaround B window 10 -> 15
- Frames between consecutive wallclings 20 -> 999 (one wallcling per airtime)
- Greninja vertical knockback gravity value 0.18 -> 0.15 (was an error)