### PR TITLE
Allow three intangible ledge grabs and remove ledge grab limit

### DIFF
--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -85,8 +85,8 @@ unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
 pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
     let boma = &mut *info.boma;
 
-    // fighter.set_cliff_xlu_frame(10.0.into());
-
+    // allow ledge regrab iframes
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CLIFF_XLU);
 
     // General Engine Edits
     if salty_check(fighter) {

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -86,7 +86,10 @@ pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
     let boma = &mut *info.boma;
 
     // allow ledge regrab iframes
-    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CLIFF_XLU);
+    if WorkModule::get_int(fighter.boma(), *FIGHTER_INSTANCE_WORK_ID_INT_CLIFF_COUNT) < 3 {
+        // indicate that your next ledge grab grab is capable of having iframes
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CLIFF_XLU);
+    }
 
     // General Engine Edits
     if salty_check(fighter) {

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -94,7 +94,8 @@
   <float hash="cliff_robbed_speed_x">-0.5</float>
   <float hash="cliff_robbed_speed_y">17.5</float>
   <int hash="cliff_robbed_no_control_frame">40</int>
-  <int hash="air_lasso_catch_num">6</int>
+  <int hash="air_lasso_catch_num">999</int>
+  <int hash="cliff_max_count">999</int>
   <int hash="air_lasso_cliff_wait_frame">7</int>
   <int hash="air_lasso_landing_frame">25</int>
   <float hash="stand_stick_y">0.2</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -96,6 +96,7 @@
   <int hash="cliff_robbed_no_control_frame">40</int>
   <int hash="air_lasso_catch_num">999</int>
   <int hash="cliff_max_count">999</int>
+  <int hash="0x189f0b0c96">999</int>
   <int hash="air_lasso_cliff_wait_frame">7</int>
   <int hash="air_lasso_landing_frame">25</int>
   <float hash="stand_stick_y">0.2</float>


### PR DESCRIPTION
Allows refreshed iframes on ledge grab, up to 3 ledge grabs. Subsequent grabs will not have iframes, and the hard limit of six ledge grabs per airtime has been removed (it is now 999).