### PR TITLE
Weight Adjustment List

### DIFF
--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -52,7 +52,7 @@
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">2.4</float>
       <float hash="dive_speed_y">2.96</float>
-      <float hash="weight">121</float>
+      <float hash="weight">115</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">14</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -82,6 +82,7 @@
       <float hash="air_speed_y_stable">2.13</float>
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.13</float>
+      <float hash="weight">104</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">7</float>
@@ -112,7 +113,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.87</float>
       <float hash="dive_speed_y">2.604</float>
-      <float hash="weight">111</float>
+      <float hash="weight">108</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -140,6 +141,7 @@
       <float hash="damage_fly_top_air_accel_y">0.094</float>
       <float hash="damage_fly_top_speed_y_stable">1.9</float>
       <float hash="dive_speed_y">2.93</float>
+      <float hash="weight">104</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">9</float>
@@ -171,6 +173,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.6</float>
       <float hash="dive_speed_y">2.217</float>
+      <float hash="weight">79</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -202,7 +205,7 @@
       <float hash="damage_fly_top_air_accel_y">0.15</float>
       <float hash="damage_fly_top_speed_y_stable">2.8</float>
       <float hash="dive_speed_y">3.4</float>
-      <float hash="weight">74</float>
+      <float hash="weight">75</float>
       <float hash="landing_attack_air_frame_f">15</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">10</float>
@@ -231,6 +234,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">1.9</float>
       <float hash="dive_speed_y">2.7</float>
+      <float hash="weight">79</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -263,7 +267,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.71</float>
       <float hash="dive_speed_y">2.192</float>
-      <float hash="weight">90</float>
+      <float hash="weight">100</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">8</float>
@@ -295,6 +299,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.83</float>
       <float hash="dive_speed_y">2.23</float>
+      <float hash="weight">94</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_lw">10</float>
@@ -328,6 +333,7 @@
       <float hash="damage_fly_top_air_accel_y">0.13</float>
       <float hash="damage_fly_top_speed_y_stable">2.808</float>
       <float hash="dive_speed_y">3.5</float>
+      <float hash="weight">104</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -386,6 +392,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.5</float>
       <float hash="dive_speed_y">2.1</float>
+      <float hash="weight">90</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_b">8</float>
@@ -417,7 +424,7 @@
       <float hash="damage_fly_top_air_accel_y">0.13</float>
       <float hash="damage_fly_top_speed_y_stable">2.12</float>
       <float hash="dive_speed_y">2.812</float>
-      <float hash="weight">128</float>
+      <float hash="weight">120</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -448,6 +455,7 @@
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">1.61</float>
       <float hash="dive_speed_y">2.167</float>
+      <float hash="weight">92</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
@@ -476,6 +484,7 @@
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">1.61</float>
       <float hash="dive_speed_y">2.167</float>
+      <float hash="weight">92</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
@@ -534,7 +543,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.5</float>
       <float hash="dive_speed_y">2.245</float>
-      <float hash="weight">86</float>
+      <float hash="weight">89</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">11</float>
@@ -630,6 +639,7 @@
       <float hash="damage_fly_top_air_accel_y">0.15</float>
       <float hash="damage_fly_top_speed_y_stable">3.1</float>
       <float hash="dive_speed_y">3.5</float>
+      <float hash="weight">82</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -686,6 +696,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.16</float>
       <float hash="dive_speed_y">2.9</float>
+      <float hash="weight">86</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">7</float>
@@ -717,7 +728,7 @@
       <float hash="air_speed_y_stable">2</float>
       <float hash="damage_fly_top_air_accel_y">0.13</float>
       <float hash="damage_fly_top_speed_y_stable">2</float>
-      <float hash="weight">112</float>
+      <float hash="weight">111</float>
       <float hash="landing_attack_air_frame_n">11</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -771,6 +782,7 @@
       <float hash="damage_fly_top_air_accel_y">0.115</float>
       <float hash="damage_fly_top_speed_y_stable">2.4</float>
       <float hash="dive_speed_y">3.024</float>
