### PR TITLE
Weaken getup attacks

### DIFF
--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -5,11 +5,26 @@ use std::arch::asm;
 
 #[skyline::hook(offset = 0x3dc160)]
 unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut smash2::app::AttackData) {
+    let boma = *(module as *mut *mut BattleObjectModuleAccessor).add(1);
+
     // if a hitbox does not intentionally trip 100% of time, remove random trip chance
     if data.slip < 1.0 {
         // -1.0 trip chance prevents any tripping whatsoever
         data.slip = -1.0;
     }
+
+    // Reduce strength of getup attacks
+    if (*boma).is_status(*FIGHTER_STATUS_KIND_DOWN_STAND_ATTACK) {
+        data.power = 6.0;  // damage
+        data.vector = 361;  // angle
+        data.sub_shield = 0;  // shield damage modifier
+    }
+    if (*boma).is_status(*FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK) {
+        data.power = 5.0;
+        data.vector = 361;
+        data.sub_shield = 0;
+    }
+    
     call_original!(module, id, group, data)
 }
 

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -17,13 +17,15 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
     if (*boma).is_status(*FIGHTER_STATUS_KIND_DOWN_STAND_ATTACK) {
         data.power = 6.0;  // damage
         data.vector = 361;  // angle
+        data.r_eff = 50;  // KBG
+        data.r_add = 80;  // BKB
         data.sub_shield = 0;  // shield damage modifier
     }
     if (*boma).is_status(*FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK) {
         data.power = 5.0;
         data.vector = 361;
-        data.r_eff = 50;  // KBG
-        data.r_add = 80;  // BKB
+        data.r_eff = 50;
+        data.r_add = 80;
         data.sub_shield = 0;
     }
     if (*boma).is_status(*FIGHTER_STATUS_KIND_CLIFF_ATTACK) {

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -22,13 +22,15 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
     if (*boma).is_status(*FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK) {
         data.power = 5.0;
         data.vector = 361;
+        data.r_eff = 50;  // KBG
+        data.r_add = 80;  // BKB
         data.sub_shield = 0;
     }
     if (*boma).is_status(*FIGHTER_STATUS_KIND_CLIFF_ATTACK) {
         data.power = 8.0;
         data.vector = 361;
-        data.r_eff = 50;  // KBG
-        data.r_add = 70;  // BKB
+        data.r_eff = 50;
+        data.r_add = 70;
         data.sub_shield = 0;
     }
     

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -24,6 +24,13 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
         data.vector = 361;
         data.sub_shield = 0;
     }
+    if (*boma).is_status(*FIGHTER_STATUS_KIND_CLIFF_ATTACK) {
+        data.power = 8.0;
+        data.vector = 361;
+        data.r_eff = 50;  // KBG
+        data.r_add = 70;  // BKB
+        data.sub_shield = 0;
+    }
     
     call_original!(module, id, group, data)
 }


### PR DESCRIPTION
Globally standardizes the following parameters of getup attacks to match PM:
- Damage 7% -> 6%
- Angle 48 -> 361
- KBG 48 -> 50
- Shield damage modifier 8 -> 0

Slip attack:
- Damage 6% -> 5%
- Angle 48 -> 361
- BKB 60 -> 80
- Shield damage modifier 8 -> 0

Ledge attack:
- Damage 9% -> 8%
- Angle 45 -> 361
- BKB 90 -> 70
- KBG 20 -> 50
- Shield damage modifier 1 -> 0