### PR TITLE
Fix tilt button causing shield drop

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -254,7 +254,7 @@ bitflags! {
     pub struct CatHdr: i32 {
         const TiltAttack = 0x1;
         const Wavedash = 0x2;
-        const ShieldDrop = 0x3;
+        const ShieldDrop = 0x4;
     }
 
     pub struct PadFlag: i32 {


### PR DESCRIPTION
Fixes an issue where inputting tilt button while shielding would erroneously trigger a shield drop.

Fixes #1020 