+      <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_lw">13</float>
@@ -799,6 +811,7 @@
       <float hash="damage_fly_top_air_accel_y">0.095</float>
       <float hash="damage_fly_top_speed_y_stable">1.71</float>
       <float hash="dive_speed_y">2.28</float>
+      <float hash="weight">75</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_hi">10</float>
@@ -889,6 +902,7 @@
       <float hash="damage_fly_top_air_accel_y">0.135</float>
       <float hash="damage_fly_top_speed_y_stable">2.05</float>
       <float hash="dive_speed_y">2.75</float>
+      <float hash="weight">80</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -923,7 +937,7 @@
       <float hash="damage_fly_top_air_accel_y">0.122</float>
       <float hash="damage_fly_top_speed_y_stable">1.93</float>
       <float hash="dive_speed_y">2.486</float>
-      <float hash="weight">104</float>
+      <float hash="weight">106</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">7</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -957,6 +971,7 @@
       <float hash="damage_fly_top_air_accel_y">0.098</float>
       <float hash="damage_fly_top_speed_y_stable">2.12</float>
       <float hash="dive_speed_y">2.89</float>
+      <float hash="weight">105</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -989,6 +1004,7 @@
       <float hash="damage_fly_top_air_accel_y">0.103</float>
       <float hash="damage_fly_top_speed_y_stable">2.05</float>
       <float hash="dive_speed_y">2.9</float>
+      <float hash="weight">104</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -1021,6 +1037,7 @@
       <float hash="damage_fly_top_air_accel_y">0.128</float>
       <float hash="damage_fly_top_speed_y_stable">1.72</float>
       <float hash="dive_speed_y">2.4</float>
+      <float hash="weight">75</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">7</float>
@@ -1050,6 +1067,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.7</float>
       <float hash="dive_speed_y">2.301</float>
+      <float hash="weight">91</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">8</float>
@@ -1080,7 +1098,7 @@
       <float hash="air_speed_y_stable">1.75</float>
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">1.75</float>
-      <float hash="weight">115</float>
+      <float hash="weight">112</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -1110,6 +1128,7 @@
       <float hash="damage_fly_top_air_accel_y">0.125</float>
       <float hash="damage_fly_top_speed_y_stable">2.55</float>
       <float hash="dive_speed_y">3.023</float>
+      <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
@@ -1141,6 +1160,7 @@
       <float hash="damage_fly_top_air_accel_y">0.125</float>
       <float hash="damage_fly_top_speed_y_stable">2.3</float>
       <float hash="dive_speed_y">2.7</float>
+      <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_lw">10</float>
@@ -1204,7 +1224,7 @@
       <float hash="damage_fly_top_air_accel_y">0.095</float>
       <float hash="damage_fly_top_speed_y_stable">2.25</float>
       <float hash="dive_speed_y">3.3</float>
-      <float hash="weight">115</float>
+      <float hash="weight">113</float>
       <float hash="landing_attack_air_frame_n">11</float>
       <float hash="landing_attack_air_frame_f">14</float>
       <float hash="landing_attack_air_frame_b">11</float>
@@ -1271,7 +1291,7 @@
       <float hash="damage_fly_top_air_accel_y">0.125</float>
       <float hash="damage_fly_top_speed_y_stable">2.02</float>
       <float hash="dive_speed_y">2.728</float>
-      <float hash="weight">99</float>
+      <float hash="weight">96</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -1302,7 +1322,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">2</float>
       <float hash="dive_speed_y">2.648</float>
-      <float hash="weight">103</float>
+      <float hash="weight">105</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">7</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -1333,6 +1353,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.06</float>
       <float hash="dive_speed_y">2.831</float>
+      <float hash="weight">85</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">7</float>
       <float hash="landing_attack_air_frame_hi">11</float>
@@ -1401,6 +1422,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.649</float>
       <float hash="dive_speed_y">2.225</float>
+      <float hash="weight">86</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -1431,6 +1453,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.18</float>
       <float hash="dive_speed_y">2.91</float>
