### PR TITLE
Falco aim lasers during up throw and back throw

### DIFF
--- a/fighters/falco/src/acmd/throws.rs
+++ b/fighters/falco/src/acmd/throws.rs
@@ -1,9 +1,28 @@
 
 use super::*;
 
+#[acmd_script( agent = "falco_blaster_bullet", script = "game_flythrowhi" , category = ACMD_GAME , low_priority)]
+unsafe fn falco_blaster_bullet_flythrowhi_game(fighter: &mut L2CAgentBase) {
+	if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 90, 80, 0, 60, 5.0, 0.0, 0.0, 4.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 4.0, 90, 80, 0, 60, 5.0, 0.0, 0.0, 8.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
+    }
+}
+
+#[acmd_script( agent = "falco_blaster_bullet", script = "game_flythrowb" , category = ACMD_GAME , low_priority)]
+unsafe fn falco_blaster_bullet_flythrowb_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+
+	frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 50, 80, 0, 60, 5.0, 0.0, 0.0, 4.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 50, 80, 0, 60, 5.0, 0.0, 0.0, 8.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
+    }
+}
 
 pub fn install() {
     install_acmd_scripts!(
+        falco_blaster_bullet_flythrowhi_game,
+        falco_blaster_bullet_flythrowb_game
     );
 }
-

--- a/fighters/falco/src/acmd/throws.rs
+++ b/fighters/falco/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 
 #[acmd_script( agent = "falco_blaster_bullet", script = "game_flythrowhi" , category = ACMD_GAME , low_priority)]
 unsafe fn falco_blaster_bullet_flythrowhi_game(fighter: &mut L2CAgentBase) {
-	if is_excute(fighter) {
+    if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 90, 80, 0, 60, 5.0, 0.0, 0.0, 4.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 4.0, 90, 80, 0, 60, 5.0, 0.0, 0.0, 8.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
     }
@@ -13,7 +13,7 @@ unsafe fn falco_blaster_bullet_flythrowhi_game(fighter: &mut L2CAgentBase) {
 unsafe fn falco_blaster_bullet_flythrowb_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
 
-	frame(lua_state, 3.0);
+    frame(lua_state, 3.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 50, 80, 0, 60, 5.0, 0.0, 0.0, 4.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 50, 80, 0, 60, 5.0, 0.0, 0.0, 8.0, None, None, None, 0.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FALCO_BLASTER, *ATTACK_REGION_ENERGY);

--- a/fighters/falco/src/opff.rs
+++ b/fighters/falco/src/opff.rs
@@ -65,11 +65,30 @@ unsafe fn firebird_startup_ledgegrab(fighter: &mut L2CFighterCommon) {
     }
 }
 
+unsafe fn aim_throw_lasers(boma: &mut BattleObjectModuleAccessor) {
+    let frame = boma.motion_frame();
+    let lr = PostureModule::lr(boma);
+
+    if boma.is_motion(Hash40::new("throw_hi"))
+    && 12.0 <= frame
+    && frame < 22.0 {
+        let rot = Vector3f::new(0.0, boma.stick_x() * lr * -20.0, 0.0);
+        boma.set_joint_rotate("clavicler", rot);
+    }
+    else if boma.is_motion(Hash40::new("throw_b"))
+    && 8.0 <= frame
+    && frame < 20.0 {
+        let rot = Vector3f::new(0.0, boma.stick_y() * -20.0, 0.0);
+        boma.set_joint_rotate("shoulderr", rot);
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
 
     laser_ff_land_cancel(boma, status_kind, situation_kind, cat[1], stick_y);
     shine_jc_turnaround(fighter, frame);
     firebird_startup_ledgegrab(fighter);
+    aim_throw_lasers(boma);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_FALCO )]


### PR DESCRIPTION
Implements slightly adjusting the angle (maximum of 20 degrees in either direction) at which falco shoots his lasers during up throw and back throw so he can follow DI.

Resolves #1078 

Not implemented but throwing it out there for discussion: As a small compensation nerf, maybe nerf the hitbox size just a bit on these? I think it's totally reasonable they are bigger than the visual even with this addition but like good lord they packing (see image)
![2022100321123900-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/8334080/193670766-c4130ae5-2695-4605-8f7d-282f868a2bee.jpg)

Edit: Nerfed hitbox size, both throws: 9.6u -> 5.0u

![2022100822201100-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/8334080/194728280-27227edd-5aea-4e39-b15e-b39e0df2bc9c.jpg)
