### PR TITLE
add shoto + terry meter ui

### DIFF
--- a/dynamic/src/lib.rs
+++ b/dynamic/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ext;
 mod modules;
 pub mod frame_info;
 pub mod game_modes;
+pub mod ui;
 
 #[macro_use]
 extern crate modular_bitfield;

--- a/dynamic/src/ui.rs
+++ b/dynamic/src/ui.rs
@@ -1,0 +1,75 @@
+extern "C" {
+    #[link_name = "UiManager__set_dk_barrel_enable"]
+    fn ui_manager_set_dk_barrel_enable(entry_id: u32, enable: bool);
+
+    #[link_name = "UiManager__set_shoto_meter_enable"]
+    fn ui_manager_set_shoto_meter_enable(entry_id: u32, enable: bool);
+
+    #[link_name = "UiManager__set_shoto_bar_percentage"]
+    fn ui_manager_set_shoto_bar_percentage(entry_id: u32, percentage: f32);
+
+    #[link_name = "UiManager__set_shoto_number"]
+    fn ui_manager_set_shoto_number(entry_id: u32, number: i32);
+
+    #[link_name = "UiManager__set_ex_meter_enable"]
+    fn ui_manager_set_ex_meter_enable(entry_id: u32, enable: bool);
+
+    #[link_name = "UiManager__set_ex_meter_info"]
+    fn ui_manager_set_ex_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32);
+
+    #[link_name = "UiManager__set_ff_meter_enable"]
+    fn ui_manager_set_ff_meter_enable(entry_id: u32, enable: bool);
+
+    #[link_name = "UiManager__set_ff_meter_info"]
+    fn ui_manager_set_ff_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32);
+}
+
+pub mod UiManager {
+    pub fn set_dk_barrel_enable(entry_id: u32, enable: bool) {
+        unsafe {
+            super::ui_manager_set_dk_barrel_enable(entry_id, enable)
+        }
+    }
+
+    pub fn set_shoto_meter_enable(entry_id: u32, enable: bool) {
+        unsafe {
+            super::ui_manager_set_shoto_meter_enable(entry_id, enable)
+        }
+    }
+
+    pub fn set_shoto_bar_percentage(entry_id: u32, percentage: f32) {
+        unsafe {
+            super::ui_manager_set_shoto_bar_percentage(entry_id, percentage)
+        }
+    }
+
+    pub fn set_shoto_number(entry_id: u32, number: i32) {
+        unsafe {
+            super::ui_manager_set_shoto_number(entry_id, number)
+        }
+    }
+
+    pub fn set_ex_meter_enable(entry_id: u32, enable: bool) {
+        unsafe {
+            super::ui_manager_set_ex_meter_enable(entry_id, enable)
+        }
+    }
+
+    pub fn set_ex_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        unsafe {
+            super::ui_manager_set_ex_meter_info(entry_id, current, max, per_level)
+        }
+    }
+
+    pub fn set_ff_meter_enable(entry_id: u32, enable: bool) {
+        unsafe {
+            super::ui_manager_set_ff_meter_enable(entry_id, enable)
+        }
+    }
+
+    pub fn set_ff_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        unsafe {
+            super::ui_manager_set_ff_meter_info(entry_id, current, max, per_level)
+        }
+    }
+}

--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -150,7 +150,7 @@ pub unsafe extern "Rust" fn shotos_common(fighter: &mut L2CFighterCommon) {
 }
 
 pub unsafe fn shotos_moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    MeterModule::update(fighter.battle_object, true);