+      <float hash="weight">102</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">17</float>
@@ -1459,6 +1482,7 @@
       <float hash="damage_fly_top_air_accel_y">0.113</float>
       <float hash="damage_fly_top_speed_y_stable">1.816</float>
       <float hash="dive_speed_y">2.414</float>
+      <float hash="weight">96</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -1487,6 +1511,7 @@
       <float hash="air_speed_y_stable">1.6</float>
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="dive_speed_y">2.287</float>
+      <float hash="weight">94</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">9</float>
@@ -1580,6 +1605,7 @@
       <float hash="damage_fly_top_air_accel_y">0.124</float>
       <float hash="damage_fly_top_speed_y_stable">1.915</float>
       <float hash="dive_speed_y">2.51</float>
+      <float hash="weight">90</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -1609,7 +1635,7 @@
       <float hash="air_speed_y_stable">1.655</float>
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="dive_speed_y">2.472</float>
-      <float hash="weight">94</float>
+      <float hash="weight">90</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -1639,6 +1665,7 @@
       <float hash="damage_fly_top_air_accel_y">0.099</float>
       <float hash="damage_fly_top_speed_y_stable">2.25</float>
       <float hash="dive_speed_y">3</float>
+      <float hash="weight">93</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -1670,6 +1697,7 @@
       <float hash="damage_fly_top_air_accel_y">0.106</float>
       <float hash="damage_fly_top_speed_y_stable">2.18</float>
       <float hash="dive_speed_y">2.998</float>
+      <float hash="weight">96</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_lw">13</float>
@@ -1696,6 +1724,7 @@
       <float hash="damage_fly_top_air_accel_y">0.111</float>
       <float hash="damage_fly_top_speed_y_stable">2.238</float>
       <float hash="dive_speed_y">3.007</float>
+      <float hash="weight">106</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -1725,6 +1754,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.91</float>
       <float hash="dive_speed_y">2.8</float>
+      <float hash="weight">86</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -1754,6 +1784,7 @@
       <float hash="damage_fly_top_air_accel_y">0.12</float>
       <float hash="damage_fly_top_speed_y_stable">1.97</float>
       <float hash="dive_speed_y">2.6</float>
+      <float hash="weight">103</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_hi">10</float>
@@ -1787,7 +1818,7 @@
       <float hash="damage_fly_top_air_accel_y">0.114</float>
       <float hash="damage_fly_top_speed_y_stable">2.375</float>
       <float hash="dive_speed_y">3.225</float>
-      <float hash="weight">104</float>
+      <float hash="weight">101</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">11</float>
@@ -1817,6 +1848,7 @@
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">2.08</float>
       <float hash="dive_speed_y">2.848</float>
+      <float hash="weight">98</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">12</float>
@@ -1879,6 +1911,7 @@
       <float hash="damage_fly_top_air_accel_y">0.095</float>
       <float hash="damage_fly_top_speed_y_stable">2.05</float>
       <float hash="dive_speed_y">2.817</float>
+      <float hash="weight">94</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">8</float>
@@ -1895,7 +1928,7 @@
       <float hash="run_accel_mul">0.07621</float>
       <float hash="run_accel_add">0.02</float>
       <float hash="run_speed_max">1.91</float>
-      <int hash="jump_squat_frame">5</int>
+      <int hash="jump_squat_frame">4</int>
       <float hash="jump_speed_x_max">1.6</float>
       <float hash="jump_initial_y">12.155</float>
       <float hash="air_accel_x_mul">0.0625</float>
@@ -1906,7 +1939,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.19</float>
       <float hash="dive_speed_y">2.993</float>
-      <float hash="weight">115</float>
+      <float hash="weight">98</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_b">13</float>
@@ -1935,7 +1968,7 @@
       <float hash="air_speed_y_stable">2</float>
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">2</float>
-      <float hash="weight">108</float>
+      <float hash="weight">105</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_lw">18</float>
       <float hash="scale">1.03</float>
