### PR TITLE
Pichu - Discharge buff

### DIFF
--- a/fighters/pichu/src/acmd/specials.rs
+++ b/fighters/pichu/src/acmd/specials.rs
@@ -187,11 +187,13 @@ unsafe fn pichu_special_lw_game(fighter: &mut L2CAgentBase) {
             WorkModule::on_flag(boma, /*Flag*/ *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_KAMINARI_GENERATE);
         }
         else {
+            let charge_state_time = ParamModule::get_int(boma.object(), ParamType::Agent, "charge_state_time") as f32;
             let charge_state_remaining = VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) as f32;
-            // Full Charge State time = 900
-            // 1 second to use full power Discharge before decreasing in power = 840 max cap
-            // 25% full power at minimum = 210 min cap
-            let discharge_power_mul = charge_state_remaining.clamp(210.0, 840.0)/840.0;
+            // 1 second to use full power Discharge before it starts decreasing in power
+            let discharge_decrease_power_frame = charge_state_time - 60.0;
+            // 50% power at minimum
+            let discharge_min_power_mul = ParamModule::get_float(boma.object(), ParamType::Agent, "discharge_min_power_mul");
+            let discharge_power_mul = 1.0 - ((1.0 - (charge_state_remaining.min(discharge_decrease_power_frame)/discharge_decrease_power_frame)) * discharge_min_power_mul);
             VarModule::set_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL, discharge_power_mul);
             VarModule::on_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK);
             VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, 0);
@@ -249,7 +251,7 @@ unsafe fn pichu_special_lw_hit_effect(fighter: &mut L2CAgentBase) {
     WorkModule::is_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_KAMINARI_ATTACK_HIT);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
-            let discharge_effect_mul = 1.0 - ((1.0 - VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL)) * 0.5);
+            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_kaminari_hit2"), Hash40::new("hip"), 0, 0, 0, 0, 90, 0, 1.15 * discharge_effect_mul, true);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_final_explosion"), Hash40::new("hip"), 0, 0, 0, 0, 0, 0, 0.3 * discharge_effect_mul, false);
         }
@@ -368,7 +370,7 @@ unsafe fn pichu_special_air_lw_hit_effect(fighter: &mut L2CAgentBase) {
     WorkModule::is_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_KAMINARI_ATTACK_HIT);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
-            let discharge_effect_mul = 1.0 - ((1.0 - VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL)) * 0.5);
+            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_kaminari_hit2"), Hash40::new("hip"), 0, 0, 0, 0, 90, 0, 1.15 * discharge_effect_mul, true);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_final_explosion"), Hash40::new("hip"), 0, 0, 0, 0, 0, 0, 0.3 * discharge_effect_mul, false);
         }

--- a/fighters/pichu/src/opff.rs
+++ b/fighters/pichu/src/opff.rs
@@ -15,7 +15,8 @@ unsafe fn charge_state_increase(boma: &mut BattleObjectModuleAccessor) {
     MeterModule::update(boma.object(), false);
     if VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_LEVEL) == 0 {
         if MeterModule::level(boma.object()) >= 2 {
-            VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, 900);
+            let charge_state_time = ParamModule::get_int(boma.object(), ParamType::Agent, "charge_state_time");
+            VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, charge_state_time);
             MeterModule::reset(boma.object());
             VarModule::set_int(boma.object(), vars::pichu::instance::CHARGE_LEVEL, 1);
             //gimmick_flash(boma);