+    MeterModule::update(fighter.battle_object, false);
     if boma.kind() != *FIGHTER_KIND_DOLLY {
         utils::ui::UiManager::set_ex_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
         utils::ui::UiManager::set_ex_meter_info(
@@ -169,11 +169,11 @@ pub unsafe fn shotos_moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleOb
     // Magic Series
     //magic_series(fighter, boma, id, cat, status_kind, situation_kind, motion_kind, stick_x, stick_y, facing, frame);
 
-    if fighter.is_button_on(Buttons::AppealAll) {
-        MeterModule::show(fighter.battle_object);
-    } else {
-        MeterModule::stop_show(fighter.battle_object);
-    }
+    // if fighter.is_button_on(Buttons::AppealAll) {
+    //     MeterModule::show(fighter.battle_object);
+    // } else {
+    //     MeterModule::stop_show(fighter.battle_object);
+    // }
     backdash_energy(fighter);
 }
 

--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -151,6 +151,15 @@ pub unsafe extern "Rust" fn shotos_common(fighter: &mut L2CFighterCommon) {
 
 pub unsafe fn shotos_moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     MeterModule::update(fighter.battle_object, true);
+    if boma.kind() != *FIGHTER_KIND_DOLLY {
+        utils::ui::UiManager::set_ex_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_ex_meter_info(
+            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
+            MeterModule::meter(fighter.object()),
+            ParamModule::get_float(fighter.object(), ParamType::Common, "meter_max_damage"),
+            MeterModule::meter_per_level(fighter.object())
+        );
+    }
     //dtilt_utilt_repeat_increment(boma, id, motion_kind); // UNUSED
     tatsumaki_ex_land_cancel_hover(boma, status_kind, situation_kind);
 	//ex_shoryuken(boma, status_kind, situation_kind, motion_kind);

--- a/fighters/dolly/src/opff.rs
+++ b/fighters/dolly/src/opff.rs
@@ -750,12 +750,12 @@ unsafe fn magic_series(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMo
 pub fn dolly_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
-        MeterModule::update(fighter.object(), true);
-        if fighter.is_button_on(Buttons::AppealAll) {
-            MeterModule::show(fighter.object());
-        } else {
-            MeterModule::stop_show(fighter.object());
-        }
+        MeterModule::update(fighter.object(), false);
+        // if fighter.is_button_on(Buttons::AppealAll) {
+        //     MeterModule::show(fighter.object());
+        // } else {
+        //     MeterModule::stop_show(fighter.object());
+        // }
         utils::ui::UiManager::set_ff_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
         utils::ui::UiManager::set_ff_meter_info(
             fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,

--- a/fighters/dolly/src/opff.rs
+++ b/fighters/dolly/src/opff.rs
@@ -756,6 +756,13 @@ pub fn dolly_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
         } else {
             MeterModule::stop_show(fighter.object());
         }
+        utils::ui::UiManager::set_ff_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_ff_meter_info(
+            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
+            MeterModule::meter(fighter.object()),
+            ParamModule::get_float(fighter.object(), ParamType::Common, "meter_max_damage"),
+            MeterModule::meter_per_level(fighter.object())
+        );
 		dolly_frame(fighter)
     }
 }

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -125,6 +125,13 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
     barrel_pull(fighter, boma, status_kind, situation_kind);
     headbutt_aerial_stall(fighter, boma, id, status_kind, situation_kind, frame);
+    if VarModule::get_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER) == 0 {
+        utils::ui::UiManager::set_shoto_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_shoto_bar_percentage(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, 100.0);
+    } else {
+        utils::ui::UiManager::set_dk_barrel_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, false);
+        utils::ui::UiManager::set_shoto_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+    }
 
     // Magic Series
     //down_special_cancels(fighter, boma, id, status_kind, situation_kind, cat[0], frame);

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,6 +17,8 @@ utils-dyn = { package = "dynamic", path = "../dynamic" }
 ninput = { git = "https://github.com/blu-dev/ninput" }
 skyline-web = { git = "https://github.com/skyline-rs/skyline-web" }
 smash_script = { git = "https://github.com/blu-dev/smash-script", branch = "development" }
+once_cell = "1.15.0"
+colorgrad = "0.6.2"
 
 [patch.'https://github.com/jam1garner/smash-arc']
 smash-arc = "0.5"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod offsets;
 
 mod modules;
 mod game_modes;
+mod ui;
 
 pub use utils_dyn::ext;
 pub use utils_dyn::consts;
