### PR TITLE
Changed the logic for clearing STATUS vars

### DIFF
--- a/fighters/common/src/function_hooks/init_settings.rs
+++ b/fighters/common/src/function_hooks/init_settings.rs
@@ -110,14 +110,14 @@ unsafe fn init_settings_hook(boma: &mut BattleObjectModuleAccessor, situation: s
     let object = boma.object();
     if VarModule::has_var_module(object) {
         let mut mask = 0;
-        if keep_flag == *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG {
+        if keep_flag != *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_FLAG {
             mask += VarModule::RESET_STATUS_FLAG;
         }
-        if keep_int == *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT {
+        if keep_int != *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_INT {
             mask += VarModule::RESET_STATUS_INT;
             mask += VarModule::RESET_STATUS_INT64;
         }
-        if keep_float == *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT {
+        if keep_float != *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_FLOAT {
             mask += VarModule::RESET_STATUS_FLOAT;
         }
         VarModule::reset(object, mask);


### PR DESCRIPTION
Updates the logic for clearing STATUS variables. Before, STATUS vars were cleared when init_settings was passed the `KEEP_NONE` flag for FLAG, INT, and FLOAT. Now, STATUS vars will get cleared when init settings is *not* passed the `KEEP_ALL` flag instead. This should catch more cases where we would *want* STATUS vars to be cleared, but aren't.

Example: Hero's `IS_CRITICAL_HIT` status flag will get carried over if he is hit during an attack that uses it, as the `DAMAGE` statuses don't pass `KEEP_NONE`, but a different, damage-specific flag. With this change, `IS_CRITICAL_HIT` will get cleared *when Hero gets hit*, instead of *after Hero leaves the Damage-related statuses*.