### PR TITLE
Fix Byleth up special command grab still spiking

### DIFF
--- a/fighters/master/src/acmd/specials.rs
+++ b/fighters/master/src/acmd/specials.rs
@@ -528,10 +528,12 @@ unsafe fn master_special_air_hi_overtake_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        /*VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
+        VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
+		/*
         if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)){
             VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-        }*/
+        }
+		*/
         VarModule::on_flag(fighter.battle_object, vars::master::instance::SPECIAL_AIR_HI_CATCH);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_NONE);
         ArticleModule::generate_article(boma, *FIGHTER_MASTER_GENERATE_ARTICLE_SWORD, false, 0);


### PR DESCRIPTION
Fixes an issue where Byleth's up special would still spike when used after activating the special input forward smash (the `IS_HEAVY_ATTACK` flag wasn't properly being cleared at the beginning of the up special footstool ACMD script, so when turned on via activating special input forward smash that flag would persist into the up special status if regular forward smash wasn't used beforehand)