@@ -19,6 +20,7 @@ pub fn init() {
     modules::init();
     singletons::init();
     game_modes::install();
+    ui::install();
 
     std::panic::set_hook(Box::new(|info| {
         let location = info.location().unwrap();

--- a/utils/src/ui.rs
+++ b/utils/src/ui.rs
@@ -1,0 +1,266 @@
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+
+use self::ex_meter::ExMeter;
+use self::ff_meter::FfMeter;
+
+mod ex_meter;
+mod ff_meter;
+
+trait UiObject {
+    fn update(&mut self);
+    fn is_valid(&self) -> bool;
+    fn set_enable(&mut self, enable: bool);
+    fn is_enabled(&self) -> bool;
+}
+
+static UI_MANAGER: Lazy<RwLock<UiManager>> = Lazy::new(|| RwLock::new(UiManager { 
+    ex_meter: [ExMeter::default(); 8],
+    ff_meter: [FfMeter::default(); 8],
+}));
+
+pub struct UiManager {
+    ex_meter: [ExMeter; 8],
+    ff_meter: [FfMeter; 8]
+}
+
+impl UiManager {
+    #[export_name = "UiManager__set_dk_barrel_enable"]
+    pub extern "C" fn set_dk_barrel_enable(entry_id: u32, enable: bool) {
+        // let manager = UI_MANAGER.read();
+        // unsafe {
+        //     set_pane_visible(manager.dk_handles[entry_id as usize], enable);
+        // }
+    }
+
+    #[export_name = "UiManager__set_shoto_meter_enable"]
+    pub extern "C" fn set_shoto_meter_enable(entry_id: u32, enable: bool) {
+        // let manager = UI_MANAGER.read();
+        // unsafe {
+        //     set_pane_visible(manager.shoto_meter_handles[entry_id as usize], enable);
+        //     set_pane_visible(manager.shoto_bar_handles[entry_id as usize], enable);
+        //     set_pane_visible(manager.shoto_number_handles[entry_id as usize], enable);
+        // }
+    }
+
+    #[export_name = "UiManager__set_shoto_bar_percentage"]
+    pub extern "C" fn set_shoto_bar_percentage(entry_id: u32, percentage: f32) {
+        // let mut manager = UI_MANAGER.write();
+        // unsafe {
+        //     if manager.shoto_bar_widths[entry_id as usize] < 0.0 {
+        //         manager.shoto_bar_widths[entry_id as usize] = get_width_height(manager.shoto_bar_handles[entry_id as usize]).0;
+        //         manager.shoto_bar_heights[entry_id as usize] = get_width_height(manager.shoto_bar_handles[entry_id as usize]).1;
+        //     }
+        //     set_tex_coords(
+        //         manager.shoto_bar_handles[entry_id as usize],
+        //         [
+        //             0.0, 0.0,
+        //             percentage / 100.0, 0.0,
+        //             0.0, 1.0,
+        //             percentage / 100.0, 1.0
+        //         ]
+        //     );
+        //     set_width_height(
+        //         manager.shoto_bar_handles[entry_id as usize],
+        //         manager.shoto_bar_widths[entry_id as usize] * (percentage / 100.0),
+        //         manager.shoto_bar_heights[entry_id as usize]
+        //     );
+        // }
+    }
+
+    #[export_name = "UiManager__set_shoto_number"]
+    pub extern "C" fn set_shoto_number(entry_id: u32, number: i32) {
+        // let number = number.clamp(0, 5);
+        // let manager = UI_MANAGER.read();
+        // unsafe {
+        //     let left_x = number as f32 / 6.0;
+        //     let right_x = (number + 1) as f32 / 6.0;
+
+        //     set_tex_coords(
+        //         manager.shoto_number_handles[entry_id as usize],
+        //         [
+        //             left_x, 0.0,
+        //             right_x, 0.0,
+        //             left_x, 1.0,
+        //             right_x, 1.0
+        //         ]
+        //     );
+        // }
+    }
+
+    #[export_name = "UiManager__set_ex_meter_enable"]
+    pub extern "C" fn set_ex_meter_enable(entry_id: u32, enable: bool) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.ex_meter[entry_id as usize].set_enable(enable);
+        }
+    }
+
+    #[export_name = "UiManager__set_ex_meter_info"]
+    pub extern "C" fn set_ex_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.ex_meter[entry_id as usize].set_meter_info(current, max, per_level);
+        }
+    }
+
+    #[export_name = "UiManager__set_ff_meter_enable"]
+    pub extern "C" fn set_ff_meter_enable(entry_id: u32, enable: bool) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.ff_meter[entry_id as usize].set_enable(enable);
+        }
+    }
+
+    #[export_name = "UiManager__set_ff_meter_info"]
+    pub extern "C" fn set_ff_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.ff_meter[entry_id as usize].set_meter_info(current, max, per_level);
+        }
+    }
+}
+
+fn set_pane_visible(pane: u64, visible: bool) {
+    unsafe {
+        let internal = *(pane as *const u64);
+        *(internal as *mut u8).add(0x58) &= 0xFE;
+        *(internal as *mut u8).add(0x58) |= visible as u8;
+    }
+}
+
+fn set_pane_colors(
+    pane: u64,
+    white: [f32; 4],
+    black: [f32; 4]
+) {
+    set_vertex_colors(pane, black, black, white, white);
+}
+
+fn set_vertex_colors(
+    pane: u64,
+    tl: [f32; 4],
+    tr: [f32; 4],
+    bl: [f32; 4],
+    br: [f32; 4]
+) {
+    unsafe {
+        let internal = *(pane as *const u64);
+        let colors = [tl, tr, bl, br];
+        for (index, color) in colors.iter().enumerate() {
+            *(internal as *mut u8).add(0xe0 + index * 4) = (color[0] * 255.0) as u8;
+            *(internal as *mut u8).add(0xe1 + index * 4) = (color[1] * 255.0) as u8;
+            *(internal as *mut u8).add(0xe2 + index * 4) = (color[2] * 255.0) as u8;
+            *(internal as *mut u8).add(0xe3 + index * 4) = (color[3] * 255.0) as u8;
+        }
+    }
+}
+
+unsafe fn get_pane_by_name(layout_view: u64, name: &str) -> [u64; 4] {
+    let func: extern "C" fn(u64, *const u8, ...) -> [u64; 4] = std::mem::transmute((skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8).add(0x37752e0));
+    func(layout_view, name.as_ptr())
+}
+
+fn set_tex_coords(pane: u64, coords: [f32; 8]) {
+    unsafe {
+        let internal = *(pane as *const u64);
+        let coordinates = std::slice::from_raw_parts_mut(
+            *((internal + 0xf8) as *mut *mut f32),
+            8
+        );
+        coordinates[0] = coords[0];
+        coordinates[1] = coords[1];
+        coordinates[2] = coords[2];
+        coordinates[3] = coords[3];
+        coordinates[4] = coords[4];
+        coordinates[5] = coords[5];
+        coordinates[6] = coords[6];
+        coordinates[7] = coords[7];
+    }
+}
+
+fn is_pane_valid(pane: u64) -> bool {
+    unsafe {
+        *(pane as *const u64) != 0
+    }
+}
+
+fn set_width_height(pane: u64, width: f32, height: f32) {
+    unsafe {
+        let internal = *(pane as *const u64);
+        *(internal as *mut f32).add(0x50 / 4) = width;
+        *(internal as *mut f32).add(0x54 / 4) = height;
+    }
+}
+
+fn get_width_height(pane: u64) -> (f32, f32) {
+    unsafe {
+        let internal = *(pane as *const u64);
+        (
+            *(internal as *mut f32).add(0x50 / 4),
+            *(internal as *mut f32).add(0x54 / 4)
+        )
+    }
+}
+
+fn get_pane_from_layout(layout_data: u64, name: &str) -> Option<u64> {
+    unsafe {
+        let pane_udata = get_pane_by_name(layout_data, name);
+        if pane_udata[1] != 0 {
+            Some(pane_udata[1])
+        } else {
+            None
+        }
+    }
+}
+
+#[skyline::hook(offset = 0x1b6c108, inline)]
+unsafe fn get_set_info_alpha(ctx: &skyline::hooks::InlineCtx) {
+    let layout_udata = *ctx.registers[0].x.as_ref();
+    let layout_view = *(layout_udata as *const u64).add(1);
+    let layout_pane = *(layout_view as *const u64).add(3);
+    let ui2d_pane = *(layout_pane as *const u64);
+
+    let name_ptr = (ui2d_pane as *const u8).add(0xb0);
+    let mut len = skyline::libc::strlen(name_ptr);
+
+    let name = std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, len));
+    let index = match name {
+        "p1" => 0,
+        "p2" => 1,
+        "p3" => 2,
+        "p4" => 3,
+        "p5" => 4,
+        "p6" => 5,
+        "p7" => 6,
+        "p8" => 7,
+        _ => return
+    };
+
+    let mut manager = UI_MANAGER.write();
+
+    manager.ex_meter[index] = ExMeter::new(layout_udata);
+    manager.ff_meter[index] = FfMeter::new(layout_udata);
+}
+
+#[skyline::hook(offset = 0x138a6f0, inline)]
+fn hud_update(_: &skyline::hooks::InlineCtx) {
+    let mut mgr = UI_MANAGER.write();
+    for ex_meter in mgr.ex_meter.iter_mut() {
+        if ex_meter.is_valid() && ex_meter.is_enabled() {
+            ex_meter.update();
+        }
+    }
+    for ff_meter in mgr.ff_meter.iter_mut() {
+        if ff_meter.is_valid() && ff_meter.is_enabled() {
+            ff_meter.update();
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        get_set_info_alpha,
+        hud_update,
+    );
+}

--- a/utils/src/ui/ex_meter.rs
+++ b/utils/src/ui/ex_meter.rs
@@ -1,0 +1,343 @@
+use super::*;
+
+const BACKGROUND_WHITE: [f32; 4] = [244.0 / 255.0, 177.0 / 255.0, 31.0 / 255.0, 1.0];
+const BACKGROUND_BLACK: [f32; 4] = [88.0 / 255.0, 61.0 / 255.0, 4.0 / 255.0, 1.0];
+
+const FOREGROUND_CHARGE_WHITE: [f32; 4] = [11.0 / 255.0, 115.0 / 255.0, 234.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_BLACK: [f32; 4] = [6.0 / 255.0, 67.0 / 255.0, 136.0 / 255.0, 1.0];
+
+const FOREGROUND_CHARGED_WHITE: [f32; 4] = [133.0 / 255.0, 187.0 / 255.0, 249.0 / 255.0, 1.0];
+const FOREGROUND_CHARGED_BLACK: [f32; 4] = [9.0 / 255.0, 91.0 / 255.0, 185.0 / 255.0, 1.0];
+
+const FULL_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    1.0, 0.0,
+    0.0, 1.0,
+    1.0, 1.0
+];
+
+const EMPTY_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    0.0, 0.0,
+    0.0, 1.0,
+    0.0, 1.0
+];
+
+#[derive(Default, Copy, Clone)]
+pub struct ExMeter {
+    // Panes
+    pub base_bar: u64,
+    pub bars: [u64; 2],
+    pub bars_background: [u64; 2],
+    pub ex_icon: u64,
+    pub number: u64,
+
+    // Initial state
+    pub original_bar_width: f32,
+    pub original_bar_height: f32,
+
+    // Progress tracking
+    pub actual_percentage: f32,
+    pub visual_percentage: f32,
+
+    // Number tracking
+    pub current_number: usize,
+
+    // Pulsing
+    pub current_pulse_frame: f32,
+
+    enabled: bool,
+}
+
+impl ExMeter {
+    pub fn new(layout_data: u64) -> Self {
+        let base_bar = super::get_pane_from_layout(layout_data, "ex_meter_base\0")
+            .expect("Could not find the base EX meter!");
+
+        let bar1 = super::get_pane_from_layout(layout_data, "ex_meter_bar1\0")
+            .expect("Could not find first bar for EX meter!");
+        
+        let bar2 = super::get_pane_from_layout(layout_data, "ex_meter_bar2\0")
+            .expect("Could not find second bar for EX meter!");
+
+        let bar1_bg = super::get_pane_from_layout(layout_data, "ex_meter_bar1_bg\0")
+            .expect("Could not find first bg bar for EX meter!");
+
+        let bar2_bg = super::get_pane_from_layout(layout_data, "ex_meter_bar2_bg\0")
+            .expect("Could not find second bg bar for EX meter!");
+
+        let ex_icon = super::get_pane_from_layout(layout_data, "ex_meter_ex\0")
+            .expect("Could not find ex icon for EX meter!");
+
+        let number = super::get_pane_from_layout(layout_data, "ex_meter_number\0")
+            .expect("Could no find number for EX meter!");
+
+        Self {
+            base_bar,
+            bars: [bar1, bar2],
+            bars_background: [bar1_bg, bar2_bg],
+            ex_icon,
+            number,
+
+            original_bar_width: -1.0,
+            original_bar_height: -1.0,
+
+            actual_percentage: -1.0,
+            visual_percentage: -1.0,
+
+            current_number: 0,
+
+            current_pulse_frame: 0.0,
+            enabled: false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        set_pane_visible(self.base_bar, true);
+        set_pane_visible(self.ex_icon, false);
+        set_pane_visible(self.bars[0], false);
+        set_pane_visible(self.bars[1], false);
+        set_pane_visible(self.bars_background[0], false);
+        set_pane_visible(self.bars_background[1], false);
+        set_pane_visible(self.number, true);
+
+        if self.original_bar_height < 0.0 {
+            self.original_bar_width = get_width_height(self.bars[0]).0;
+            self.original_bar_height = get_width_height(self.bars[0]).1;
+        }
+
+        self.current_number = 0;
+        self.actual_percentage = 0.0;
+        self.visual_percentage = 0.0;
+    }
+
+    pub fn update_number(&mut self) {
+        if self.current_number == 5 {
+            set_pane_visible(self.number, false);
+            set_pane_visible(self.ex_icon, true);
+        } else {
+            set_pane_visible(self.number, true);
+            set_pane_visible(self.ex_icon, false);
+        }
+
+        let left_x = self.current_number as f32 / 5.0;
+        let right_x = (self.current_number + 1) as f32 / 5.0;
+
+        set_tex_coords(
+            self.number,
+            [
+                left_x, 0.0,
+                right_x, 0.0,
+                left_x, 1.0,
+                right_x, 1.0
+            ]
+        );
+    }
+
+    pub fn set_meter_info(&mut self, current: f32, max: f32, per_level: f32) {
+        let bar_total = per_level * 2.0;
+
+        let number = current / bar_total;
+        let number = number.clamp(0.0, 5.0) as usize;
+
+        let percent = if number == 5 {
+            1.0
+        } else {
+            (current % bar_total) / bar_total
+        };
+
+        if number != self.current_number && number != 5 {
+            self.actual_percentage = percent;
+            self.visual_percentage = 0.0;
+        } else {
+            self.actual_percentage = percent;
+        }
+
+        if number != 5 {
+            self.current_pulse_frame = 0.0;
+        }
+
+        self.current_number = number;
+    }
+
+    pub fn set_tex_coords(&mut self) {
+        // Handle the first bar
+        set_pane_colors(self.bars_background[0], BACKGROUND_BLACK, BACKGROUND_WHITE);
+        set_pane_colors(self.bars_background[1], BACKGROUND_BLACK, BACKGROUND_WHITE);
+        set_pane_colors(self.bars[0], FOREGROUND_CHARGED_BLACK, FOREGROUND_CHARGED_WHITE);
+        set_pane_colors(self.bars[1], FOREGROUND_CHARGED_BLACK, FOREGROUND_CHARGED_WHITE);
+
+        if self.actual_percentage >= 0.5 {
+            set_tex_coords(self.bars_background[0], FULL_TEXCOORDS);
+            set_width_height(self.bars_background[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+
+            if self.actual_percentage >= 1.0 {
+                set_tex_coords(self.bars_background[1], FULL_TEXCOORDS);
+                set_width_height(self.bars_background[1], self.original_bar_width, self.original_bar_height);
+                set_pane_visible(self.bars_background[1], true);
+            } else {
+                let percentage = (self.actual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars_background[1], true);
+                set_tex_coords(
+                    self.bars_background[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars_background[1], self.original_bar_width * percentage, self.original_bar_height);
+            }
+        } else {
+            set_tex_coords(self.bars_background[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars_background[1], 0.0, 0.0);
+            set_pane_visible(self.bars_background[1], false);
+
+            let percentage = self.actual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars_background[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars_background[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+        }
+    
+        if self.visual_percentage >= 0.5 {
+            set_tex_coords(self.bars[0], FULL_TEXCOORDS);
+            set_width_height(self.bars[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGED_BLACK, FOREGROUND_CHARGED_WHITE);
+
+            if self.visual_percentage >= 1.0 {
+                set_tex_coords(self.bars[1], FULL_TEXCOORDS);
+                set_width_height(self.bars[1], self.original_bar_width, self.original_bar_height);
+                set_pane_visible(self.bars[1], true);
+                set_pane_colors(self.bars[1], FOREGROUND_CHARGED_BLACK, FOREGROUND_CHARGED_WHITE);
+            } else {
+                let percentage = (self.visual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars[1], true);
+                set_tex_coords(
+                    self.bars[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars[1], self.original_bar_width * percentage, self.original_bar_height);
+                set_pane_colors(self.bars[1], FOREGROUND_CHARGE_BLACK, FOREGROUND_CHARGE_WHITE);
+            }
+        } else {
+            set_tex_coords(self.bars[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars[1], 0.0, 0.0);
+            set_pane_visible(self.bars[1], false);
+
+            let percentage = self.visual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGE_BLACK, FOREGROUND_CHARGE_WHITE);
+        }
+    }
+
+    pub fn update_pulse(&mut self) {
+        if self.current_number != 5 || self.actual_percentage > self.visual_percentage {
+            return;
+        }
+
+        let g = colorgrad::CustomGradient::new()
+            .colors(&[
+                colorgrad::Color::from_rgba8(255, 255, 255, 255),
+                colorgrad::Color::from_rgba8(
+                    (FOREGROUND_CHARGED_BLACK[0] * 255.0) as u8,
+                    (FOREGROUND_CHARGED_BLACK[1] * 255.0) as u8,
+                    (FOREGROUND_CHARGED_BLACK[2] * 255.0) as u8,
+                    (FOREGROUND_CHARGED_BLACK[3] * 255.0) as u8
+                ),
+            ])
+            .build()
+            .unwrap();
+
+        let distance = ((-(self.current_pulse_frame * 2.0).to_radians().cos() + 1.0) / 2.0).abs().powf(0.5);
+
+        let color = g.at(distance as f64);
+
+        set_pane_colors(
+            self.ex_icon,
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+        );
+
+        set_pane_colors(
+            self.bars[0],
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+        );
+
+        set_pane_colors(
+            self.bars[1],
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+            [color.r as f32, color.g as f32, color.b as f32, color.a as f32],
+        );
+        self.current_pulse_frame += 1.0;
+
+    }
+
+    pub fn update_percentages(&mut self) {
+        self.visual_percentage = f32::min(self.visual_percentage + 0.01, self.actual_percentage);
+    }
+}
+
+impl UiObject for ExMeter {
+    fn update(&mut self) {
+        self.update_number();
+        self.set_tex_coords();
+        self.update_percentages();
+        self.update_pulse();
+    }
+
+    fn is_valid(&self) -> bool {
+        is_pane_valid(self.base_bar)
+            && is_pane_valid(self.ex_icon)
+            && is_pane_valid(self.number)
+    }
+
+    fn set_enable(&mut self, enable: bool) {
+        if enable && !self.enabled {
+            self.reset();
+        } else if !enable {
+            set_pane_visible(self.base_bar, false);
+            set_pane_visible(self.ex_icon, false);
+            set_pane_visible(self.number, false);
+            set_pane_visible(self.bars[0], false);
+            set_pane_visible(self.bars[1], false);
+            set_pane_visible(self.bars_background[0], false);
+            set_pane_visible(self.bars_background[1], false);
+        }
+        self.enabled = enable;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}

--- a/utils/src/ui/ff_meter.rs
+++ b/utils/src/ui/ff_meter.rs
@@ -1,0 +1,279 @@
+use super::*;
+
+const BACKGROUND_WHITE: [f32; 4] = [244.0 / 255.0, 177.0 / 255.0, 31.0 / 255.0, 1.0];
+const BACKGROUND_BLACK: [f32; 4] = [88.0 / 255.0, 61.0 / 255.0, 4.0 / 255.0, 1.0];
+
+const FOREGROUND_CHARGE_WHITE: [f32; 4] = [11.0 / 255.0, 115.0 / 255.0, 234.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_BLACK: [f32; 4] = [6.0 / 255.0, 67.0 / 255.0, 136.0 / 255.0, 1.0];
+
+const FULL_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    1.0, 0.0,
+    0.0, 1.0,
+    1.0, 1.0
+];
+
+const EMPTY_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    0.0, 0.0,
+    0.0, 1.0,
+    0.0, 1.0
+];
+
+#[derive(Default, Copy, Clone)]
+pub struct FfMeter {
+    // Panes
+    pub base_bar: u64,
+    pub bars: [u64; 2],
+    pub bars_background: [u64; 2],
+    pub number: u64,
+
+    // Initial state
+    pub original_bar_width: f32,
+    pub original_bar_height: f32,
+
+    pub original_bar2_width: f32,
+    pub original_bar2_height: f32,
+
+    // Progress tracking
+    pub actual_percentage: f32,
+    pub visual_percentage: f32,
+
+    // Number tracking
+    pub current_number: usize,
+
+    enabled: bool,
+}
+
+impl FfMeter {
+    pub fn new(layout_data: u64) -> Self {
+        let base_bar = super::get_pane_from_layout(layout_data, "ff_meter_base\0")
+            .expect("Could not find the base FF meter!");
+
+        let bar1 = super::get_pane_from_layout(layout_data, "ff_meter_bar1\0")
+            .expect("Could not find first bar for FF meter!");
+        
+        let bar2 = super::get_pane_from_layout(layout_data, "ff_meter_bar2\0")
+            .expect("Could not find second bar for FF meter!");
+
+        let bar1_bg = super::get_pane_from_layout(layout_data, "ff_meter_bar1_bg\0")
+            .expect("Could not find first bg bar for FF meter!");
+
+        let bar2_bg = super::get_pane_from_layout(layout_data, "ff_meter_bar2_bg\0")
+            .expect("Could not find second bg bar for FF meter!");
+
+        let number = super::get_pane_from_layout(layout_data, "ff_meter_num\0")
+            .expect("Could no find number for FF meter!");
+
+        Self {
+            base_bar,
+            bars: [bar1, bar2],
+            bars_background: [bar1_bg, bar2_bg],
+            number,
+
+            original_bar_width: -1.0,
+            original_bar_height: -1.0,
+
+            original_bar2_width: -1.0,
+            original_bar2_height: -1.0,
+
+            actual_percentage: -1.0,
+            visual_percentage: -1.0,
+
+            current_number: 0,
+
+            enabled: false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        set_pane_visible(self.base_bar, true);
+        set_pane_visible(self.bars[0], false);
+        set_pane_visible(self.bars[1], false);
+        set_pane_visible(self.bars_background[0], false);
+        set_pane_visible(self.bars_background[1], false);
+        set_pane_visible(self.number, true);
+
+        if self.original_bar_height < 0.0 {
+            self.original_bar_width = get_width_height(self.bars[0]).0;
+            self.original_bar_height = get_width_height(self.bars[0]).1;
+
+            self.original_bar2_width = get_width_height(self.bars[1]).0;
+            self.original_bar2_height = get_width_height(self.bars[1]).1;
+        }
+
+        self.current_number = 0;
+        self.actual_percentage = 0.0;
+        self.visual_percentage = 0.0;
+    }
+
+    pub fn update_number(&mut self) {
+        set_pane_visible(self.number, true);
+
+        let left_x = self.current_number as f32 / 6.0;
+        let right_x = (self.current_number + 1) as f32 / 6.0;
+
+        set_tex_coords(
+            self.number,
+            [
+                left_x, 0.0,
+                right_x, 0.0,
+                left_x, 1.0,
+                right_x, 1.0
+            ]
+        );
+    }
+
+    pub fn set_meter_info(&mut self, current: f32, max: f32, per_level: f32) {
+        let bar_total = per_level * 2.0;
+
+        let number = current / bar_total;
+        let number = number.clamp(0.0, 5.0) as usize;
+
+        let percent = if number == 5 {
+            1.0
+        } else {
+            (current % bar_total) / bar_total
+        };
+
+        if number != self.current_number && number != 5 {
+            self.actual_percentage = percent;
+            self.visual_percentage = 0.0;
+        } else {
+            self.actual_percentage = percent;
+        }
+
+        self.current_number = number;
+    }
+
+    pub fn set_tex_coords(&mut self) {
+        // Handle the first bar
+        set_pane_colors(self.bars_background[0], BACKGROUND_WHITE, BACKGROUND_BLACK);
+        set_pane_colors(self.bars_background[1], BACKGROUND_WHITE, BACKGROUND_BLACK);
+        set_pane_colors(self.bars[0], FOREGROUND_CHARGE_WHITE, FOREGROUND_CHARGE_BLACK);
+        set_pane_colors(self.bars[1], FOREGROUND_CHARGE_WHITE, FOREGROUND_CHARGE_BLACK);
+
+        if self.actual_percentage >= 0.5 {
+            set_tex_coords(self.bars_background[0], FULL_TEXCOORDS);
+            set_width_height(self.bars_background[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+
+            if self.actual_percentage >= 1.0 {
+                set_tex_coords(self.bars_background[1], FULL_TEXCOORDS);
+                set_width_height(self.bars_background[1], self.original_bar2_width, self.original_bar2_height);
+                set_pane_visible(self.bars_background[1], true);
+            } else {
+                let percentage = (self.actual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars_background[1], true);
+                set_tex_coords(
+                    self.bars_background[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars_background[1], self.original_bar2_width * percentage, self.original_bar2_height);
+            }
+        } else {
+            set_tex_coords(self.bars_background[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars_background[1], 0.0, 0.0);
+            set_pane_visible(self.bars_background[1], false);
+
+            let percentage = self.actual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars_background[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars_background[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+        }
+    
+        if self.visual_percentage >= 0.5 {
+            set_tex_coords(self.bars[0], FULL_TEXCOORDS);
+            set_width_height(self.bars[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+
+            if self.visual_percentage >= 1.0 {
+                set_tex_coords(self.bars[1], FULL_TEXCOORDS);
+                set_width_height(self.bars[1], self.original_bar2_width, self.original_bar2_height);
+                set_pane_visible(self.bars[1], true);
+            } else {
+                let percentage = (self.visual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars[1], true);
+                set_tex_coords(
+                    self.bars[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars[1], self.original_bar2_width * percentage, self.original_bar2_height);
+            }
+        } else {
+            set_tex_coords(self.bars[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars[1], 0.0, 0.0);
+            set_pane_visible(self.bars[1], false);
+
+            let percentage = self.visual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+        }
+    }
+
+    pub fn update_percentages(&mut self) {
+        self.visual_percentage = f32::min(self.visual_percentage + 0.01, self.actual_percentage);
+    }
+}
+
+impl UiObject for FfMeter {
+    fn update(&mut self) {
+        self.update_number();
+        self.set_tex_coords();
+        self.update_percentages();
+    }
+
+    fn is_valid(&self) -> bool {
+        is_pane_valid(self.base_bar)
+            && is_pane_valid(self.number)
+    }
+
+    fn set_enable(&mut self, enable: bool) {
+        if enable && !self.enabled {
+            self.reset();
+        } else if !enable {
+            set_pane_visible(self.base_bar, false);
+            set_pane_visible(self.number, false);
+            set_pane_visible(self.bars[0], false);
+            set_pane_visible(self.bars[1], false);
+            set_pane_visible(self.bars_background[0], false);
+            set_pane_visible(self.bars_background[1], false);
+        }
+        self.enabled = enable;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}


### PR DESCRIPTION
adds shoto + terry meter UI.

requires this layout.arc in hdr-assets/ui/info/info_melee/info_melee/layout.arc
[layout.arc.zip](https://github.com/HDR-Development/HewDraw-Remix/files/9816205/layout_1.arc.zip)
