### PR TITLE
Robin Nair/Thoron tweaks

### DIFF
--- a/fighters/robin/src/acmd/aerials.rs
+++ b/fighters/robin/src/acmd/aerials.rs
@@ -5,9 +5,17 @@ use super::*;
 unsafe fn reflet_attack_air_n_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 0.75);
+    }
     frame(lua_state, 4.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+    }
+    frame(lua_state, 8.0);
+    if is_excute(fighter ) {
+        FT_MOTION_RATE(fighter, 1.0);
     }
     frame(lua_state, 9.0);
     if is_excute(fighter) {

--- a/fighters/robin/src/acmd/specials.rs
+++ b/fighters/robin/src/acmd/specials.rs
@@ -2,12 +2,46 @@
 use super::*;
 
 
+#[acmd_script( agent = "reflet", script = "game_specialntronstart" , category = ACMD_GAME , low_priority)]
+unsafe fn reflet_special_n_tron_start_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 15.0/(19.0-1.0));
+    frame(lua_state, 19.0);
+    FT_MOTION_RATE(fighter, 1.0);
+}
+
+
+
+#[acmd_script( agent = "reflet", script = "game_specialairntronstart" , category = ACMD_GAME , low_priority)]
+unsafe fn reflet_special_air_n_tron_start_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 15.0/(19.0-1.0));
+    frame(lua_state, 19.0);
+    FT_MOTION_RATE(fighter, 1.0);
+}
+
+
+
+#[acmd_script( agent = "reflet", script = "game_specialntronend" , category = ACMD_GAME , low_priority)]
+unsafe fn reflet_special_n_tron_end_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 0.7); //FAF is frame 61
+    }
+}
+
+
 #[acmd_script( agent = "reflet", script = "game_specialairntronend" , category = ACMD_GAME , low_priority)]
 unsafe fn reflet_special_air_n_tron_end_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.5);
+        FT_MOTION_RATE(fighter, 0.35); //FAF is frame 63
     }
 }
 
@@ -83,6 +117,9 @@ unsafe fn reflet_special_air_hi_game(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
+        reflet_special_n_tron_start_game,
+        reflet_special_air_n_tron_start_game,
+        reflet_special_n_tron_end_game,
         reflet_special_air_n_tron_end_game,
         reflet_special_hi_game,
         reflet_special_air_hi_game,


### PR DESCRIPTION
Minor correction on Robin's Nair startup and Thoron buff
- Previously Robin's nair was supposed to matched vanilla ultimate's frame data but did not. Robin's nair now currently starts at frame 7 instead of the previous frame 9.
- Thoron's startup has been reduced from frame 23 to frame 17. The grounded/aerial FAF has been reduced from 75/78 -> 61/63
