### PR TITLE
Joker - restoration of pre-ECB change gundash window

### DIFF
--- a/romfs/source/fighter/jack/param/vl.prcxml
+++ b/romfs/source/fighter/jack/param/vl.prcxml
@@ -28,7 +28,9 @@
   <list hash="param_special_n">
     <struct index="0">
       <float hash="start_speed_mul_x">1</float>
-      <float hash="air_accel_y">0.05</float>
+      <float hash="air_start_speed_mul_y">0.5</float>
+      <float hash="air_accel_y">0.0398</float>
+      <float hash="air_speed_y_stable">1.2</float>
       <int hash="landing_frame">4</int>
     </struct>
     <struct index="1">


### PR DESCRIPTION
Decreased air_accel_y from 0.05 to 0.0398 to bring back consistency to gundashing/goondashing. Due to the ECB overhaul, gundashing forward was extremely hard to perform for no reason and you have to be frame perfect with it.