### PR TITLE
Allows Ganon to angle Float

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -391,7 +391,8 @@ pub mod vars {
             pub const FLOAT_ENABLE_ACTIONS: i32 = 0x1100;
             pub const FLOAT_FALL_SPEED_Y_INCREASE: i32 = 0x1101;
             pub const FLOAT_CANCEL: i32 = 0x1102;
-            pub const FLOAT_GROUND_CHANGE_KINETIC: i32 = 0x1103;
+            pub const FLOAT_GROUND_DECIDE_ANGLE: i32 = 0x1103;
+            pub const FLOAT_GROUND_CHANGE_KINETIC: i32 = 0x1104;
         }
 
     }

--- a/fighters/ganon/src/acmd/specials.rs
+++ b/fighters/ganon/src/acmd/specials.rs
@@ -9,6 +9,10 @@ unsafe fn ganon_float_start_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         WHOLE_HIT(fighter, *HIT_STATUS_XLU);
     }
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, vars::ganon::status::FLOAT_GROUND_DECIDE_ANGLE);
+    }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
         WHOLE_HIT(fighter, *HIT_STATUS_NORMAL);

--- a/fighters/ganon/src/status/special_n.rs
+++ b/fighters/ganon/src/status/special_n.rs
@@ -74,6 +74,27 @@ unsafe fn special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 }
 
 unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Decided which direction Ganon should float.
+    if VarModule::is_flag(fighter.battle_object, vars::ganon::status::FLOAT_GROUND_DECIDE_ANGLE) {
+        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_AIR_ANGLE);
+        let stick_x = fighter.global_table[globals::STICK_X].get_f32();
+        let angle = (45.0 * -stick_x).to_radians();
+        sv_kinetic_energy!(
+            set_angle,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_MOTION,
+            angle
+        );
+        if angle != 0.0 {
+            sv_kinetic_energy!(
+                set_speed_mul,
+                fighter,
+                FIGHTER_KINETIC_ENERGY_ID_MOTION,
+                1.2
+            );
+        }
+        VarModule::off_flag(fighter.battle_object, vars::ganon::status::FLOAT_GROUND_DECIDE_ANGLE);
+    }
     // Increases Ganon's fall speed when this flag is enabled.
     if VarModule::is_flag(fighter.battle_object, vars::ganon::status::FLOAT_GROUND_CHANGE_KINETIC) {
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);


### PR DESCRIPTION
Tilting the stick Left or Right allows Ganon to angle his ascent if he uses Float from the ground, up to 45 degrees left or right.

https://user-images.githubusercontent.com/26860994/208350574-3ff7d2a2-02e7-4175-a0b4-15f1ad4d8a20.mp4

