### PR TITLE
More knockback adjustments

### DIFF
--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -354,7 +354,7 @@ unsafe fn preset_lifetime_rate_partial_hook(boma: &mut BattleObjectModuleAccesso
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR])
     {
-        rate = (rate * 0.5).max(0.25);
+        rate = 0.35;
     }
     original!()(boma, rate)
 }

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -136,7 +136,7 @@ pub unsafe fn FighterStatusUniqProcessDamage_leave_stop_hook(fighter: &mut L2CFi
     }
     // <HDR>
     check_asdi(fighter);
-    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR, *FIGHTER_STATUS_KIND_BURY])
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE_FLY, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR])
     && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_TO_PIERCE) {
         MotionModule::set_rate(fighter.module_accessor, 1.0);
         WorkModule::set_float(fighter.module_accessor, 1.0, *FIGHTER_STATUS_DAMAGE_WORK_FLOAT_DAMAGE_MOTION_RATE);
@@ -330,12 +330,11 @@ unsafe fn status_DamageFly_Main_hook(fighter: &mut L2CFighterCommon) -> L2CValue
         }
         ***/
         // <HDR>
-        if MotionModule::is_end(fighter.module_accessor) && MotionModule::rate(fighter.module_accessor) != 0.0 {
+        if MotionModule::frame(fighter.module_accessor) >= (MotionModule::end_frame(fighter.module_accessor) - 1.0) && MotionModule::rate(fighter.module_accessor) != 0.0 {
             MotionModule::set_rate(fighter.module_accessor, 0.0);
         }
         // </HDR>
         if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_DAMAGE_FALL) 
-        && MotionModule::is_end(fighter.module_accessor)
         && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_DAMAGE_FLAG_END_REACTION)
         {
             fighter.change_status(FIGHTER_STATUS_KIND_DAMAGE_FALL.into(), false.into());
@@ -366,9 +365,9 @@ unsafe fn status_DamageFly_Main_hook(fighter: &mut L2CFighterCommon) -> L2CValue
 
 #[skyline::hook(replace = L2CFighterCommon_calc_damage_motion_rate)]
 unsafe fn calc_damage_motion_rate_hook(fighter: &mut L2CFighterCommon, motion_kind: L2CValue, start_frame: L2CValue, is_pierce: L2CValue) -> L2CValue {
-    // Reverts vanilla's motion rating of DamageFly, DamageFlyTop, and DamageFlyMeteor animations
+    // Reverts vanilla's motion rating of DamageFly, DamageFlyTop, and DamageFlyMeteor ani`mations
     // to emulate Melee/PM's knockback feel
-    if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE, *FIGHTER_STATUS_KIND_DAMAGE_AIR, *FIGHTER_STATUS_KIND_BURY]) && !is_pierce.get_bool() {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DAMAGE_FLY, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR]) && !is_pierce.get_bool() {
         WorkModule::set_float(fighter.module_accessor, 1.0, *FIGHTER_STATUS_DAMAGE_WORK_FLOAT_DAMAGE_MOTION_RATE);
         return L2CValue::F32(1.0);
     }

--- a/romfs/source/fighter/common/param/effect.prcxml
+++ b/romfs/source/fighter/common/param/effect.prcxml
@@ -2,5 +2,5 @@
 <struct>
   <float hash="fly_effect_smoke_speed">3.08</float>
   <float hash="fly_effect_aura_speed">999</float>
-  <float hash="vector_adjust_effect_remove_reaction_frame_mul">0</float>
+  <int hash="vector_adjust_effect_remove_frame">1</int>
 </struct>

--- a/romfs/source/fighter/common/param/effect.prcxml
+++ b/romfs/source/fighter/common/param/effect.prcxml
@@ -2,4 +2,5 @@
 <struct>
   <float hash="fly_effect_smoke_speed">3.08</float>
   <float hash="fly_effect_aura_speed">999</float>
+  <float hash="vector_adjust_effect_remove_reaction_frame_mul">0</float>
 </struct>


### PR DESCRIPTION
Bugfix:
- Grounded spikes *definitely* don't cause characters do disappear into the void anymore (fr this time)

Aesthetic:
- Smoke dissipation rate is now a static value of 0.35, rather than varying under certain conditions
- The blue DI line effect now disappears much quicker

Before:

https://user-images.githubusercontent.com/47401664/193419395-6ec2ec13-b1a1-4bbb-bf20-00041579f544.mp4

After:

https://user-images.githubusercontent.com/47401664/193419399-81571ee2-264f-41a3-8753-d2b7f4bef397.mp4
