### PR TITLE
revert b reverse window to 10f

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -65,7 +65,7 @@
     <float index="9">0.01</float>
   </list>
   <float hash="mini_jump_attack_mul">1</float>
-  <int hash="special_air_n_turn_frame">15</int>
+  <int hash="special_air_n_turn_frame">10</int>
   <byte hash="special_command_life_max">10</byte>
   <byte hash="super_special_command_life_max">20</byte>
   <float hash="catch_dash_brake_mul">1</float>


### PR DESCRIPTION
this reverts the b reverse window from 15f back to 10f, to reduce unintended B reverse inputs.