### PR TITLE
Projectile spawn fix rework

### DIFF
--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -75,15 +75,17 @@ unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollis
     
     let flags = *(groundcollisioninfo.add(0x5d8 / 4) as *mut u32);
     let is_fighter = flags >> 0x1b & 1 == 0;
+    let is_item = flags >> 0xa & 1 == 0;
     let situation_kind = *(groundcollisioninfo.add(0x5a0 / 4) as *mut i32);  // 1 = ground, 2 = air, 3 = cliff...
     let pos_y = *groundcollisioninfo.add(0x634 / 4);
     let prev_ecb_offset_y = *groundcollisioninfo.add(0x424 / 4);
     let ecb_offset_y = *groundcollisioninfo.add(0x3d4 / 4);
 
     if !is_fighter
+    && !is_item
     && situation_kind == 2
-    && (prev_ecb_offset_y == 0.0 && ecb_offset_y != 0.0)  // this only passes on the spawn frame of a projectile
-    && pos_y < touch_pos_y  // checks if the projectile's position is underneath the surface it is touching
+    && (prev_ecb_offset_y == 0.0 && ecb_offset_y != 0.0)  // this only passes on the frame a projectile spawns
+    && (pos_y + ecb_offset_y) <= touch_pos_y  // checks if the projectile's ECB bottom position is underneath the nearest surface
     {
         *groundcollisioninfo.add(0x420 / 4) = *groundcollisioninfo.add(0x3d0 / 4);  // prev_ecb_offset_x = ecb_offset_x
         *groundcollisioninfo.add(0x424 / 4) = *groundcollisioninfo.add(0x3d4 / 4);  // prev_ecb_offset_y = ecb_offset_y

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -77,6 +77,7 @@ unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollis
     let is_fighter = flags >> 0x1b & 1 == 0;
     let is_item = flags >> 0xa & 1 == 0;
     let situation_kind = *(groundcollisioninfo.add(0x5a0 / 4) as *mut i32);  // 1 = ground, 2 = air, 3 = cliff...
+    let prev_pos_y = *groundcollisioninfo.add(0x4c4 / 4);
     let pos_y = *groundcollisioninfo.add(0x634 / 4);
     let prev_ecb_offset_y = *groundcollisioninfo.add(0x424 / 4);
     let ecb_offset_y = *groundcollisioninfo.add(0x3d4 / 4);
@@ -85,6 +86,7 @@ unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollis
     && !is_item
     && situation_kind == 2
     && (prev_ecb_offset_y == 0.0 && ecb_offset_y != 0.0)  // this only passes on the frame a projectile spawns
+    && (prev_pos_y + ecb_offset_y) <= touch_pos_y  // checks if the projectile's ECB bottom position on the previous frame was underneath the nearest surface
     && (pos_y + ecb_offset_y) <= touch_pos_y  // checks if the projectile's ECB bottom position is underneath the nearest surface
     {
         *groundcollisioninfo.add(0x420 / 4) = *groundcollisioninfo.add(0x3d0 / 4);  // prev_ecb_offset_x = ecb_offset_x

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -1,110 +1,6 @@
 use super::*;
 use globals::*;
 
-// This prevents projectiles from dying on platforms/ground
-#[skyline::hook(replace=GroundModule::is_touch)]
-unsafe fn is_touch_hook(boma: &mut BattleObjectModuleAccessor, ground_touch_flags: u32) -> bool {
-    let mut ground_touch_flags = ground_touch_flags;
-    let normal_y = GroundModule::get_touch_normal_y(boma, *GROUND_TOUCH_FLAG_DOWN as u32);
-    let prev_pos = *PostureModule::prev_pos(boma);
-    let pos = *PostureModule::pos(boma);
-
-    if boma.is_weapon()
-    && (normal_y >= 0.99 && normal_y <= 1.01)  // if touching a near-flat platform/ground
-    && prev_pos.y <= pos.y  // if the projectile wasn't moving downwards
-    && [*WEAPON_KIND_SAMUS_CSHOT,
-        *WEAPON_KIND_RYU_HADOKEN,
-        *WEAPON_KIND_LUCAS_PK_FIRE,
-        *WEAPON_KIND_EDGE_FLARE1,
-        *WEAPON_KIND_WOLF_BLASTER_BULLET,
-        *WEAPON_KIND_MASTER_ARROW1,
-        *WEAPON_KIND_MASTER_ARROW2,
-        *WEAPON_KIND_LUIGI_FIREBALL,
-        *WEAPON_KIND_FOX_BLASTER_BULLET,
-        *WEAPON_KIND_SAMUSD_CSHOT,
-        *WEAPON_KIND_BRAVE_FIREBALL,
-        *WEAPON_KIND_FALCO_BLASTER_BULLET,
-        *WEAPON_KIND_KEN_HADOKEN,
-        *WEAPON_KIND_REFLET_THUNDER,
-        *WEAPON_KIND_SZEROSUIT_PARALYZER_BULLET,
-        *WEAPON_KIND_MIIGUNNER_ATTACKAIRF_BULLET,
-        *WEAPON_KIND_WIIFIT_SUNBULLET,
-        *WEAPON_KIND_SAMUS_SUPERMISSILE,
-        *WEAPON_KIND_SAMUSD_SUPERMISSILE,
-        *WEAPON_KIND_MEWTWO_SHADOWBALL,
-        *WEAPON_KIND_LUCARIO_AURABALL,
-        *WEAPON_KIND_MIIGUNNER_SUPERMISSILE,
-        *WEAPON_KIND_MIIGUNNER_GUNNERCHARGE,
-        *WEAPON_KIND_GEKKOUGA_SHURIKEN,
-        *WEAPON_KIND_PICHU_DENGEKIDAMA,
-        *WEAPON_KIND_BRAVE_DEATHBALL,
-        *WEAPON_KIND_KAMUI_RYUSENSYA,
-        *WEAPON_KIND_EDGE_FIRE
-    ].contains(&boma.kind())
-    {
-        if ground_touch_flags == *GROUND_TOUCH_FLAG_ALL as u32
-        && !original!()(boma, *GROUND_TOUCH_FLAG_LEFT as u32 | *GROUND_TOUCH_FLAG_RIGHT as u32)  // if not touching a wall
-        {
-            // Ignore ground collision
-            return false;
-        }
-        if ground_touch_flags & *GROUND_TOUCH_FLAG_DOWN as u32 != 0 {
-            // Ignore ground collision
-            ground_touch_flags -= *GROUND_TOUCH_FLAG_DOWN as u32;
-        }
-    }
-    original!()(boma, ground_touch_flags)
-}
-
-#[skyline::hook(replace=GroundModule::is_floor_touch_line)]
-unsafe fn is_floor_touch_line_hook(boma: &mut BattleObjectModuleAccessor, ground_touch_flags: u32) -> bool {
-    let mut ground_touch_flags = ground_touch_flags;
-    let normal_y = GroundModule::get_touch_normal_y(boma, *GROUND_TOUCH_FLAG_DOWN as u32);
-    let prev_pos = *PostureModule::prev_pos(boma);
-    let pos = *PostureModule::pos(boma);
-
-    if boma.is_weapon()
-    && (normal_y >= 0.99 && normal_y <= 1.01)  // if touching a near-flat platform/ground
-    && prev_pos.y <= pos.y  // if the projectile wasn't moving downwards
-    && ( ([*WEAPON_KIND_KROOL_IRONBALL, *WEAPON_KIND_KROOL_SPITBALL].contains(&boma.kind())
-            && boma.is_status(*WEAPON_KROOL_IRONBALL_STATUS_KIND_SHOOT))
-        || (boma.kind() == *WEAPON_KIND_KOOPAJR_CANNONBALL
-            && boma.is_status(*WEAPON_KOOPAJR_CANNONBALL_STATUS_KIND_SHOOT)
-            && !KineticModule::is_enable_energy(boma, *WEAPON_KOOPAJR_CANNONBALL_KINETIC_ENERGY_ID_GRAVITY)) )  // if Jr.'s cannonball is flying straight horizontally
-    {
-        if ground_touch_flags == *GROUND_TOUCH_FLAG_ALL as u32
-        && !original!()(boma, *GROUND_TOUCH_FLAG_LEFT as u32 | *GROUND_TOUCH_FLAG_RIGHT as u32)  // if not touching a wall
-        {
-            // Ignore ground collision
-            return false;
-        }
-        if ground_touch_flags & *GROUND_TOUCH_FLAG_DOWN as u32 != 0 {
-            // Ignore ground collision
-            ground_touch_flags -= *GROUND_TOUCH_FLAG_DOWN as u32;
-        }
-    }
-    original!()(boma, ground_touch_flags)
-}
-
-#[skyline::hook(replace=GroundModule::get_touch_flag)]
-unsafe fn get_touch_flag_hook(boma: &mut BattleObjectModuleAccessor) -> i32 {
-    let normal_y = GroundModule::get_touch_normal_y(boma, *GROUND_TOUCH_FLAG_DOWN as u32);
-
-    if boma.is_weapon()
-    && (normal_y >= 0.99 && normal_y <= 1.01)  // if touching a near-flat platform/ground
-    && boma.kind() == *WEAPON_KIND_DEDEDE_GORDO
-    && boma.is_status(*WEAPON_DEDEDE_GORDO_STATUS_KIND_THROW)  // when Dedede first tosses Gordo
-    && boma.status_frame() == 0  // on frame 1 of the toss
-    {
-        if original!()(boma) == *GROUND_TOUCH_FLAG_DOWN {
-            // Ignore ground collision
-            return *GROUND_TOUCH_FLAG_NONE;
-        }
-    }
-    original!()(boma)
-}
-
-
 // This function is used to calculate the following:
 //      param_2: Left ECB point's horizontal offset from Top bone (negative number)
 //      param_3: Bottom ECB point's vertical offset from Top bone (positive number, 0.0 in vanilla)
@@ -168,18 +64,38 @@ unsafe fn groundcollision__processgroundcollisioninfo(groundcollisioninfo: *mut 
     call_original!(groundcollisioninfo, groundcollision)
 }
 
-// Performs ground correct
+// Performs ground correct/sets situation kind
 #[skyline::hook(offset = 0x53fe30)]
-unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollisioninfo: *mut f32, groundcollision: *mut u64) {
+unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollisioninfo: *mut f32, groundcollision: u64) {
+    let groundcollisionline = *((groundcollision + 0x320) as *mut u64) as *mut GroundCollisionLine;
+    let groundcollisionline_next = *(groundcollisionline as *mut *mut GroundCollisionLine);
+    let vertex_1_y = *(((groundcollisionline_next as u64) + 0x24) as *mut f32);
+    let vertex_2_y = *(((groundcollisionline_next as u64) + 0x34) as *mut f32);
+    let touch_pos_y = (vertex_1_y + vertex_2_y) / 2.0;
+    
     let flags = *(groundcollisioninfo.add(0x5d8 / 4) as *mut u32);
     let is_fighter = flags >> 27 & 1 == 0;
+    let situation_kind = *(groundcollisioninfo.add(0x5a0 / 4) as *mut i32);  // 1 = ground, 2 = air, 3 = cliff...
+    let pos_y = *groundcollisioninfo.add(0x634 / 4);
+    let translation = *groundcollisioninfo.add(0x624 / 4);
+    let prev_ecb_offset_y = *groundcollisioninfo.add(0x424 / 4);
+    let ecb_offset_y = *groundcollisioninfo.add(0x3d4 / 4);
 
+    if !is_fighter
+    && situation_kind == 2
+    && (prev_ecb_offset_y == 0.0 && ecb_offset_y != 0.0)
+    && pos_y < touch_pos_y
+    {
+        *groundcollisioninfo.add(0x420 / 4) = *groundcollisioninfo.add(0x3d0 / 4);
+        *groundcollisioninfo.add(0x424 / 4) = *groundcollisioninfo.add(0x3d4 / 4);
+        *((groundcollision + 0x39f) as *mut bool) = true;
+    } else {
+        *((groundcollision + 0x39f) as *mut bool) = false;
+    };
     call_original!(groundcollisioninfo, groundcollision);
-
     let prev_touch_pos_y = *groundcollisioninfo.add(0x1A4 / 4);
     let touch_pos_y = *groundcollisioninfo.add(0xB4 / 4);
     let ecb_offset_y = *groundcollisioninfo.add(0x3d4 / 4);
-    //println!("situation kind {}", *groundcollisioninfo.add(0x5a0 / 4));
 
     if is_fighter
     && prev_touch_pos_y == 0.0
@@ -192,19 +108,11 @@ unsafe fn groundcollision__processgroundcollisioninfo_check_landing(groundcollis
         *groundcollisioninfo.add(0x3d4 / 4) = 0.0;
     }
 }
-// Unused for now
 // Sets GroundCollisionLine
 #[skyline::hook(offset = 0x52d900)]
 unsafe fn groundcollision__processgroundcollisioninfo_check_landing_sub(groundcollision: u64, arg2: *mut u64, prev_ecb_bottom_pos: *mut smash::phx::Vector2f, ecb_bottom_translation: *mut smash::phx::Vector2f, arg5: u64, arg6: u64, arg7: *mut u64) -> *mut GroundCollisionLine {
-    if arg5 == 2048 && arg6 == 1048576 {
-        let groundcollisionline = *((groundcollision + 0x320) as *mut u64) as *mut GroundCollisionLine;
-        let groundcollisionline_prev = *((groundcollision + 0x328) as *mut u64) as *mut GroundCollisionLine;
-
-        let groundcollisionline_next = *(groundcollisionline as *mut *mut GroundCollisionLine);
-        let normal = *(((groundcollisionline_next as u64) + 0xA0) as *mut smash::phx::Vector2f);
-        let vertex_1_y = *(((groundcollisionline_next as u64) + 0x24) as *mut f32);
-        let vertex_2_y = *(((groundcollisionline_next as u64) + 0x34) as *mut f32);
-
+    if *((groundcollision + 0x39f) as *mut bool) {
+        return 0 as *mut GroundCollisionLine;
     }
     call_original!(groundcollision, arg2, prev_ecb_bottom_pos, ecb_bottom_translation, arg5, arg6, arg7)
 }
@@ -217,10 +125,8 @@ pub fn install() {
         skyline::patching::Patch::in_text(0x540ddc).data(0x72a78468);
     }
     skyline::install_hooks!(
-        is_touch_hook,
-        is_floor_touch_line_hook,
-        get_touch_flag_hook,
         groundcollision__processgroundcollisioninfo_check_landing,
+        groundcollision__processgroundcollisioninfo_check_landing_sub,
         ground_module_ecb_point_calc_hook,
         model_module_joint_global_position_with_offset_hook
     );


### PR DESCRIPTION
Previously there was an issue where certain projectiles would die when spawned inside a platform. A (hacky) solution was merged a little while ago, but this solution aims to resolve the problem at the source: within the game's collision functions.

Ground collision is now disabled on the frame a projectile spawns, if the projectile was rising or traveling straight horizontally.