### PR TITLE
Buff wavedashes universally to halfway between before and now

### DIFF
--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -95,7 +95,9 @@ pub unsafe fn status_end_EscapeAir(fighter: &mut L2CFighterCommon) -> L2CValue {
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_SLIDE) {
             let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_frame_escape_air_slide_max"));
             WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+            let global_speed_mul = ParamModule::get_float(fighter.object(), ParamType::Common, "wavedash_speed_mul");
             let speed_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_motion"), hash40("landing_speed_mul_escape_air_slide"));
+            let speed_mul = speed_mul * global_speed_mul;
             fighter.clear_lua_stack();
             lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP);
             let speed_x = app::sv_kinetic_energy::get_speed_x(fighter.lua_state_agent) * speed_mul;

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -40,4 +40,5 @@
     </struct>
     <float hash="ucf_escape_stick_y">-0.8</float>
     <float hash="ucf_pass_stick_y">-0.675</float>
+    <float hash="wavedash_speed_mul">0.8945</float>
 </struct>

--- a/romfs/source/fighter/common/param/fighter_param_motion.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param_motion.prcxml
@@ -32,7 +32,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="1">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -65,7 +65,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="2">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -98,7 +98,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="3">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -131,7 +131,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="4">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -164,7 +164,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="5">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -197,7 +197,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="6">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -230,7 +230,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="7">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -263,7 +263,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="8">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -296,7 +296,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="9">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -329,7 +329,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="10">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -362,7 +362,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="11">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -395,7 +395,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">63</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="12">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -428,7 +428,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="13">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -461,7 +461,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="14">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -494,7 +494,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="15">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -527,7 +527,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="16">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -560,7 +560,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="17">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -593,7 +593,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">60</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="18">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -626,7 +626,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="19">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -659,7 +659,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="20">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -692,7 +692,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="21">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -725,7 +725,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="22">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -758,7 +758,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="23">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -791,7 +791,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="24">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -824,7 +824,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="25">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -857,7 +857,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="26">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -890,7 +890,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="27">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -923,7 +923,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="28">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -956,7 +956,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="29">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -989,7 +989,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="30">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1022,7 +1022,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="31">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1055,7 +1055,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="32">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1088,7 +1088,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="33">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1121,7 +1121,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="34">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1154,7 +1154,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="35">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1187,7 +1187,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="36">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1220,7 +1220,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="37">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1253,7 +1253,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="38">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1286,7 +1286,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="39">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1319,7 +1319,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="40">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1352,7 +1352,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="41">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1385,7 +1385,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="42">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1418,7 +1418,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="43">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1451,7 +1451,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="44">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1484,7 +1484,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="45">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1517,7 +1517,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="46">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1550,7 +1550,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="47">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1583,7 +1583,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="48">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1616,7 +1616,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="49">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1649,7 +1649,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="50">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1682,7 +1682,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="51">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1715,7 +1715,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="52">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1748,7 +1748,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="53">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1781,7 +1781,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="54">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1814,7 +1814,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="55">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1847,7 +1847,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="56">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1880,7 +1880,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="57">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1913,7 +1913,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="58">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1946,7 +1946,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="59">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1979,7 +1979,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="60">
       <float hash="escape_n_hit_xlu_frame">7</float>
@@ -2012,7 +2012,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="61">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2045,7 +2045,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="62">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2078,7 +2078,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="63">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2111,7 +2111,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="64">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2144,7 +2144,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="65">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2177,7 +2177,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="66">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2210,7 +2210,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="67">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2243,7 +2243,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="68">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2276,7 +2276,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="69">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2309,7 +2309,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="70">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2342,7 +2342,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="71">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2375,7 +2375,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="72">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2408,7 +2408,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="73">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2441,7 +2441,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="74">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2474,7 +2474,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="75">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2507,7 +2507,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="76">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2540,7 +2540,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="77">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2573,7 +2573,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="78">
       <float hash="escape_n_hit_xlu_frame">7</float>
@@ -2606,7 +2606,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="79">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2639,7 +2639,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="80">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2672,7 +2672,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="81">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2705,7 +2705,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="82">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2738,7 +2738,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="83">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2771,7 +2771,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">60</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="84">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2804,7 +2804,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="85">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2837,7 +2837,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="86">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2870,7 +2870,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="87">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2903,7 +2903,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="88">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2936,7 +2936,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="89">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2969,7 +2969,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="90">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3002,7 +3002,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="91">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3023,7 +3023,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="92">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3044,7 +3044,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
     <struct index="93">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3065,7 +3065,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.832</float>
