### PR TITLE
Missed a Transition Term for Jump Cancel boma ext

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -855,6 +855,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         else {
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL);
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON);
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_FLY);
             if fighter.sub_transition_group_check_air_jump_aerial().get_bool() {
                 return true;
             }


### PR DESCRIPTION
Most characters who have multiple jumps use a status called FIGHTER_STATUS_KIND_FLY instead of FIGHTER_STATUS_KIND_JUMP_AERIAL, which has its own transition term. This was previously omitted from the Jump Cancel boma extension, this fixes that.

This fixes Pit being unable to jump cancel Upperdash Arm, and any other jump cancel on these multiple jumps.