@@ -1964,7 +1997,7 @@
       <float hash="damage_fly_top_air_accel_y">0.118</float>
       <float hash="damage_fly_top_speed_y_stable">2.3</float>
       <float hash="dive_speed_y">3.05</float>
-      <float hash="weight">126</float>
+      <float hash="weight">118</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -1993,6 +2026,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.76</float>
       <float hash="dive_speed_y">2.37</float>
+      <float hash="weight">82</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2024,7 +2058,7 @@
       <float hash="damage_fly_top_air_accel_y">0.126</float>
       <float hash="damage_fly_top_speed_y_stable">2.2</float>
       <float hash="dive_speed_y">2.953</float>
-      <float hash="weight">112</float>
+      <float hash="weight">110</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2121,6 +2155,7 @@
       <float hash="damage_fly_top_air_accel_y">0.111</float>
       <float hash="damage_fly_top_speed_y_stable">1.98</float>
       <float hash="dive_speed_y">2.7</float>
+      <float hash="weight">101</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2152,6 +2187,7 @@
       <float hash="damage_fly_top_air_accel_y">0.127</float>
       <float hash="damage_fly_top_speed_y_stable">2.33</float>
       <float hash="dive_speed_y">3.1</float>
+      <float hash="weight">104</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2247,7 +2283,7 @@
       <float hash="air_speed_y_stable">1.815</float>
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">1.815</float>
-      <float hash="weight">99</float>
+      <float hash="weight">92</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">7</float>
@@ -2276,6 +2312,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">1.825</float>
       <float hash="dive_speed_y">2.464</float>
+      <float hash="weight">91</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -2298,6 +2335,7 @@
       <float hash="jump_speed_x_max">1.27</float>
       <float hash="air_speed_x_stable">0.91</float>
       <float hash="air_speed_y_stable">1.8</float>
+      <float hash="weight">110</float>
       <float hash="damage_fly_top_air_accel_y">0.108</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -2327,7 +2365,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">2.14</float>
       <float hash="dive_speed_y">2.889</float>
-      <float hash="weight">88</float>
+      <float hash="weight">86</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_hi">9</float>
@@ -2352,7 +2390,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">2.09</float>
       <float hash="dive_speed_y">2.884</float>
-      <float hash="weight">104</float>
+      <float hash="weight">95</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">11</float>
@@ -2437,6 +2475,7 @@
       <float hash="damage_fly_top_air_accel_y">0.145</float>
       <float hash="damage_fly_top_speed_y_stable">2.5</float>
       <float hash="dive_speed_y">3.272</float>
+      <float hash="weight">86</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
@@ -2471,7 +2510,7 @@
       <float hash="damage_fly_top_air_accel_y">0.11</float>
       <float hash="damage_fly_top_speed_y_stable">2.06</float>
       <float hash="dive_speed_y">2.76</float>
-      <float hash="weight">104</float>
+      <float hash="weight">98</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">11</float>
       <float hash="landing_attack_air_frame_lw">12</float>
@@ -2537,7 +2576,7 @@
       <float hash="damage_fly_top_air_accel_y">0.1</float>
       <float hash="damage_fly_top_speed_y_stable">1.55</float>
       <float hash="dive_speed_y">2.24</float>
-      <float hash="weight">90</float>
+      <float hash="weight">88</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2572,7 +2611,7 @@
       <float hash="damage_fly_top_air_accel_y">0.12</float>
       <float hash="damage_fly_top_speed_y_stable">2.34</float>
       <float hash="dive_speed_y">3.2</float>
-      <float hash="weight">79</float>
+      <float hash="weight">78</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">8</float>
@@ -2608,7 +2647,7 @@
       <float hash="damage_fly_top_air_accel_y">0.091</float>
       <float hash="damage_fly_top_speed_y_stable">2.28</float>
       <float hash="dive_speed_y">2.698</float>
