### PR TITLE
Pichu - Charge State adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -806,6 +806,7 @@ pub mod vars {
             // floats
             pub const CHARGE_DAMAGE_MUL: i32 = 0x0100;
             pub const CHARGE_RECOIL_MUL: i32 = 0x0101;
+            pub const DISCHARGE_POWER_MUL: i32 = 0x0102;
         }
     }
 

--- a/fighters/pichu/src/opff.rs
+++ b/fighters/pichu/src/opff.rs
@@ -51,6 +51,20 @@ unsafe fn charge_state_decrease(boma: &mut BattleObjectModuleAccessor) {
         }
         if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) <= 0 {
             VarModule::set_int(boma.object(), vars::pichu::instance::CHARGE_LEVEL, 0);
+            EffectModule::req_on_joint(
+                boma,
+                Hash40::new("sys_smash_flash"),
+                Hash40::new("head"),
+                &Vector3f::zero(),
+                &Vector3f::zero(),
+                1.5,
+                &Vector3f::zero(),
+                &Vector3f::zero(),
+                false,
+                0,
+                0,
+                0
+            );
         }
     }
 }


### PR DESCRIPTION
- Discharge's power and size now decrease linearly based on how much Charge State is left
- At minimum, Discharge's power is 25% of its full power
- There is now a "flash" visual effect when Pichu runs out of Charge State

Full power Discharge:

https://user-images.githubusercontent.com/47401664/192004708-53dd3520-b51b-44ce-8c26-305ad6437815.mp4


Minimum power Discharge:

https://user-images.githubusercontent.com/47401664/192004727-172941eb-fcee-482a-9402-aeb9db1b6567.mp4

