### PR TITLE
Improve matching against previous merges for queued nightlies

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -28,7 +28,7 @@ jobs:
         id: last_merge
         shell: bash
         run: |
-          echo "short_hash=$(echo $(git log --pretty=format:"%h" --merges -n 2) | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+          echo "short_hash=$(echo $(git log --oneline --merges -n 10 | grep -m2 "pull request" | tail -n1 | cut -d' ' -f1))" >> $GITHUB_OUTPUT
 
       - run: |
           echo "Last Merge: ${{ steps.last_merge.outputs.short_hash }}"


### PR DESCRIPTION
more accurately get the most recent merge to `dev`, to run status checks for `version_and_changelog`