### PR TITLE
Revert B-Reverse/turnaround B stick threshold

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -65,7 +65,6 @@
     <float index="9">0.01</float>
   </list>
   <float hash="mini_jump_attack_mul">1</float>
-  <float hash="status_start_turn_stick_x">0</float>
   <int hash="special_air_n_turn_frame">15</int>
   <byte hash="special_command_life_max">10</byte>
   <byte hash="super_special_command_life_max">20</byte>


### PR DESCRIPTION
B-Reverse or turnaround B sensitivity 0.0 -> 0.3

A value of 0.0 did not take into account the stick's deadzones, and thus would trigger B-Reverse/turnaround B too easily.