### PR TITLE
Skip results screen with start button

### DIFF
--- a/fighters/common/Cargo.toml
+++ b/fighters/common/Cargo.toml
@@ -14,3 +14,4 @@ utils = { package = "dynamic", path = "../../dynamic" }
 ninput = { git = "https://github.com/blu-dev/ninput" }
 interpolation = "0.2.0" # for f32::lerp
 smash2 = { package = "smash", git = "https://github.com/blu-dev/smash-rs" }
+rand = { git = "https://github.com/skyline-rs/rand" }

--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -1,5 +1,7 @@
 use super::*;
 use utils::ext::*;
+use rand::prelude::SliceRandom;
+use rand::Rng;
 
 #[skyline::hook(offset = 0x16d948c, inline)]
 unsafe fn packed_packet_creation(ctx: &mut skyline::hooks::InlineCtx) {
@@ -482,6 +484,32 @@ unsafe extern "C" fn is_throw_stick(fighter: &mut L2CFighterCommon) -> L2CValue 
     out
 }
 
+static mut SHOULD_END_RESULT_SCREEN : bool = false;
+
+// Skip results screen with start button
+#[skyline::hook(offset = 0x3664040)]
+unsafe fn process_inputs_handheld(controller: &mut Controller) {
+    let entry_count = lua_bind::FighterManager::entry_count(utils::singletons::FighterManager());
+    if lua_bind::FighterManager::is_result_mode(utils::singletons::FighterManager()) && entry_count > 0 {
+        if ninput::any::is_press(ninput::Buttons::PLUS) {
+            SHOULD_END_RESULT_SCREEN = true;
+        }
+        if SHOULD_END_RESULT_SCREEN {
+            let mut rng = rand::thread_rng();
+            // Need to space apart A-presses so it does not seem like we are holding the button.
+            let n: u32 = rng.gen_range(0..3);
+            if n == 1 {
+                controller.current_buttons.set_a(true);
+                controller.just_down.set_a(true);
+            }
+        }
+    }
+    if entry_count == 0 {
+        SHOULD_END_RESULT_SCREEN = false;
+    }
+    call_original!(controller);
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hook!(is_throw_stick);
@@ -497,7 +525,8 @@ pub fn install() {
         write_packet,
         parse_inputs,
         handle_incoming_packet,
-        after_exec
+        after_exec,
+        process_inputs_handheld
     );
     skyline::nro::add_hook(nro_hook);
 }


### PR DESCRIPTION
Pressing Start/+ on the results screen now advances it to the end.

Resolves #1085 