### PR TITLE
Amsah tech refinements

### DIFF
--- a/fighters/common/src/general_statuses/passive.rs
+++ b/fighters/common/src/general_statuses/passive.rs
@@ -12,7 +12,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
         skyline::install_hooks!(
             sub_check_passive_button_for_damage,
             status_pre_passive,
-            status_pre_passivefb
+            status_pre_passivefb,
+            sub_uniq_process_Passive_init
         );
     }
 }
@@ -28,7 +29,7 @@ pub unsafe fn status_pre_passive(fighter: &mut L2CFighterCommon) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
         SituationKind(*SITUATION_KIND_GROUND),
-        *FIGHTER_KINETIC_TYPE_MOTION, // Originally *FIGHTER_KINETIC_TYPE_PASSIVE_GROUND
+        *FIGHTER_KINETIC_TYPE_UNIQ, // Originally *FIGHTER_KINETIC_TYPE_PASSIVE_GROUND
         *GROUND_CORRECT_KIND_GROUND as u32,
         GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
         true,
@@ -57,7 +58,7 @@ pub unsafe fn status_pre_passivefb(fighter: &mut L2CFighterCommon) -> L2CValue {
     StatusModule::init_settings(
         fighter.module_accessor,
         SituationKind(*SITUATION_KIND_GROUND),
-        *FIGHTER_KINETIC_TYPE_MOTION, // Originally *FIGHTER_KINETIC_TYPE_PASSIVE_GROUND_MOTION
+        *FIGHTER_KINETIC_TYPE_UNIQ, // Originally *FIGHTER_KINETIC_TYPE_PASSIVE_GROUND_MOTION
         *GROUND_CORRECT_KIND_GROUND_CLIFF_STOP as u32,
         GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
         false,
@@ -75,11 +76,44 @@ pub unsafe fn status_pre_passivefb(fighter: &mut L2CFighterCommon) -> L2CValue {
         false,
         0,
         (
-            *FIGHTER_STATUS_ATTR_DISABLE_GROUND_FRICTION |
             *FIGHTER_STATUS_ATTR_DISABLE_TURN_DAMAGE
         ) as u32,
         0,
         0
     );
     0.into()
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sub_uniq_process_Passive_init)]
+pub unsafe fn sub_uniq_process_Passive_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_PASSIVE, *FIGHTER_STATUS_KIND_PASSIVE_FB]) {
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_DAMAGE);
+        let damage_speed_x = smash::app::sv_kinetic_energy::get_speed_x(fighter.lua_state_agent);
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_DAMAGE);
+        let damage_speed_y = smash::app::sv_kinetic_energy::get_speed_y(fighter.lua_state_agent);
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_DAMAGE);
+        smash::app::sv_kinetic_energy::clear_speed(fighter.lua_state_agent);
+        
+        KineticModule::unable_energy_all(fighter.module_accessor);
+    
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, ENERGY_MOTION_RESET_TYPE_GROUND_TRANS, 0.0, 0.0, 0.0, 0.0, 0.0);
+        app::sv_kinetic_energy::reset_energy(fighter.lua_state_agent);
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+    
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, ENERGY_STOP_RESET_TYPE_GROUND, damage_speed_x, damage_speed_y, 0.0, 0.0, 0.0);
+        app::sv_kinetic_energy::reset_energy(fighter.lua_state_agent);
+    
+        let ground_brake = WorkModule::get_param_float(fighter.module_accessor, hash40("ground_brake"), 0);
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, ground_brake, 0.0);
+        app::sv_kinetic_energy::set_brake(fighter.lua_state_agent);
+    
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+    }
+    call_original!(fighter)
 }

--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -19,6 +19,7 @@ use smash_script::{self, *, macros::*};
 
 /// Sets the extra traction flag depending on current speed and current status in order to prevent
 /// the game feeling too slippery
+/// TODO: get rid of this horrible shit and move it to energy funcs
 unsafe fn extra_traction(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     let speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN);
     let max_walk = WorkModule::get_param_float(boma, hash40("walk_speed_max"), 0);
@@ -51,7 +52,11 @@ unsafe fn extra_traction(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
         *FIGHTER_STATUS_KIND_CATCH_WAIT,
         *FIGHTER_STATUS_KIND_CATCH_ATTACK,
         *FIGHTER_STATUS_KIND_CATCH_PULL,
-        *FIGHTER_STATUS_KIND_ITEM_THROW
+        *FIGHTER_STATUS_KIND_ITEM_THROW,
+        *FIGHTER_STATUS_KIND_DOWN,
+        *FIGHTER_STATUS_KIND_DOWN_WAIT,
+        *FIGHTER_STATUS_KIND_PASSIVE,
+        *FIGHTER_STATUS_KIND_PASSIVE_FB
     ];
 
     if boma.is_status_one_of(&double_traction_statuses) {
@@ -69,7 +74,9 @@ unsafe fn extra_traction(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
         }
         if speed_x.abs() > max_walk
         && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
-        && !VarModule::is_flag(boma.object(), vars::common::instance::IS_MOTION_BASED_ATTACK) {
+        && ( !VarModule::is_flag(boma.object(), vars::common::instance::IS_MOTION_BASED_ATTACK)
+            || boma.is_status(*FIGHTER_STATUS_KIND_PASSIVE_FB) )
+        {
             if boma.is_prev_status_one_of(&double_traction_statuses) {
                 KineticModule::add_speed(boma, &added_traction);
             }


### PR DESCRIPTION
- Fixes an issue where Amsah techrolls could slide off of edges
   - They now properly stick to edges until the techroll animation is over
- Double traction rules now apply to knockdowns and Amsah techs
- Amsah tech velocity is now capped at the ground speed limit (4.0)