### PR TITLE
Camera changes

### DIFF
--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -13,13 +13,6 @@ unsafe fn battle_object__process_begin_sub(ctx: &skyline::hooks::InlineCtx) {
 }
 
 // Doubles camera speed while not in hitlag
-#[skyline::hook(offset = 0x2606270)]
-unsafe fn cameramanager__update_frame(camera_manager: *mut *mut u64) {
-    call_original!(camera_manager);
-    if !IS_STOP {
-        call_original!(camera_manager);
-    }
-}
 #[skyline::hook(offset = 0x4f0a80)]
 unsafe fn cameramanager__update(camera_manager: *mut *mut u64) {
     call_original!(camera_manager);
@@ -31,7 +24,6 @@ unsafe fn cameramanager__update(camera_manager: *mut *mut u64) {
 pub fn install() {
     skyline::install_hooks!(
         battle_object__process_begin_sub,
-        cameramanager__update_frame,
         cameramanager__update
     );
 }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -1,6 +1,13 @@
 use super::*;
 use utils::ext::*;
 
+static mut IS_STOP: bool = false;
+
+#[skyline::hook(offset = 0x3a7f90, inline)]
+unsafe fn battle_object__process_begin_sub(ctx: &skyline::hooks::InlineCtx) {
+    IS_STOP = *ctx.registers[19].w.as_ref() & 1 != 0;
+}
+
 #[skyline::hook(offset = 0x2606270)]
 unsafe fn cameramanager__update_frame(camera_manager: *mut *mut u64) {
     call_original!(camera_manager);
@@ -19,6 +26,7 @@ unsafe fn cameramanager__update(camera_manager: *mut *mut u64) {
 
 pub fn install() {
     skyline::install_hooks!(
+        battle_object__process_begin_sub,
         cameramanager__update_frame,
         cameramanager__update
     );

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -1,0 +1,25 @@
+use super::*;
+use utils::ext::*;
+
+#[skyline::hook(offset = 0x2606270)]
+unsafe fn cameramanager__update_frame(camera_manager: *mut *mut u64) {
+    call_original!(camera_manager);
+    if !IS_STOP {
+        call_original!(camera_manager);
+    }
+}
+
+#[skyline::hook(offset = 0x4f0a80)]
+unsafe fn cameramanager__update(camera_manager: *mut *mut u64) {
+    call_original!(camera_manager);
+    if !IS_STOP {
+        call_original!(camera_manager);
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        cameramanager__update_frame,
+        cameramanager__update
+    );
+}

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -2,28 +2,15 @@ use super::*;
 use utils::ext::*;
 
 
-static mut IS_STOP: bool = false;
-
-// Keeps track of hitlag
-#[skyline::hook(offset = 0x3a7f74, inline)]
-unsafe fn battle_object__process_begin_sub(ctx: &skyline::hooks::InlineCtx) {
-    let boma = *ctx.registers[23].x.as_ref() as *mut BattleObjectModuleAccessor;
-    let stop_module = *(boma as *mut BattleObjectModuleAccessor as *mut u64).add(0x90 / 8) as *const u64;
-    IS_STOP = *(stop_module as *const bool).add(0x3c);
-}
-
-// Doubles camera speed while not in hitlag
-#[skyline::hook(offset = 0x4f0a80)]
-unsafe fn cameramanager__update(camera_manager: *mut *mut u64) {
-    call_original!(camera_manager);
-    if !IS_STOP {
-        call_original!(camera_manager);
-    }
+// Doubles camera speed
+#[skyline::hook(offset = 0x4fdbf0)]
+unsafe fn normal_camera(ptr: u64, float: f32) {
+    call_original!(ptr, float);
+    call_original!(ptr, float);
 }
 
 pub fn install() {
     skyline::install_hooks!(
-        battle_object__process_begin_sub,
-        cameramanager__update
+        normal_camera
     );
 }

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -19,6 +19,7 @@ pub mod stage_hazards;
 pub mod set_fighter_status_data;
 pub mod attack;
 pub mod collision;
+pub mod camera;
 
 
 pub fn install() {
@@ -41,6 +42,7 @@ pub fn install() {
     set_fighter_status_data::install();
     attack::install();
     collision::install();
+    camera::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -150,11 +150,18 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
     }
 }
 
+// For use with camera function hooks in function_hooks/camera.rs
+pub static mut IS_STOP: bool = false;
+pub unsafe fn is_stop(fighter: &mut L2CFighterCommon) {
+    IS_STOP = StopModule::is_stop(fighter.module_accessor);
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     
     airdodge_refresh_on_hit_disable(boma, status_kind);
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
     ecb_shift_disabled_motions(fighter);
+    is_stop(fighter);
 }
 

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -150,18 +150,11 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
     }
 }
 
-// For use with camera function hooks in function_hooks/camera.rs
-pub static mut IS_STOP: bool = false;
-pub unsafe fn is_stop(fighter: &mut L2CFighterCommon) {
-    IS_STOP = StopModule::is_stop(fighter.module_accessor);
-}
-
 pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     
     airdodge_refresh_on_hit_disable(boma, status_kind);
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
     ecb_shift_disabled_motions(fighter);
-    is_stop(fighter);
 }
 


### PR DESCRIPTION
Doubles camera speed programmatically, akin to what PM did. This makes camera movement smoother, yet still quick. The camera zooms in & out more dynamically as well.

As a result, general character movement should look less jittery, and knockback should appear faster as well.

Must be used with the following romfs:
[Extract_into_hdr-stages.zip](https://github.com/HDR-Development/HewDraw-Remix/files/10180872/Extract_into_hdr-stages.zip)


To be merged with HDR-Development/hdr-private#247