### PR TITLE
CC buff

### DIFF
--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -94,6 +94,11 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
                 }
             }
         }
+        if boma.is_status(*FIGHTER_STATUS_KIND_DAMAGE_AIR)
+        && next_status == *FIGHTER_STATUS_KIND_LANDING
+        && boma.motion_frame() < 1.0 {
+            VarModule::on_flag(boma.object(), vars::common::instance::IS_CC_NON_TUMBLE);
+        }
 
         if boma.kind() == *FIGHTER_KIND_TRAIL
         && StatusModule::status_kind(boma) == *FIGHTER_TRAIL_STATUS_KIND_SPECIAL_S_SEARCH


### PR DESCRIPTION
Hitstun is now halved if you land on frame 1 of non-tumble knockback (due to ASDI down), even if not crouching before the hit.

This brings the criteria to get halved hitstun on non-tumble knockback landing to either:
- If you were crouching before getting hit
- If you ASDI down to land on frame 1

This increases CC's effectiveness against multihits and grounded combos.