### PR TITLE
Decrease character model sizes

### DIFF
--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -27,7 +27,7 @@
       <float hash="landing_attack_air_frame_b">7</float>
       <float hash="landing_attack_air_frame_hi">7</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.035</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10</float>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
@@ -95,7 +95,7 @@
       <float hash="landing_attack_air_frame_b">7</float>
       <float hash="landing_attack_air_frame_hi">13</float>
       <float hash="landing_attack_air_frame_lw">18</float>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10.4</float>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.815</float>
@@ -129,7 +129,7 @@
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">0.99</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.2</float>
       <float hash="tread_jump_speed_y_mul">0.7</float>
       <int hash="attack_hi4_hold_keep_frame">1</int>
@@ -160,7 +160,7 @@
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">14</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">0.97</float>
+      <float hash="scale">0.94</float>
       <float hash="shield_radius">7.7</float>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
@@ -301,7 +301,7 @@
       <float hash="landing_attack_air_frame_hi">7</float>
       <float hash="landing_attack_air_frame_lw">10</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10.5</float>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.75</float>
@@ -372,7 +372,7 @@
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">8</float>
-      <float hash="scale">1.05</float>
+      <float hash="scale">1.03</float>
       <float hash="shield_radius">11</float>
       <float hash="tread_jump_speed_y_mul">0.775</float>
       <float hash="tread_mini_jump_speed_y_mul">0.775</float>
@@ -401,7 +401,7 @@
       <float hash="weight">65</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <int hash="landing_heavy_frame">3</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.8</float>
       <float hash="shield_break_y">86.84</float>
       <float hash="tread_jump_speed_y_mul">0.81</float>
@@ -439,7 +439,7 @@
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_lw">7</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.04</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">11</float>
       <float hash="tread_jump_speed_y_mul">0.775</float>
       <float hash="tread_mini_jump_speed_y_mul">0.775</float>
@@ -570,7 +570,7 @@
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">11</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">11.5</float>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
@@ -637,7 +637,7 @@
       <float hash="landing_attack_air_frame_f">12</float>
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.035</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.9</float>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
@@ -742,7 +742,7 @@
       <float hash="weight">87</float>
       <float hash="landing_attack_air_frame_f">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">0.99</float>
+      <float hash="scale">0.95</float>
       <float hash="shield_radius">12.5</float>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
@@ -772,7 +772,7 @@
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">7</float>
       <float hash="landing_attack_air_frame_lw">16</float>
-      <float hash="scale">1.03</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10.4</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -808,7 +808,7 @@
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">15</float>
-      <float hash="scale">0.98</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">13.4</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -867,7 +867,7 @@
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_lw">13</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">0.98</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.4</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -899,7 +899,7 @@
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">10</float>
-      <float hash="scale">1.05</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10</float>
       <float hash="tread_jump_speed_y_mul">0.835</float>
       <float hash="tread_mini_jump_speed_y_mul">0.835</float>
@@ -931,7 +931,7 @@
       <float hash="landing_attack_air_frame_b">13</float>
       <float hash="landing_attack_air_frame_lw">10</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.05</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10.7</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -1002,7 +1002,7 @@
       <float hash="landing_attack_air_frame_hi">8</float>
       <float hash="landing_attack_air_frame_lw">9</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.01</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">11.6</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1040,7 +1040,7 @@
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">13</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10</float>
       <float hash="tread_jump_speed_y_mul">0.825</float>
       <float hash="tread_mini_jump_speed_y_mul">0.825</float>
@@ -1076,7 +1076,7 @@
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">10</float>
-      <float hash="scale">1</float>
+      <float hash="scale">0.97</float>
       <float hash="shield_radius">12.4</float>
       <float hash="tread_jump_speed_y_mul">0.825</float>
       <float hash="tread_mini_jump_speed_y_mul">0.825</float>
@@ -1112,7 +1112,7 @@
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.03</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">12.2</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -1182,7 +1182,7 @@
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">12</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.16</float>
+      <float hash="scale">1.14</float>
       <float hash="shield_radius">10</float>
       <float hash="tread_jump_speed_y_mul">0.825</float>
       <float hash="tread_mini_jump_speed_y_mul">0.825</float>
@@ -1247,7 +1247,7 @@
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.7</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -1316,7 +1316,7 @@
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">16</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">0.99</float>
+      <float hash="scale">0.95</float>
       <float hash="shield_radius">10.6</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -1389,7 +1389,7 @@
       <float hash="landing_attack_air_frame_b">8</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.04</float>
+      <float hash="scale">0.95</float>
       <float hash="shield_radius">10.3</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1427,7 +1427,7 @@
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">10</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.07</float>
+      <float hash="scale">1.05</float>
       <float hash="shield_radius">10.6</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1494,7 +1494,7 @@
       <float hash="landing_attack_air_frame_hi">11</float>
       <float hash="landing_attack_air_frame_lw">17</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.04</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.7</float>
       <int hash="jump_count_max">3</int>
       <float hash="tread_jump_speed_y_mul">0.8</float>
@@ -1533,7 +1533,7 @@
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.19</float>
+      <float hash="scale">1.18</float>
       <float hash="shield_radius">8.7</float>
       <float hash="tread_jump_speed_y_mul">0.825</float>
       <float hash="tread_mini_jump_speed_y_mul">0.825</float>
@@ -1602,7 +1602,7 @@
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_hi">17</float>
       <float hash="landing_attack_air_frame_lw">13</float>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.8</float>
       <float hash="attack_s4_smash_hold_attack_up">1.4</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
