### PR TITLE
change flick y impl for dash drop

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -403,7 +403,6 @@ pub trait BomaExt {
     unsafe fn stick_y(&mut self) -> f32;
     unsafe fn prev_stick_x(&mut self) -> f32;
     unsafe fn prev_stick_y(&mut self) -> f32;
-    unsafe fn is_flick_y(&mut self, sensitivity: f32) -> bool;
     unsafe fn is_input_jump(&mut self) -> bool;
     unsafe fn get_aerial(&mut self) -> Option<AerialKind>;
     unsafe fn set_joint_rotate(&mut self, bone_name: &str, rotation: Vector3f);
@@ -565,22 +564,6 @@ impl BomaExt for BattleObjectModuleAccessor {
         }
 
         return self.is_cat_flag(Cat1::JumpButton);
-    }
-        
-    // TODO: Reimplement this check
-    unsafe fn is_flick_y(&mut self, sensitivity: f32) -> bool {
-        let stick = self.stick_y();
-        let p_stick = self.prev_stick_y();
-
-        if sensitivity < 0.0 && stick < sensitivity && (stick < p_stick || self.is_cat_flag(Cat2::FallJump)) {
-            return true;
-        }
-
-        if sensitivity > 0.0 && stick > sensitivity && (stick > p_stick || self.is_cat_flag(Cat2::FallJump)) {
-            return true;
-        }
-
-        return false;
     }
 
     /// returns whether or not the stick x is pointed in the "forwards" direction for

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -156,8 +156,10 @@ unsafe fn waveland_plat_drop(boma: &mut BattleObjectModuleAccessor, cat2: i32, s
 //=================================================================
 unsafe fn dash_drop(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
     let flick_y_sens = ParamModule::get_float(boma.object(), ParamType::Common, "general_flick_y_sens");
+    let flick_y = ControlModule::get_flick_y(boma);
     if GroundModule::is_passable_ground(boma)
-    && boma.is_flick_y(flick_y_sens)
+    && flick_y != 0xFE
+    && boma.stick_y() < flick_y_sens
     && boma.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_RUN,
         *FIGHTER_STATUS_KIND_RUN_BRAKE,


### PR DESCRIPTION
fixes the flick y impl for plat drop during dash, run, run brake, and turn dash.

before, if you moved your stick *anywhere* beneath -0.66 while you are performing one of those actions on a platform, you will drop through the platform. This makes crouch out of run on a platform borderline impossible.

this changes it to use an actual flick within the last 2 frames 