### PR TITLE
Collision improvements

### DIFF
--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -14,9 +14,16 @@ unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash:
     let mut start_frame = arg3;
     change_motion_pos_shift_check(boma);
     if boma.is_fighter() {
-        // Starts heavy landing animation on frame 2
+        // Starts landing animations on frame 2
         // This is a purely aesthetic change, makes for snappier landings
-        if motion_hash == Hash40::new("landing_heavy") {
+        if [Hash40::new("landing_heavy"),
+            Hash40::new("landing_air_n"),
+            Hash40::new("landing_air_f"),
+            Hash40::new("landing_air_b"),
+            Hash40::new("landing_air_hi"),
+            Hash40::new("landing_air_lw"),
+            Hash40::new("landing_fall_special")].contains(&motion_hash)
+        {
             start_frame = 1.0;
         }
     }

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -212,7 +212,7 @@ unsafe fn groundcollision__processgroundcollisioninfo_check_landing_sub(groundco
 pub fn install() {
     unsafe {
         // Removes 0.3 unit leniency above ECB bottom when deciding whether to land
-        // which reduces frequency of NILs
+        // which reduces frequency of platform cancels
         skyline::patching::Patch::in_text(0x540dd8).data(0x529ae148);
         skyline::patching::Patch::in_text(0x540ddc).data(0x72a78468);
     }

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -224,7 +224,6 @@ pub fn install() {
         get_touch_flag_hook,
         groundcollision__processgroundcollisioninfo_check_landing,
         ground_module_ecb_point_calc_hook,
-        model_module_joint_global_position_with_offset_hook,
-        //groundmodule__setcorrect
+        model_module_joint_global_position_with_offset_hook
     );
 }

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -105,61 +105,6 @@ unsafe fn get_touch_flag_hook(boma: &mut BattleObjectModuleAccessor) -> i32 {
 }
 
 
-// Unused for now
-#[skyline::hook(offset = 0x6ca950)]
-unsafe fn ground_module_update_hook(ground_module: u64) {
-    let boma = *((ground_module + 0x20) as *mut *mut BattleObjectModuleAccessor);
-    // The original function calls ground_module_update_rhombus_sub
-    call_original!(ground_module);
-}
-
-
-// Unused for now
-
-// This function is used to calculate your ECB's 4 points
-// Once calculated, it stores each point's coordinates as a Vector4f
-// These 4 Vector4fs are stored in param_3's Vector4f pointer
-#[skyline::hook(offset = 0x45f6c0)]
-unsafe fn ground_module_update_rhombus_sub(ground_module: u64, param_2: u64, param_3: *mut Vector4f) {
-    let boma = *((ground_module + 0x20) as *mut *mut BattleObjectModuleAccessor);
-    // This routine corrects your position upon landing
-    // Otherwise, characters will appear stuck halfway into the ground on the first frame of landing
-    if (*boma).is_fighter() {
-        let prev_pos = *PostureModule::prev_pos(boma);
-        let pos = *PostureModule::pos(boma);
-        let prev_ecb_bottom_y_offset = VarModule::get_float((*boma).object(), vars::common::instance::ECB_BOTTOM_Y_OFFSET);
-        let prev_ecb_bottom_pos_y = prev_pos.y + prev_ecb_bottom_y_offset + 0.2;
-        let mut prev_ground_pos = Vector2f::zero();
-        GroundModule::line_segment_check(boma, &Vector2f::new(pos.x, prev_ecb_bottom_pos_y), &Vector2f::new(pos.x, prev_ecb_bottom_pos_y - 999.0), &Vector2f::zero(), &mut prev_ground_pos, true);
-
-        // The original function calls ground_module_ecb_point_calc_hook
-        call_original!(ground_module, param_2, param_3);
-
-        let ecb_bottom_pos_y = pos.y + (*param_3.add(1)).y;
-        // (*param_3.add(1)).y is your ECB bottom's vertical offset from your base position (AKA your vertical ECB shift)
-        if (*param_3.add(1)).y != 0.0 {
-            let mut ground_pos_any = Vector2f::zero();
-            let mut ground_pos_stage = Vector2f::zero();
-            GroundModule::line_segment_check(boma, &Vector2f::new(pos.x, ecb_bottom_pos_y), &Vector2f::new(pos.x, ecb_bottom_pos_y + 999.0), &Vector2f::zero(), &mut ground_pos_any, true);
-            GroundModule::line_segment_check(boma, &Vector2f::new(pos.x, ecb_bottom_pos_y), &Vector2f::new(pos.x, ecb_bottom_pos_y + 999.0), &Vector2f::zero(), &mut ground_pos_stage, false);
-
-            if ecb_bottom_pos_y < prev_ecb_bottom_pos_y  // if your ECB was moving downwards
-            && ((ground_pos_any != Vector2f::zero() && ground_pos_stage == Vector2f::zero() && !GroundModule::is_passable_check(boma))  // if you touched a platform without passing through
-                || ground_pos_stage != Vector2f::zero())  // or you touched stage
-            && (prev_ground_pos.y - ground_pos_any.y).abs() < 1.0  // if the same surface that was under your ECB bottom on the previous frame is now above your ECB bottom on the current frame
-            {
-                // Reset your ECB shift to 0.0
-                (*param_3.add(1)).y = 0.0;
-            }
-        }
-        VarModule::set_float((*boma).object(), vars::common::instance::ECB_BOTTOM_Y_OFFSET, (*param_3.add(1)).y);
-    }
-    else {
-        call_original!(ground_module, param_2, param_3);
-    }
-}
-
-
 // This function is used to calculate the following:
 //      param_2: Left ECB point's horizontal offset from Top bone (negative number)
 //      param_3: Bottom ECB point's vertical offset from Top bone (positive number, 0.0 in vanilla)
@@ -218,13 +163,68 @@ unsafe fn model_module_joint_global_position_with_offset_hook(model_module: u64,
     call_original!(model_module, bone, param_3, param_4, param_5);
 }
 
+// Unused for now
+#[skyline::hook(offset = 0x523a60)]
+unsafe fn groundcollision__processgroundcollisioninfo(groundcollisioninfo: *mut f32, groundcollision: *mut u64) {
+    call_original!(groundcollisioninfo, groundcollision)
+}
+
+// Performs ground correct
+#[skyline::hook(offset = 0x53fe30)]
+unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollisioninfo: *mut f32, groundcollision: *mut u64) {
+    call_original!(groundcollisioninfo, groundcollision);
+    let prev_touch_pos_y = *groundcollisioninfo.add(0x1A4 / 4);
+    let touch_pos_y = *groundcollisioninfo.add(0xB4 / 4);
+    let ecb_y_offset = *groundcollisioninfo.add(0x3d4 / 4);
+    //println!("situation kind {}", *groundcollisioninfo.add(0x5a0 / 4));
+
+    if prev_touch_pos_y == 0.0
+    && touch_pos_y != 0.0
+    && ecb_y_offset != 0.0
+    {
+        // When landing, sets your position to the coordinates of the surface you are landing on
+        *groundcollisioninfo.add(0x634 / 4) = touch_pos_y;
+        *groundcollisioninfo.add(0x3d4 / 4) = 0.0;
+    }
+}
+// Unused for now
+// Sets GroundCollisionLine
+#[skyline::hook(offset = 0x52d900)]
+unsafe fn groundcollision__processgroundcollisioninfo_check_landing_sub(groundcollision: u64, arg2: *mut u64, prev_ecb_bottom_pos: *mut smash::phx::Vector2f, ecb_bottom_translation: *mut smash::phx::Vector2f, arg5: u64, arg6: u64, arg7: *mut u64) -> *mut GroundCollisionLine {
+    if arg5 == 2048 && arg6 == 1048576 {
+        let groundcollisionline = *((groundcollision + 0x320) as *mut u64) as *mut GroundCollisionLine;
+        let groundcollisionline_prev = *((groundcollision + 0x328) as *mut u64) as *mut GroundCollisionLine;
+
+        let groundcollisionline_next = *(groundcollisionline as *mut *mut GroundCollisionLine);
+        let normal = *(((groundcollisionline_next as u64) + 0xA0) as *mut smash::phx::Vector2f);
+        let vertex_1_y = *(((groundcollisionline_next as u64) + 0x24) as *mut f32);
+        let vertex_2_y = *(((groundcollisionline_next as u64) + 0x34) as *mut f32);
+
+    }
+    call_original!(groundcollision, arg2, prev_ecb_bottom_pos, ecb_bottom_translation, arg5, arg6, arg7)
+}
+// Unused for now
+// Adds 0.01 to y pos when landing
+#[skyline::hook(offset = 0x548560)]
+unsafe fn groundcollision__processgroundcollisioninfo_sub(groundcollisioninfo: *mut f32, groundcollision: *mut u64) {
+    call_original!(groundcollisioninfo, groundcollision);
+
+}
+
 pub fn install() {
+    unsafe {
+        // Removes 0.3 unit leniency above ECB bottom when deciding whether to land
+        // Reduces frequency of NILs
+        skyline::patching::Patch::in_text(0x540dd8).data(0x529ae148);
+        skyline::patching::Patch::in_text(0x540ddc).data(0x72a78468);
+    }
     skyline::install_hooks!(
         is_touch_hook,
         is_floor_touch_line_hook,
         get_touch_flag_hook,
-        ground_module_update_rhombus_sub,
+        groundcollision__processgroundcollisioninfo_check_landing,
         ground_module_ecb_point_calc_hook,
-        model_module_joint_global_position_with_offset_hook
+        model_module_joint_global_position_with_offset_hook,
+        //groundmodule__setcorrect
     );
 }

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -137,10 +137,24 @@ pub unsafe fn cliff_xlu_frame_counter(fighter: &mut L2CFighterCommon) {
     }
 }
 
+pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
+    if ( (fighter.kind() == *FIGHTER_KIND_SZEROSUIT
+            && fighter.is_motion(Hash40::new("attack_air_hi")))
+        || (fighter.kind() == *FIGHTER_KIND_PALUTENA
+            && fighter.is_motion(Hash40::new("attack_air_n")))
+        || (fighter.kind() == *FIGHTER_KIND_GANON
+            && fighter.is_motion_one_of(&[Hash40::new("attack_air_n"), Hash40::new("attack_air_lw"), Hash40::new("attack_air_hi")])) )
+    && !VarModule::is_flag(fighter.battle_object, vars::common::status::DISABLE_ECB_SHIFT)
+    {
+        VarModule::on_flag(fighter.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
+    }
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     
     airdodge_refresh_on_hit_disable(boma, status_kind);
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
+    ecb_shift_disabled_statuses(fighter);
 }
 

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -155,6 +155,6 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleA
     airdodge_refresh_on_hit_disable(boma, status_kind);
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
-    ecb_shift_disabled_statuses(fighter);
+    ecb_shift_disabled_motions(fighter);
 }
 

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -14,7 +14,7 @@
     <int hash="glide_toss_cancel_frame">5</int>
     <float hash="waveland_pass_neutral_sens">-0.66</float>
     <int hash="air_escape_snap_frame">5</int>
-    <float hash="waveland_distance_threshold">5</float>
+    <float hash="waveland_distance_threshold">6</float>
     <struct hash="dacus_enable">
         <int hash="start_frame">3</int>
         <int hash="end_frame">10</int>

--- a/utils/src/game_modes.rs
+++ b/utils/src/game_modes.rs
@@ -123,7 +123,7 @@ unsafe fn once_per_game_frame(game_state_ptr: u64) {
     // check the current match mode
     // 1 is regular smash, 45 is online arena match
     if utils_dyn::util::get_match_mode().0 != 1 && utils_dyn::util::get_match_mode().0 != 45 {
-        println!("mode is {}, so not running custom game modes.", utils_dyn::util::get_match_mode().0);
+        //println!("mode is {}, so not running custom game modes.", utils_dyn::util::get_match_mode().0);
         CURRENT_CUSTOM_MODES = None;
     }
 


### PR DESCRIPTION
Removes a leniency with collision that Ultimate had in place, which, when coupled with the new ECB changes, allowed you to land on platforms while rising (platform cancel) pretty frequently. Platform cancels should be less frequent now, and more intentional.

Also fixes any remaining visual bugs when landing (characters appearing stuck halfway into ground on first frame of landing).