-      <float hash="weight">84</float>
+      <float hash="weight">81</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">12</float>
@@ -2639,7 +2678,7 @@
       <float hash="damage_fly_top_air_accel_y">0.114</float>
       <float hash="damage_fly_top_speed_y_stable">2.33</float>
       <float hash="dive_speed_y">2.98</float>
-      <float hash="weight">92</float>
+      <float hash="weight">90</float>
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">13</float>
@@ -2671,7 +2710,7 @@
       <float hash="damage_fly_top_air_accel_y">0.12</float>
       <float hash="damage_fly_top_speed_y_stable">2.52</float>
       <float hash="dive_speed_y">3.146</float>
-      <float hash="weight">86</float>
+      <float hash="weight">82</float>
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">9</float>
@@ -2705,6 +2744,7 @@
       <float hash="damage_fly_top_air_accel_y">0.13</float>
       <float hash="damage_fly_top_speed_y_stable">2.2</float>
       <float hash="dive_speed_y">2.9</float>
+      <float hash="weight">103</float>
       <float hash="landing_attack_air_frame_n">7</float>
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">8</float>
@@ -2733,7 +2773,7 @@
       <float hash="damage_fly_top_air_accel_y">0.09</float>
       <float hash="damage_fly_top_speed_y_stable">2.23</float>
       <float hash="dive_speed_y">3</float>
-      <float hash="weight">104</float>
+      <float hash="weight">102</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">12</float>


### PR DESCRIPTION
Weight adjustments for the roster aimed to generally lower weights and reduce overall kill percent. Not every character's weight was changed, and some had their weights increased. With Ridley in particular, his lower weight was compensated with a lower jumpsquat at 4 frames. Other changes are slated for him in a character PR. 

```
HDR Current -> New

Bowser	        128 -> 120
King K.Rool	126 -> 118
Donkey Kong	121 -> 115
Charizard	115 -> 112
King Dedede	115 -> 113
Ridley	        115 -> 98
Kazuya	        113 -> 110
Ganondorf	112 -> 111
Incineroar	112 -> 110
Samus	        111 -> 108
Piranha Plant	109 -> 109
Bowser Jr.	108 -> 106
Simon	        108 -> 105
Ike	        107 -> 104
Snake	        106 -> 105
Banjo	        106 -> 104
Link	        104
Yoshi	        104
Captain Falcon	104
Dr. Mario	104
Wario	        104 -> 106
Cloud	        104 -> 101
Terry	        104
Pyra	        104 -> 95
Mii SF		104 -> 98
Richter		104 -> 102
R.O.B.		103 -> 105
Ryu		103
Ken		103
Megaman		102
Hero		101
Mii Gunner	101
Mario		100
Byleth		100
Lucario		99 -> 96
Min min		99 -> 92
Corrin		98
Shulk		97 -> 96
Ivysaur		96 -> 91
Wii Fit Trainer	96
Roy		95 -> 85
Robin		95 -> 93
Ness		94
Lucas		94 -> 85
Pac-Man		94 -> 90
Inkling		94
Mii Brawler	94 -> 86
Popo		92
Nana		92
Villager	92 -> 86
Steve		92 -> 91
Chrom		92 -> 90
Toon Link	91 -> 85
Palutena	91 -> 90
Luigi		90 -> 100
Mewtwo		90
Diddy Kong	90 -> 85
Little Mac	90
Sephiroth	90
Dark Samus	90 -> 88
Peach		89 -> 90
Young Link	88 -> 86
Isabelle	88 -> 82
Sora		88 -> 86
Marth		87
Joker		87
Zelda		86 -> 89
Greninja	86
Duckhunt	86
Dark Pit	86 -> 82
Sheik		85
Wolf		84
Bayonetta	84
Lucina		84 -> 81
Olimar		83
Falco		82
Sonic		82
Rosalina	82 -> 94
Pit		80
Zero Suit Samus	80
Kirby		79
Pikachu		79
Daisy		79 -> 78
Metaknight	78
Mythra		78
Game&Watch	75
Squirtle	75
Fox		74 -> 75
Pichu		70
Jigglypuff	65
```

