### PR TITLE
Banjo's falling shockpad hitbox more accurately reflects its model

### DIFF
--- a/fighters/buddy/src/acmd/other.rs
+++ b/fighters/buddy/src/acmd/other.rs
@@ -201,6 +201,40 @@ unsafe fn buddy_bullet_bakyun_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "buddy_pad", script = "game_fall" , category = ACMD_GAME , low_priority)]
+unsafe fn buddy_pad_fall_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;    
+    let boma = smash::app::sv_system::battle_object_module_accessor(lua_state);
+    let pad_length = 6.0;
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 46, 70, 0, 40, 2.0, 0.0, 2.2, pad_length, Some(0.0), Some(2.2), Some(-pad_length), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        }
+    //Vanilla code from here on out
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_LEFT);
+    }
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_LEFT);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_RIGHT);
+    }
+    frame(lua_state, 23.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_RIGHT);
+    }
+    frame(lua_state, 26.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_LEFT);
+    }
+    frame(lua_state, 42.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, /*Flag*/ *WEAPON_BUDDY_PAD_STATUS_WORK_FLAG_FALL_LEANING_TO_THE_LEFT);
+    }
+}
 
 #[acmd_script( agent = "buddy", script = "game_escapeair" , category = ACMD_GAME , low_priority)]
 unsafe fn escape_air_game(fighter: &mut L2CAgentBase) {
@@ -238,6 +272,7 @@ pub fn install() {
         dash_sound,
         turn_dash_game,
         buddy_bullet_bakyun_game,
+        buddy_pad_fall_game,
         damageflyhi_sound,
         damageflylw_sound,
         damageflyn_sound,


### PR DESCRIPTION
Hitbox radius changed from 3.2 to 6.0, making it about the length of the green area of the pad

![](https://user-images.githubusercontent.com/13909643/194733415-dae37ff4-6956-400f-8fd9-6462700272a1.png)