### PR TITLE
Adding deletion lists for nightly-beta switching

### DIFF
--- a/.github/workflows/build_beta.yml
+++ b/.github/workflows/build_beta.yml
@@ -263,6 +263,8 @@ jobs:
 
     - run: mv upgrade_artifacts/upgrade.zip to-nightly.zip
 
+    - run: mv upgrade_artifacts/deletions.json to_nightly_deletions.json
+
     # get the most recent latest beta
     - id: latest_beta
       uses: pozetroninc/github-action-get-latest-release@master
@@ -278,6 +280,19 @@ jobs:
         prerelease: false
         file_glob: false
         asset_name: to-nightly.zip
+        repo_name: HDR-Development/HDR-Releases
+        tag: ${{ steps.latest_beta.outputs.release }}
+        overwrite: true
+
+    # upload the to_nightly_deletions.json to the beta for the launcher
+    - name: Upload to_nightly_deletions.json to beta
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to_nightly_deletions.json
+        prerelease: false
+        file_glob: false
+        asset_name: to_nightly_deletions.json
         repo_name: HDR-Development/HDR-Releases
         tag: ${{ steps.latest_beta.outputs.release }}
         overwrite: true

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -226,6 +226,8 @@ jobs:
 
     - run: mv upgrade_artifacts/upgrade.zip to-nightly.zip
 
+    - run: mv upgrade_artifacts/deletions.json to_nightly_deletions.json
+
     # get the most recent latest beta
     - id: latest_beta
       uses: pozetroninc/github-action-get-latest-release@master
@@ -241,6 +243,19 @@ jobs:
         prerelease: false
         file_glob: false
         asset_name: to-nightly.zip
+        repo_name: HDR-Development/HDR-Releases
+        tag: ${{ steps.latest_beta.outputs.release }}
+        overwrite: true
+
+    # upload the to_nightly_deletions.json to the beta for the launcher
+    - name: Upload to_nightly_deletions.json to beta
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to_nightly_deletions.json
+        prerelease: false
+        file_glob: false
+        asset_name: to_nightly_deletions.json
         repo_name: HDR-Development/HDR-Releases
         tag: ${{ steps.latest_beta.outputs.release }}
         overwrite: true
@@ -276,6 +291,8 @@ jobs:
 
     - run: mv upgrade_artifacts/upgrade.zip to-beta.zip
 
+    - run: mv upgrade_artifacts/deletions.json to_beta_deletions.json
+
     # upload the to-beta.zip to the beta for the launcher
     - name: Upload to-beta.zip to nightly
       uses: svenstaro/upload-release-action@v2
@@ -285,6 +302,19 @@ jobs:
         prerelease: false
         file_glob: false
         asset_name: to-beta.zip
+        repo_name: HDR-Development/HDR-Nightlies
+        tag: ${{ needs.version_and_changelog.outputs.version }}
+        overwrite: true
+    
+    # upload the to_beta_deletions.json to the beta for the launcher
+    - name: Upload to_beta_deletions.json to nightly
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.RELEASE_TOKEN }}
+        file: to_beta_deletions.json
+        prerelease: false
+        file_glob: false
+        asset_name: to_beta_deletions.json
         repo_name: HDR-Development/HDR-Nightlies
         tag: ${{ needs.version_and_changelog.outputs.version }}
         overwrite: true


### PR DESCRIPTION
Updating nightly and beta github CI to upload deletion lists for nightly-beta switching in the launcher. The result is that using verify as a hack to delete unnecessary files when switching between nightly and beta will no longer be an issue. Instead we will delete specific files we know should be deleted. This means verify will not need to be run when switching, which will make the switch significantly faster on both platforms.