### PR TITLE
Perfect Pivot adjustment

### DIFF
--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -247,14 +247,14 @@ unsafe fn dash_energy(fighter: &mut L2CFighterCommon) {
             if stick_x.abs() < dash_stick_x
             && StatusModule::prev_status_kind(fighter.module_accessor, 0) == *FIGHTER_STATUS_KIND_TURN 
             && StatusModule::prev_status_kind(fighter.module_accessor, 1) == *FIGHTER_STATUS_KIND_DASH { // if you are in a backdash
-                // apply late (F3) pivot energy
+                // apply pivot energy
                 fighter.clear_lua_stack();
                 lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL);
                 app::sv_kinetic_energy::clear_speed(fighter.lua_state_agent);
                 if VarModule::is_flag(fighter.battle_object, vars::common::instance::CAN_PERFECT_PIVOT) {
                     VarModule::off_flag(fighter.battle_object, vars::common::instance::CAN_PERFECT_PIVOT);
                     let dash_speed: f32 = WorkModule::get_param_float(fighter.module_accessor, hash40("dash_speed"), 0);
-                    let speed_mul = ParamModule::get_float(fighter.object(), ParamType::Common, "late_perfect_pivot_speed_mul");
+                    let speed_mul = ParamModule::get_float(fighter.object(), ParamType::Common, "perfect_pivot_speed_mul");
                     let pivot_boost = dash_speed * speed_mul * PostureModule::lr(fighter.module_accessor);
                     fighter.clear_lua_stack();
                     lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, pivot_boost);

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -29,7 +29,6 @@
     </struct>
     <int hash="dash_perfect_pivot_window">3</int>
     <float hash="perfect_pivot_speed_mul">-0.75</float>
-    <float hash="late_perfect_pivot_speed_mul">-0.5</float>
     <struct hash="suicide_throw">
         <float hash="throw_frame">300.0</float>
         <float hash="damage_frame_mul">0.25</float>


### PR DESCRIPTION
- Late Perfect Pivots now apply the same speed as normal Perfect Pivots (0.75 * dash speed), rather than less (0.5 * dash speed)
- Makes them even more consistent across different controllers