### PR TITLE
Chrom - revert upB cancel behavior

### DIFF
--- a/fighters/chrom/src/opff.rs
+++ b/fighters/chrom/src/opff.rs
@@ -19,22 +19,15 @@ unsafe fn soaring_slash_drift(fighter: &mut L2CFighterCommon) {
 // Chrome Soaring Slash Cancel
 unsafe fn soaring_slash_cancel(fighter: &mut L2CFighterCommon) {
     let frame = fighter.motion_frame();
-    if fighter.is_status(*FIGHTER_ROY_STATUS_KIND_SPECIAL_HI_2) {
-        if frame < 15.0 { // earliest point to buffer dive
-            VarModule::on_flag(fighter.battle_object, vars::chrom::status::SOARING_SLASH_CANCEL);
-        } else if frame < 28.0 { // latest point to buffer dive
-            if ControlModule::check_button_on(fighter.boma(), *CONTROL_PAD_BUTTON_SPECIAL) {
-                VarModule::off_flag(fighter.battle_object, vars::chrom::status::SOARING_SLASH_CANCEL);
-            }
-        } else { // actual dive (frame after previous block)
-            if VarModule::is_flag(fighter.battle_object, vars::chrom::status::SOARING_SLASH_CANCEL) {
-                if VarModule::is_flag(fighter.battle_object, vars::chrom::status::SOARING_SLASH_HIT) {
-                    VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
-                    StatusModule::change_status_request_from_script(fighter.boma(), *FIGHTER_STATUS_KIND_FALL, true);
-                } else {
-                    StatusModule::change_status_request_from_script(fighter.boma(), *FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
-                }
-            }
+    if fighter.is_status(*FIGHTER_ROY_STATUS_KIND_SPECIAL_HI_2)
+    && 27.0 < frame && frame < 30.0
+    && fighter.is_button_on(Buttons::Guard)
+    {
+        if VarModule::is_flag(fighter.battle_object, vars::chrom::status::SOARING_SLASH_HIT) {
+            VarModule::on_flag(fighter.battle_object, vars::common::instance::UP_SPECIAL_CANCEL);
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, true);
+        } else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
         }
     }
 }


### PR DESCRIPTION
Revert upB cancel to press-shield-to-cancel, rather than automatically canceling.