@@ -28,24 +29,25 @@ unsafe fn charge_state_decrease(boma: &mut BattleObjectModuleAccessor) {
     if VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_LEVEL) == 1 {
         if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) > 0 
         && !boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]) {
+            let charge_state_time = ParamModule::get_int(boma.object(), ParamType::Agent, "charge_state_time");
             VarModule::dec_int(boma.object(), vars::common::instance::GIMMICK_TIMER);
-            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == 870 {
+            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == charge_state_time - 30 {
                 let handle = VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_EFFECT_HANDLER);
                 EffectModule::set_scale(boma, handle as u32, &Vector3f{ x: 0.8, y: 0.8, z: 0.8 });
             }
-            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == 860 {
+            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == charge_state_time - 40 {
                 let handle = VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_EFFECT_HANDLER);
                 EffectModule::set_scale(boma, handle as u32, &Vector3f{ x: 0.7, y: 0.7, z: 0.7 });
             }
-            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == 850 {
+            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == charge_state_time - 50 {
                 let handle = VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_EFFECT_HANDLER);
                 EffectModule::set_scale(boma, handle as u32, &Vector3f{ x: 0.6, y: 0.6, z: 0.6 });
             }
-            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == 840 {
+            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == charge_state_time - 60 {
                 let handle = VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_EFFECT_HANDLER);
                 EffectModule::set_scale(boma, handle as u32, &Vector3f{ x: 0.5, y: 0.5, z: 0.5 });
             }
-            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == 828 {
+            if VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) == charge_state_time - 72 {
                 STOP_SE(get_fighter_common_from_accessor(boma), Hash40::new("vc_pichu_final01"));
             }
         }
@@ -76,8 +78,10 @@ unsafe fn charge_state_damage_multipliers(boma: &mut BattleObjectModuleAccessor)
         VarModule::set_float(boma.object(), vars::pichu::instance::CHARGE_RECOIL_MUL, 1.0);
     }
     else if VarModule::get_int(boma.object(), vars::pichu::instance::CHARGE_LEVEL) == 1 {
-        VarModule::set_float(boma.object(), vars::pichu::instance::CHARGE_DAMAGE_MUL, 1.2);
-        VarModule::set_float(boma.object(), vars::pichu::instance::CHARGE_RECOIL_MUL, 1.25);
+        let charge_state_damage_mul = ParamModule::get_float(boma.object(), ParamType::Agent, "charge_state_damage_mul");
+        let charge_state_recoil_mul = ParamModule::get_float(boma.object(), ParamType::Agent, "charge_state_recoil_mul");
+        VarModule::set_float(boma.object(), vars::pichu::instance::CHARGE_DAMAGE_MUL, charge_state_damage_mul);
+        VarModule::set_float(boma.object(), vars::pichu::instance::CHARGE_RECOIL_MUL, charge_state_recoil_mul);
     }
 }
 

--- a/romfs/config.json
+++ b/romfs/config.json
@@ -15,6 +15,9 @@
 		],
 		"fighter/lucario/cmn": [
 			"fighter/lucario/param/hdr.prc"
+		],
+		"fighter/pichu/cmn": [
+			"fighter/pichu/param/hdr.prc"
 		]
 	}
 }

--- a/romfs/source/fighter/pichu/param/hdr.xml
+++ b/romfs/source/fighter/pichu/param/hdr.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <int hash="charge_state_time">900</int>
+    <float hash="charge_state_damage_mul">1.2</float>
+    <float hash="charge_state_recoil_mul">1.25</float>
+    <float hash="discharge_min_power_mul">0.5</float>
+</struct>

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -2,3 +2,4 @@ luigi: fighter/luigi/param/hdr.prc
 pikmin: fighter/pikmin/param/hdr.prc
 lucas: fighter/lucas/param/hdr.prc
 lucario: fighter/lucario/param/hdr.prc
+lucario: fighter/pichu/param/hdr.prc

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -2,4 +2,4 @@ luigi: fighter/luigi/param/hdr.prc
 pikmin: fighter/pikmin/param/hdr.prc
 lucas: fighter/lucas/param/hdr.prc
 lucario: fighter/lucario/param/hdr.prc
-lucario: fighter/pichu/param/hdr.prc
+pichu: fighter/pichu/param/hdr.prc

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -4,3 +4,4 @@ fighter/luigi/param/hdr.xml
 fighter/pikmin/param/hdr.xml
 fighter/lucas/param/hdr.xml
 fighter/lucario/param/hdr.xml
+fighter/pichu/param/hdr.xml


### PR DESCRIPTION
Minimum power/size of Discharge is now 50% of full strength rather than 25%.
Effect sizes for reduced power Discharge also adjusted to better match hitboxes.

Also moves Pichu's Charge State constants to ParamModule.