### PR TITLE
Perfect Pivot window adjustment

### DIFF
--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -27,7 +27,7 @@
         <int hash="start_frame">3</int>
         <int hash="end_frame">10</int>
     </struct>
-    <int hash="dash_perfect_pivot_window">4</int>
+    <int hash="dash_perfect_pivot_window">3</int>
     <float hash="perfect_pivot_speed_mul">-0.75</float>
     <float hash="late_perfect_pivot_speed_mul">-0.5</float>
     <struct hash="suicide_throw">


### PR DESCRIPTION
After talking with several community members and listening to discourse about melee/perfect pivots, I have come to the conclusion that a 3 frame window is the lowest we can go while having perfect pivots remain consistent and accessible. Perfect pivots have been a point of contention for some time because they get in the way of melee pivots. I believe this change will serve to help the two mechanics co-exist.