### PR TITLE
Clank/Rebound Tweaks

### DIFF
--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -20,6 +20,9 @@
   <float hash="just_shield_reflect_attack_mul">0.5</float>
   <float hash="just_shield_reflect_speed_mul">1.0</float>
   <int hash="just_shield_reflect_count_max">7</int>
+  <float hash="rebound_reaction_mul">0.3</float>
+  <float hash="rebound_reaction_add">2.0</float>
+  <float hash="rebound_power_diff">6.0</float>
   <float hash="0x117e9b3582">0.025</float>
   <float hash="0x112a8367c4">0.32</float>
   <float hash="0x1176e209f3">0.3</float>


### PR DESCRIPTION
Adjustments have been made to clanks and rebounds. 
- Clank threshold has been lowered from 9% to 6%
- Rebound animation length has been significantly reduced

For Comparison (Rebound Length):
```
Damage - Current -> New
3%  - 13 frames -> 6 frames
9%  - 22 frames -> 9 frames
12% - 30 frames -> 11 frames
14% - 32 frames -> 12 frames
16% - 36 frames -> 13 frames
20% - 44 frames -> 15 frames

```