### PR TITLE
Knockback adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -56,7 +56,7 @@ pub mod globals {
     pub const CHECK_SPECIAL_COMMAND: i32 = 0x3C;
     pub const WAZA_CUSTOMIZE_CONTROL: i32 = 0x3D;
     pub const STATUS_CHANGE_CALLBACK: i32 = 0x3E;
-    pub const LEAVE_STOP_CALLBACK: i32 = 0x42;
+    pub const DAMAGE_MOTION_KIND_CALLBACK: i32 = 0x42;
     pub const DASH_POST_TRANSITION_CALLBACK: i32 = 0x57;
 }
 

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -89,6 +89,6 @@ pub fn install() {
         change_motion_inherit_frame_hook,
         change_motion_inherit_frame_keep_rate_hook,
         change_motion_force_inherit_frame_hook,
-        change_motion_kind_hook
+        change_motion_kind_hook,
     );
 }

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -83,32 +83,12 @@ unsafe fn change_motion_ecb_shift_check(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
-#[skyline::hook(replace=EffectModule::preset_lifetime_rate_partial)]
-unsafe fn preset_lifetime_rate_partial_hook(boma: &mut BattleObjectModuleAccessor, rate: f32) -> u64 {
-    let mut rate = rate.clone();
-    // Halve the lifetime of knockback smoke
-    if boma.is_status_one_of(&[
-        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
-        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR])
-    {
-        rate *= 0.5;
-    }
-    original!()(boma, rate)
-}
-
-
 pub fn install() {
     skyline::install_hooks!(
         change_motion_hook,
         change_motion_inherit_frame_hook,
         change_motion_inherit_frame_keep_rate_hook,
         change_motion_force_inherit_frame_hook,
-        change_motion_kind_hook,
-        preset_lifetime_rate_partial_hook
+        change_motion_kind_hook
     );
 }

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -83,6 +83,25 @@ unsafe fn change_motion_ecb_shift_check(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
+#[skyline::hook(replace=EffectModule::preset_lifetime_rate_partial)]
+unsafe fn preset_lifetime_rate_partial_hook(boma: &mut BattleObjectModuleAccessor, rate: f32) -> u64 {
+    let mut rate = rate.clone();
+    // Halve the lifetime of knockback smoke
+    if boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR])
+    {
+        rate *= 0.5;
+    }
+    original!()(boma, rate)
+}
+
+
 pub fn install() {
     skyline::install_hooks!(
         change_motion_hook,
@@ -90,5 +109,6 @@ pub fn install() {
         change_motion_inherit_frame_keep_rate_hook,
         change_motion_force_inherit_frame_hook,
         change_motion_kind_hook,
+        preset_lifetime_rate_partial_hook
     );
 }

--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -291,6 +291,56 @@ unsafe fn LANDING_EFFECT_FLIP_hook(lua_state: u64) {
     l2c_agent.clear_lua_stack();
 }
 
+#[skyline::hook(replace=smash::app::sv_animcmd::DOWN_EFFECT)]
+unsafe fn DOWN_EFFECT_hook(lua_state: u64) {
+    let mut l2c_agent: L2CAgent = L2CAgent::new(lua_state);
+
+    let mut hitbox_params: [L2CValue ; 16] = [L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void()];
+
+    for i in 0..16 {
+        hitbox_params[i as usize] = l2c_agent.pop_lua_stack(i + 1);
+    }
+
+    l2c_agent.clear_lua_stack();
+
+    for i in 0..16 {
+        // Index of effect name
+        if i == 8 {
+            let size = hitbox_params[i as usize].get_f32();
+            let mut new_size: L2CValue = L2CValue::new_num(size * 0.7);
+            l2c_agent.push_lua_stack(&mut new_size);
+        }
+        else {
+            l2c_agent.push_lua_stack(&mut hitbox_params[i as usize]);
+        }
+    }
+
+    original!()(lua_state);
+    l2c_agent.clear_lua_stack();
+    l2c_agent.push_lua_stack(&mut L2CValue::new_num(0.7));
+    sv_animcmd::LAST_EFFECT_SET_ALPHA(lua_state);
+    l2c_agent.clear_lua_stack();
+}
+
+#[skyline::hook(replace=EffectModule::req_on_joint)]
+unsafe fn req_on_joint_hook(boma: &mut BattleObjectModuleAccessor, effHash: smash::phx::Hash40, boneHash: smash::phx::Hash40, pos: &smash::phx::Vector3f, rot: &smash::phx::Vector3f, size: f32, arg7: &smash::phx::Vector3f, arg8: &smash::phx::Vector3f, arg9: bool, arg10: u32, arg11: i32, arg12: i32) -> u64 {
+    let mut eff_size = size;
+    if SHOCKWAVE_FX.contains(&effHash.hash) {
+        eff_size = size * 0.7;
+    }
+    original!()(boma, effHash, boneHash, pos, rot, eff_size, arg7, arg8, arg9, arg10, arg11, arg12)
+}
+
+#[skyline::hook(replace=EffectModule::req_follow)]
+unsafe fn req_follow(boma: &mut BattleObjectModuleAccessor, effHash: smash::phx::Hash40, boneHash: smash::phx::Hash40, pos: &smash::phx::Vector3f, rot: &smash::phx::Vector3f, size: f32, arg7: bool, arg8: u32, arg9: i32, arg10: i32, arg11: i32, arg12: i32, arg13: bool, arg14: bool) -> u64 {
+    let mut eff_size = size;
+    // Shrink knockback smoke effect by 25%
+    if effHash.hash == 0x1154cb72bf as u64 {  // hash for kb smoke
+        eff_size = size * 0.75;
+    }
+    original!()(boma, effHash, boneHash, pos, rot, eff_size, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14)
+}
+
 pub fn install() {
     skyline::install_hooks!(
         EFFECT_hook,
@@ -299,6 +349,9 @@ pub fn install() {
         FOOT_EFFECT_hook,
         FOOT_EFFECT_FLIP_hook,
         LANDING_EFFECT_hook,
-        LANDING_EFFECT_FLIP_hook
+        LANDING_EFFECT_FLIP_hook,
+        DOWN_EFFECT_hook,
+        req_on_joint_hook,
+        req_follow
     );
 }

--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -341,6 +341,30 @@ unsafe fn req_follow(boma: &mut BattleObjectModuleAccessor, effHash: smash::phx:
     original!()(boma, effHash, boneHash, pos, rot, eff_size, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14)
 }
 
+#[skyline::hook(replace=EffectModule::preset_lifetime_rate_partial)]
+unsafe fn preset_lifetime_rate_partial_hook(boma: &mut BattleObjectModuleAccessor, rate: f32) -> u64 {
+    let mut rate = rate.clone();
+    // Halve the lifetime of knockback smoke
+    if boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR])
+    {
+        rate *= 0.5;
+    }
+    original!()(boma, rate)
+}
+
+#[skyline::hook(replace=EffectModule::get_dead_effect_scale)]
+unsafe fn get_dead_effect_scale_hook(boma: &mut BattleObjectModuleAccessor, arg1: &smash::phx::Vector3f, arg2: f32, arg3: bool) -> f32 {
+    // Shrink KO gfx by 25%
+    original!()(boma, arg1, arg2, arg3) * 0.75
+}
+
 pub fn install() {
     skyline::install_hooks!(
         EFFECT_hook,
@@ -352,6 +376,8 @@ pub fn install() {
         LANDING_EFFECT_FLIP_hook,
         DOWN_EFFECT_hook,
         req_on_joint_hook,
-        req_follow
+        req_follow,
+        preset_lifetime_rate_partial_hook,
+        get_dead_effect_scale_hook
     );
 }

--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -1,8 +1,8 @@
 use super::*;
 use globals::*;
 
-const shockwave_fx: [u64 ; 2] = [hash40("sys_crown"), hash40("sys_crown_collision")];
-const smoke_fx: [u64 ; 15] = [hash40("sys_atk_smoke"),
+const SHOCKWAVE_FX: [u64 ; 3] = [hash40("sys_crown"), hash40("sys_crown_collision"), 0xde89fce0a];
+const SMOKE_FX: [u64 ; 15] = [hash40("sys_atk_smoke"),
                             hash40("sys_atk_smoke2"),
                             hash40("sys_bound_smoke"),
                             hash40("sys_dash_smoke"),
@@ -41,10 +41,10 @@ unsafe fn EFFECT_hook(lua_state: u64) {
         // Index of effect name
         if i == 0 {
             let effect_name = hitbox_params[i as usize].get_hash();
-            if shockwave_fx.contains(&effect_name.hash) {
+            if SHOCKWAVE_FX.contains(&effect_name.hash) {
                 reduce_size = true;
             }
-            if smoke_fx.contains(&effect_name.hash) {
+            if SMOKE_FX.contains(&effect_name.hash) {
                 reduce_alpha = true;
             }
             l2c_agent.push_lua_stack(&mut hitbox_params[i as usize]);
@@ -88,10 +88,10 @@ unsafe fn EFFECT_FOLLOW_hook(lua_state: u64) {
         // Index of effect name
         if i == 0 {
             let effect_name = hitbox_params[i as usize].get_hash();
-            if shockwave_fx.contains(&effect_name.hash) {
+            if SHOCKWAVE_FX.contains(&effect_name.hash) {
                 reduce_size = true;
             }
-            if smoke_fx.contains(&effect_name.hash) {
+            if SMOKE_FX.contains(&effect_name.hash) {
                 reduce_alpha = true;
             }
             //let mut aux: L2CValue = L2CValue::new_int(*ATTACK_LR_CHECK_POS as u64);
@@ -136,10 +136,10 @@ unsafe fn EFFECT_FOLLOW_FLIP_hook(lua_state: u64) {
         // Index of effect name
         if i == 0 {
             let effect_name = hitbox_params[i as usize].get_hash();
-            if shockwave_fx.contains(&effect_name.hash) {
+            if SHOCKWAVE_FX.contains(&effect_name.hash) {
                 reduce_size = true;
             }
-            if smoke_fx.contains(&effect_name.hash) {
+            if SMOKE_FX.contains(&effect_name.hash) {
                 reduce_alpha = true;
             }
             //let mut aux: L2CValue = L2CValue::new_int(*ATTACK_LR_CHECK_POS as u64);

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -26,6 +26,9 @@ pub unsafe fn FighterStatusUniqProcessDamage_leave_stop_hook(fighter: &mut L2CFi
     if !arg3.get_bool() {
         return 0.into();
     }
+    // Disable hitlag shake (not SDI) once hitlag is over
+    // Prevents "smoke farts" from kb smoke
+    ShakeModule::stop(fighter.module_accessor);
     let hashmap = fighter.local_func__fighter_status_damage_2();
     // vanilla ASDI routine (only runs for paralyze/crumple attacks)
     // if hashmap["absolute_"].get_bool() {

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -135,7 +135,8 @@ pub unsafe fn FighterStatusUniqProcessDamage_leave_stop_hook(fighter: &mut L2CFi
     }
     // <HDR>
     check_asdi(fighter);
-    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR]) && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_TO_PIERCE) {
+    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR, *FIGHTER_STATUS_KIND_BURY])
+    && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_TO_PIERCE) {
         MotionModule::set_rate(fighter.module_accessor, 1.0);
         WorkModule::set_float(fighter.module_accessor, 1.0, *FIGHTER_STATUS_DAMAGE_WORK_FLOAT_DAMAGE_MOTION_RATE);
     }
@@ -361,7 +362,7 @@ unsafe fn status_DamageFly_Main_hook(fighter: &mut L2CFighterCommon) -> L2CValue
 unsafe fn calc_damage_motion_rate_hook(fighter: &mut L2CFighterCommon, motion_kind: L2CValue, start_frame: L2CValue, is_pierce: L2CValue) -> L2CValue {
     // Reverts vanilla's motion rating of DamageFly, DamageFlyTop, and DamageFlyMeteor animations
     // to emulate Melee/PM's knockback feel
-    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR]) && !is_pierce.get_bool() {
+    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR, *FIGHTER_STATUS_KIND_BURY]) && !is_pierce.get_bool() {
         WorkModule::set_float(fighter.module_accessor, 1.0, *FIGHTER_STATUS_DAMAGE_WORK_FLOAT_DAMAGE_MOTION_RATE);
         return L2CValue::F32(1.0);
     }

--- a/fighters/common/src/general_statuses/dead.rs
+++ b/fighters/common/src/general_statuses/dead.rs
@@ -1,0 +1,25 @@
+// status imports
+use super::*;
+use globals::*;
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            sub_dead_uniq_process_init_hook
+        );
+    }
+}
+
+// this runs as you are KO'd
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_dead_uniq_process_init)]
+pub unsafe fn sub_dead_uniq_process_init_hook(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Kill rage smoke gfx on star/screen KO
+    EffectModule::kill_kind(fighter.module_accessor, Hash40::new("sys_steam1"), true, true);
+    EffectModule::kill_kind(fighter.module_accessor, Hash40::new("sys_steam2"), true, true);
+    EffectModule::kill_kind(fighter.module_accessor, Hash40::new("sys_steam3"), true, true);
+    original!()(fighter)
+}

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -28,6 +28,7 @@ mod cliff;
 mod catchcut;
 mod damage;
 mod escape;
+mod dead;
 // [LUA-REPLACE-REBASE]
 // [SHOULD-CHANGE]
 // Reimplement the whole status script (already done) instead of doing this.
@@ -414,6 +415,7 @@ pub fn install() {
     catchcut::install();
     damage::install();
     escape::install();
+    dead::install();
 
     smashline::install_status_scripts!(
         damage_fly_end,

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -17,7 +17,6 @@
   <float hash="hitstop_elec_mul">1.25</float>
   <int hash="just_shield_hitstop_frame_add">22</int>
   <int hash="just_shield_hitstop_frame_max">23</int>
-  <float hash="damage_shake_mul_value">1</float>
   <float hash="just_shield_reflect_attack_mul">0.5</float>
   <float hash="just_shield_reflect_speed_mul">1.0</float>
   <int hash="just_shield_reflect_count_max">7</int>

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -31,8 +31,8 @@
   <float hash="0x16911ce78c">0.875</float>
   <float hash="jostle_team_overlap_rate">0.3</float>
   <float hash="damage_angle_air">0.785398</float>
-  <float hash="fly_top_angle_lw">1.22173</float>
-  <float hash="fly_top_angle_hi">1.91986</float>
+  <float hash="fly_top_angle_lw">0.802851</float>
+  <float hash="fly_top_angle_hi">2.338741</float>
   <list hash="0x192e58d48b">
     <hash40 index="0">dummy</hash40>
     <float index="1">1</float>

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -31,8 +31,8 @@
   <float hash="0x16911ce78c">0.875</float>
   <float hash="jostle_team_overlap_rate">0.3</float>
   <float hash="damage_angle_air">0.785398</float>
-  <float hash="fly_top_angle_lw">0.785398</float>
-  <float hash="fly_top_angle_hi">2.35619</float>
+  <float hash="fly_top_angle_lw">1.22173</float>
+  <float hash="fly_top_angle_hi">1.91986</float>
   <list hash="0x192e58d48b">
     <hash40 index="0">dummy</hash40>
     <float index="1">1</float>


### PR DESCRIPTION
- When hit from behind, you will now *always* turn around to face the attacker, rather than flying facing away from them at mid-high %s
- Reverted vanilla's slowing down of DamageFly, DamageFlyTop, and DamageFlyMeteor knockback animations to make knockback feel more natural, akin to Melee/PM
- Knockback angle range to trigger DamageFlyTop animation reduced 0.785398-2.35619 -> 0.802851-2.338741 (radians)
- Knockback smoke GFX shrunk by 25%
- Knockback smoke GFX now dissipate 50% faster
- Hitlag shake (not SDI) now stops once hitlag is over, preventing the "knockback fart" phenomenon from knockback smoke
- KO GFX shrunk by 25%
- Missed tech GFX made smaller & more transparent

Before:

https://user-images.githubusercontent.com/47401664/190866041-6b09f4be-c164-429e-8fcb-108d1f36076e.mp4

After:

https://user-images.githubusercontent.com/47401664/190866047-3028aba8-f4f7-4ee0-98f1-f8f8e80e14fb.mp4


Resolves #879 
Resolves #999 