### PR TITLE
Fix grounded spikes causing "void" bug

### DIFF
--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -354,7 +354,7 @@ unsafe fn preset_lifetime_rate_partial_hook(boma: &mut BattleObjectModuleAccesso
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR])
     {
-        rate *= 0.5;
+        rate = (rate * 0.5).max(0.25);
     }
     original!()(boma, rate)
 }

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -328,6 +328,11 @@ unsafe fn status_DamageFly_Main_hook(fighter: &mut L2CFighterCommon) -> L2CValue
             return 0.into();
         }
         ***/
+        // <HDR>
+        if MotionModule::is_end(fighter.module_accessor) && MotionModule::rate(fighter.module_accessor) != 0.0 {
+            MotionModule::set_rate(fighter.module_accessor, 0.0);
+        }
+        // </HDR>
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DAMAGE_FALL) 
         && MotionModule::is_end(fighter.module_accessor)
         && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DAMAGE_FLAG_END_REACTION)


### PR DESCRIPTION
As reported by several users, if a character got spiked on the ground, their character model would disappear at the apex of their knockback arc, and the game would basically implode after that lol

This fixes that bug :-)