### PR TITLE
Disable Aerial Jumps while Floating

### DIFF
--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -16,7 +16,25 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
         let fighter_kind = boma.kind();
         let status_kind = StatusModule::status_kind(boma);
         let id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
-    
+        
+        // disable jumping while using floats
+        if [*FIGHTER_STATUS_KIND_FALL,
+        *FIGHTER_STATUS_KIND_FALL_AERIAL,
+        *FIGHTER_STATUS_KIND_JUMP,
+        *FIGHTER_STATUS_KIND_JUMP_AERIAL,
+        *FIGHTER_STATUS_KIND_CLIFF_JUMP1,
+        *FIGHTER_STATUS_KIND_CLIFF_JUMP2,
+        *FIGHTER_STATUS_KIND_CLIFF_JUMP3,
+        *FIGHTER_STATUS_KIND_ATTACK_AIR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FALL].contains(&status_kind)
+        && WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY)
+        || VarModule::is_flag(boma.object(), vars::common::instance::OMNI_FLOAT) {
+            if [*FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON,
+                *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL].contains(&flag) {
+                    return false;
+            }
+        }
+        
         // handle tilt attack input stopping you from getting a smash attack
         if [*FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_S4_START,
             *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START,


### PR DESCRIPTION
Floats used to accept up inputs on the stick and burn your double jump in the process. This was especially prevalent with Dark Samus and Mewtwo, who could float upwards.

This fixes that so double jumps are simply disabled during all types of floats. To double jump, you have to stop floating first.

https://user-images.githubusercontent.com/26860994/195723387-884e13ad-ab88-454c-b839-8ae34df2fd56.mp4

(I don't have the visualizer in this clip but I promise I'm mashing the left stick up for every jump except for the instant floats)