+      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
     </struct>
   </list>
 </struct>

--- a/romfs/source/fighter/common/param/fighter_param_motion.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param_motion.prcxml
@@ -32,7 +32,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="1">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -65,7 +65,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="2">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -98,7 +98,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="3">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -131,7 +131,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="4">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -164,7 +164,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="5">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -197,7 +197,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="6">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -230,7 +230,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">47</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="7">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -263,7 +263,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="8">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -296,7 +296,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="9">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -329,7 +329,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="10">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -362,7 +362,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="11">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -395,7 +395,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">63</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="12">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -428,7 +428,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="13">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -461,7 +461,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="14">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -494,7 +494,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="15">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -527,7 +527,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="16">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -560,7 +560,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="17">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -593,7 +593,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">60</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="18">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -626,7 +626,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="19">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -659,7 +659,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="20">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -692,7 +692,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="21">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -725,7 +725,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="22">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -758,7 +758,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="23">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -791,7 +791,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="24">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -824,7 +824,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="25">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -857,7 +857,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="26">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -890,7 +890,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="27">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -923,7 +923,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="28">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -956,7 +956,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="29">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -989,7 +989,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="30">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1022,7 +1022,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="31">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1055,7 +1055,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="32">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1088,7 +1088,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="33">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1121,7 +1121,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="34">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1154,7 +1154,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="35">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1187,7 +1187,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="36">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1220,7 +1220,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="37">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1253,7 +1253,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="38">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1286,7 +1286,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="39">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1319,7 +1319,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="40">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1352,7 +1352,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="41">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1385,7 +1385,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="42">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1418,7 +1418,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="43">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1451,7 +1451,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="44">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1484,7 +1484,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="45">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1517,7 +1517,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="46">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1550,7 +1550,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="47">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1583,7 +1583,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="48">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1616,7 +1616,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="49">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1649,7 +1649,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="50">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1682,7 +1682,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">50</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="51">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1715,7 +1715,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="52">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1748,7 +1748,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">59</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="53">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1781,7 +1781,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="54">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1814,7 +1814,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="55">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1847,7 +1847,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="56">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1880,7 +1880,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="57">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1913,7 +1913,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="58">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1946,7 +1946,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="59">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -1979,7 +1979,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="60">
       <float hash="escape_n_hit_xlu_frame">7</float>
@@ -2012,7 +2012,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="61">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2045,7 +2045,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="62">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2078,7 +2078,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="63">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2111,7 +2111,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="64">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2144,7 +2144,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="65">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2177,7 +2177,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="66">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2210,7 +2210,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="67">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2243,7 +2243,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="68">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2276,7 +2276,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="69">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2309,7 +2309,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="70">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2342,7 +2342,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="71">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2375,7 +2375,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="72">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2408,7 +2408,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="73">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2441,7 +2441,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="74">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2474,7 +2474,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="75">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2507,7 +2507,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">55</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="76">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2540,7 +2540,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="77">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2573,7 +2573,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">57</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="78">
       <float hash="escape_n_hit_xlu_frame">7</float>
@@ -2606,7 +2606,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">52</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="79">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2639,7 +2639,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="80">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2672,7 +2672,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="81">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2705,7 +2705,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="82">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2738,7 +2738,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="83">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2771,7 +2771,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">60</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="84">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2804,7 +2804,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="85">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2837,7 +2837,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="86">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2870,7 +2870,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">58</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="87">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2903,7 +2903,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">54</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="88">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2936,7 +2936,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">53</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="89">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -2969,7 +2969,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">56</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="90">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3002,7 +3002,7 @@
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="escape_air_slide_cancel_frame">51</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="91">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3023,7 +3023,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="92">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3044,7 +3044,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
     <struct index="93">
       <float hash="escape_n_hit_xlu_frame">3</float>
@@ -3065,7 +3065,7 @@
       <float hash="escape_air_slide_end_speed">0.4</float>
       <float hash="escape_air_slide_stiff_start_frame">500</float>
       <float hash="landing_frame_escape_air_slide_max">10</float>
-      <float hash="landing_speed_mul_escape_air_slide">0.8945</float>
+      <float hash="landing_speed_mul_escape_air_slide">1</float>
     </struct>
   </list>
 </struct>


### PR DESCRIPTION
This buffs wavedash lengths (`landing_speed_mul_escape_air_slide`) universally to halfway between what they are now, and what they were before.
Originally: `0.957`
Currently: `0.832`
This PR: `0.8945`

From here on out we intend to balance this on an individual level.