@@ -1634,7 +1634,7 @@
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_b">10</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">0.99</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.5</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1667,7 +1667,7 @@
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">10</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">12.6</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1704,7 +1704,7 @@
       <float hash="landing_attack_air_frame_hi">7</float>
       <float hash="landing_attack_air_frame_lw">10</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.13</float>
+      <float hash="scale">1.11</float>
       <float hash="shield_radius">10.7</float>
       <float hash="tread_jump_speed_y_mul">0.785</float>
       <float hash="tread_mini_jump_speed_y_mul">0.785</float>
@@ -1736,7 +1736,7 @@
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">16</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">10</float>
       <float hash="tread_jump_speed_y_mul">0.65</float>
       <float hash="tread_mini_jump_speed_y_mul">0.65</float>
@@ -1770,7 +1770,7 @@
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">11</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">0.98</float>
+      <float hash="scale">0.95</float>
       <float hash="shield_radius">12.5</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1836,7 +1836,7 @@
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_b">11</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">11.8</float>
       <bool hash="wall_jump_type">false</bool>
       <float hash="tread_jump_speed_y_mul">0.815</float>
@@ -1870,7 +1870,7 @@
       <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_b">14</float>
       <float hash="landing_attack_air_frame_lw">13</float>
-      <float hash="scale">1</float>
+      <float hash="scale">0.98</float>
       <float hash="shield_radius">12</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -1936,7 +1936,7 @@
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">12</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">9.5</float>
       <float hash="tread_jump_speed_y_mul">0.775</float>
       <float hash="tread_mini_jump_speed_y_mul">0.775</float>
@@ -2037,7 +2037,7 @@
       <float hash="landing_attack_air_frame_f">10</float>
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">12</float>
-      <float hash="scale">1.02</float>
+      <float hash="scale">0.99</float>
       <float hash="shield_radius">11.8</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -2071,7 +2071,7 @@
       <float hash="landing_attack_air_frame_b">10</float>
       <float hash="landing_attack_air_frame_lw">18</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1.07</float>
+      <float hash="scale">1.03</float>
       <float hash="shield_radius">12.6</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -2167,7 +2167,7 @@
       <float hash="weight">105</float>
       <float hash="landing_attack_air_frame_n">8</float>
       <float hash="landing_attack_air_frame_lw">18</float>
-      <float hash="scale">1.03</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">13</float>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.8</float>
@@ -2270,7 +2270,7 @@
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">15</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">1.03</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">12.3</float>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.805</float>
@@ -2376,7 +2376,7 @@
       <float hash="landing_attack_air_frame_hi">7</float>
       <float hash="landing_attack_air_frame_lw">13</float>
       <int hash="landing_heavy_frame">5</int>
-      <float hash="scale">0.98</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.1</float>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>
@@ -2480,7 +2480,7 @@
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">20</float>
-      <float hash="scale">1.05</float>
+      <float hash="scale">1.02</float>
       <float hash="shield_radius">12</float>
       <float hash="tread_jump_speed_y_mul">0.825</float>
       <float hash="tread_mini_jump_speed_y_mul">0.825</float>
@@ -2846,7 +2846,7 @@
       <float hash="landing_attack_air_frame_hi">10</float>
       <float hash="landing_attack_air_frame_lw">13</float>
       <int hash="landing_heavy_frame">6</int>
-      <float hash="scale">0.99</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.7</float>
       <float hash="tread_jump_speed_y_mul">0.7</float>
       <int hash="attack_hi4_hold_keep_frame">1</int>
@@ -2922,7 +2922,7 @@
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">15</float>
-      <float hash="scale">0.96</float>
+      <float hash="scale">0.95</float>
       <float hash="tread_jump_speed_y_mul">0.775</float>
       <float hash="tread_mini_jump_speed_y_mul">0.775</float>
       <int hash="attack_hi4_hold_keep_frame">1</int>
@@ -2957,7 +2957,7 @@
       <float hash="landing_attack_air_frame_hi">9</float>
       <float hash="landing_attack_air_frame_lw">13</float>
       <int hash="landing_heavy_frame">4</int>
-      <float hash="scale">1</float>
+      <float hash="scale">0.96</float>
       <float hash="shield_radius">12.5</float>
       <float hash="tread_jump_speed_y_mul">0.815</float>
       <float hash="tread_mini_jump_speed_y_mul">0.815</float>
@@ -3060,7 +3060,7 @@
       <float hash="landing_attack_air_frame_b">12</float>
       <float hash="landing_attack_air_frame_hi">12</float>
       <float hash="landing_attack_air_frame_lw">16</float>
-      <float hash="scale">1.02</float>
+      <float hash="scale">1</float>
       <float hash="shield_radius">12.7</float>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.8</float>


### PR DESCRIPTION
Fighter model sizes were increased back in alpha to accommodate vanilla Ultimate's huge stages. Some characters can now be reverted now that stages are properly sized. As a byproduct, platform cancels are less frequent across the cast.

This reverts the character model multipliers for the following characters to vanilla values:
- Mario
- Link
- Samus
- Yoshi
- Luigi
- Captain Falcon
- Jigglypuff
- Peach
- Sheik
- Dr. Mario
- Marth
- Young Link
- Ganondorf
- Roy
- Mr. Game & Watch
- Meta Knight
- Zero Suit Samus
- Wario
- Snake
- Ike
- Ivysaur
- Diddy Kong
- Sonic
- Olimar
- Lucario
- Toon Link
- Wolf
- Mega Man
- Wii Fit Trainer
- Rosalina
- Little Mac
- Greninja
- Palutena
- Robin
- Shulk
- Duck Hunt
- Corrin
- Bayonetta
- Simon
- Incineroar
- Hero
- Byleth
- Dark Samus
- Lucina
- Chrom
- Richter


Resolves #1239 