### PR TITLE
Decrease knockdown bounce heights globally

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -246,6 +246,8 @@ pub mod vars {
             pub const INITIAL_KNOCKBACK_VEL_X: i32 = 0x1000;
             pub const INITIAL_KNOCKBACK_VEL_Y: i32 = 0x1001;
 
+            pub const RESTING_HIP_OFFSET_Y: i32 = 0x1000;
+
         }
     }
 

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -150,11 +150,27 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
     }
 }
 
+pub unsafe fn decrease_knockdown_bounce_heights(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_DOWN) {
+        let mut rot_offset = Vector3f::zero();
+        ModelModule::joint_global_offset_from_top(fighter.module_accessor, Hash40::new("rot"), &mut rot_offset);
+        let mut hip_offset = Vector3f::zero();
+        ModelModule::joint_global_offset_from_top(fighter.module_accessor, Hash40::new("hip"), &mut hip_offset);
+
+        // Halves hip bone's vertical movement and applies offset to rot bone
+        // Cannot apply offset to hip as it is already offset from rot, while rot is directly offset from top bone
+        let bounce_height_mul = 0.5;
+        rot_offset.y += hip_offset.y * -bounce_height_mul;
+        ModelModule::set_joint_translate(fighter.module_accessor, Hash40::new("rot"), &Vector3f{ x: 0.0, y: rot_offset.y, z: 0.0 }, false, false);
+    }
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     
     airdodge_refresh_on_hit_disable(boma, status_kind);
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
     ecb_shift_disabled_motions(fighter);
+    decrease_knockdown_bounce_heights(fighter);
 }
 


### PR DESCRIPTION
Characters now bounce **half** as high during their knockdown (missed tech) animation.

Before:
https://user-images.githubusercontent.com/47401664/213288757-02dad8f7-e4d1-4a28-bf4c-b4c5d9179a0a.mp4

After:
https://user-images.githubusercontent.com/47401664/213584641-7840e54f-f7d4-4dd9-a96d-09dc91b9a8cd.mp4


Resolves #1253 
