### PR TITLE
Disallow projectiles during aegis reflector

### DIFF
--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -144,6 +144,14 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
             }
         }
 
+        // disable palutena projectiles during aegis reflector
+        if fighter_kind == *FIGHTER_KIND_PALUTENA 
+            && ArticleModule::is_exist(boma, *FIGHTER_PALUTENA_GENERATE_ARTICLE_REFLECTIONBOARD)
+            && (flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S
+            || flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N) {
+                return false;
+        }
+
         if fighter_kind == *FIGHTER_KIND_TRAIL {
             if flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S {
                 if (status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI && !AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT))

--- a/romfs/source/fighter/palutena/param/vl.prcxml
+++ b/romfs/source/fighter/palutena/param/vl.prcxml
@@ -7,7 +7,7 @@
   </list>
   <list hash="param_special_n">
     <struct index="0">
-      <int hash="special_n_discharge_frame">12</int>
+      <int hash="special_n_discharge_frame">24</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/palutena/param/vl.prcxml
+++ b/romfs/source/fighter/palutena/param/vl.prcxml
@@ -24,10 +24,10 @@
   </list>
   <list hash="param_reflectionboard">
     <struct index="0">
-      <float hash="life">225</float>
+      <float hash="life">112</float>
       <int hash="durability">100</int>
       <int hash="move_frame">240</int>
-      <float hash="move_speed">0.15</float>
+      <float hash="move_speed">0.3</float>
       <float hash="effect_rate">5.333</float>
     </struct>
   </list>


### PR DESCRIPTION
- This will disallow Palutena to transition into side special or neutral special if aegis reflector is out.
- this reduces the timer for the duration of the wall from 4s to 2s (movement speed doubled to compensate)
- release frame of nspecial changed from 12f to 24f (vanilla)