### PR TITLE
Bayonetta Fix Landing D-Air + KBG Nerf 

### DIFF
--- a/fighters/bayonetta/src/acmd/aerials.rs
+++ b/fighters/bayonetta/src/acmd/aerials.rs
@@ -410,9 +410,9 @@ unsafe fn bayonetta_landing_air_lw_game(fighter: &mut L2CAgentBase) {
     }
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2d51fcdb09), *FIGHTER_BAYONETTA_SHOOTING_SLOT_L_LEG, false, false, false, 10, 3, 3, 0, true);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 45, 127, 0, 80, 3.5, 0.0, 4.0, 5.0, Some(0.0), Some(4.0), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 45, 121, 0, 80, 4.0, 0.0, 4.0, 5.0, Some(0.0), Some(4.0), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
-    wait(lua_state, 1.0);
+    wait(lua_state, 3.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }


### PR DESCRIPTION
Changes:
Down Air:
Landing active frames 0->2
Hitbox size 3.5 -> 4.0
KBG 127 -> 121

I noticed that when I daired on shield it only hit the shield once playing Bayonetta. When I checked frame by frame with the hitbox viewer I saw the hitbox was out 0 frames. My making it wait longer to clear hitboxes the move now properly comes out and links decently consistent after my change. I also nerfed the KBG because I feel that having the move work suddenly while it didn't before might have an impact on her balance. I do not know when this move was last changed or why the move did not work for so long.

-Still does not connect well if you hit them with a late hit dair but that sounds like a skill issue

https://user-images.githubusercontent.com/122749442/212571132-7db5a74b-2d36-4a89-91fc-46ecaa34a143.mp4

https://user-images.githubusercontent.com/122749442/212571255-06881b6c-64c8-4d56-b037-3a06ee7114a0.mp4


