### PR TITLE
Add .gitattributes file to standardize autocrlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Sets autocrlf for all contributors
+* text=auto


### PR DESCRIPTION
Makes .xml/.prcxml diffing not a nightmare