### PR TITLE
Fix Chrom Double Edge Dance aerial momentum

### DIFF
--- a/fighters/chrom/src/opff.rs
+++ b/fighters/chrom/src/opff.rs
@@ -139,6 +139,18 @@ unsafe fn soaring_slash(fighter: &mut L2CFighterCommon) {
     }
 }
 
+pub unsafe fn double_edge_dance_vertical_momentum(fighter: &mut L2CFighterCommon){
+    let fighter_gravity = KineticModule::get_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) as *mut FighterKineticEnergyGravity;
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_ROY_STATUS_KIND_SPECIAL_S2]) && fighter.is_situation(*SITUATION_KIND_AIR) {
+        smash::app::lua_bind::FighterKineticEnergyGravity::set_accel(fighter_gravity, -0.072);
+        smash::app::lua_bind::FighterKineticEnergyGravity::set_stable_speed(fighter_gravity, -2.0);
+    }
+
+    if fighter.is_situation(*SITUATION_KIND_GROUND) && VarModule::is_flag(fighter.battle_object, vars::common::instance::SPECIAL_STALL_USED) {
+        VarModule::off_flag(fighter.battle_object, vars::common::instance::SPECIAL_STALL_USED);
+    }
+}
+
 // symbol-based call for the fe characters' common opff
 extern "Rust" {
     fn fe_common(fighter: &mut smash::lua2cpp::L2CFighterCommon);
@@ -152,6 +164,7 @@ pub unsafe fn chrom_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon
     soaring_slash_cancel(fighter);
     side_special_cancels(fighter);
     soaring_slash(fighter);
+    double_edge_dance_vertical_momentum(fighter);
     
     // Sword remains the same size throughout jab and utilt
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_ATTACK_HI3,

--- a/romfs/source/fighter/chrom/param/vl.prcxml
+++ b/romfs/source/fighter/chrom/param/vl.prcxml
@@ -7,7 +7,8 @@
   </list>
   <list hash="param_special_s">
     <struct index="0">
-      <float hash="start_spd_x_mul">0.725</float>
+      <float hash="start_spd_x_mul">0.8</float>
+      <float hash="air_spd_y">1</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Updates Chrom's aerial side special momentum behavior to function like Roy's, which it should have been since the update to Roy's side special
Params chanegd:
 - Double Edge Dance initial aerial vertical speed decreased 1.2 -> 1.0
 - Double Edge Dance horizontal momentum multiplier increased 0.715 -> 0.8