### PR TITLE
Non-tumble hitstun landing adjustment

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -155,7 +155,7 @@ pub mod vars {
 
             pub const IS_HEAVY_ATTACK: i32 = 0x0053;
 
-            pub const IS_CC_LANDING: i32 = 0x0054;
+            pub const IS_CC_NON_TUMBLE: i32 = 0x0054;
 
             // ints
 

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -155,6 +155,8 @@ pub mod vars {
 
             pub const IS_HEAVY_ATTACK: i32 = 0x0053;
 
+            pub const IS_CC_LANDING: i32 = 0x0054;
+
             // ints
 
             pub const LAST_ATTACK_RECEIVER_ENTRY_ID: i32 = 0x0000;

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -94,16 +94,6 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
                 }
             }
         }
-        // Checks whether you have landed on the first frame of non-tumble knockback
-        // This is only possible by CCing
-        if boma.is_status(*FIGHTER_STATUS_KIND_DAMAGE_AIR) && next_status == *FIGHTER_STATUS_KIND_LANDING {
-            if get_fighter_common_from_accessor(boma).global_table[CURRENT_FRAME].get_i32() <= 1 {
-                VarModule::on_flag(boma.object(), vars::common::instance::IS_CC_LANDING);
-            }
-            else {
-                VarModule::off_flag(boma.object(), vars::common::instance::IS_CC_LANDING);
-            }
-        }
 
         if boma.kind() == *FIGHTER_KIND_TRAIL
         && StatusModule::status_kind(boma) == *FIGHTER_TRAIL_STATUS_KIND_SPECIAL_S_SEARCH

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -94,6 +94,16 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
                 }
             }
         }
+        // Checks whether you have landed on the first frame of non-tumble knockback
+        // This is only possible by CCing
+        if boma.is_status(*FIGHTER_STATUS_KIND_DAMAGE_AIR) && next_status == *FIGHTER_STATUS_KIND_LANDING {
+            if get_fighter_common_from_accessor(boma).global_table[CURRENT_FRAME].get_i32() <= 1 {
+                VarModule::on_flag(boma.object(), vars::common::instance::IS_CC_LANDING);
+            }
+            else {
+                VarModule::off_flag(boma.object(), vars::common::instance::IS_CC_LANDING);
+            }
+        }
 
         if boma.kind() == *FIGHTER_KIND_TRAIL
         && StatusModule::status_kind(boma) == *FIGHTER_TRAIL_STATUS_KIND_SPECIAL_S_SEARCH

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -164,12 +164,14 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_LandingStiffness)]
 pub unsafe fn status_LandingStiffness(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_DAMAGE_AIR
-    || fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_SAVING_DAMAGE_AIR {
-        // halve hitstun on landing, with a minimum of your heavy landing lag value
+    && VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_CC_LANDING) {
+        // halve hitstun on non-tumble landing if CC'd
+        // if halved hitstun is less than your heavy landing lag value, use your heavy landing lag value
         let hitstun = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_REACTION_FRAME);
         let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
         WorkModule::set_float(fighter.module_accessor, (hitstun * 0.5).max(landing_frame), *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_REACTION_FRAME);
     }
+    VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_CC_LANDING);
     original!()(fighter)
 }
 


### PR DESCRIPTION
- When landing from non-tumble knockback, hitstun is now halved **only** if you have successfully CC'd
- All other landing scenarios retain full hitstun