### PR TITLE
Fix Ledgehogging for PT/Aegis & Other Bugs

### DIFF
--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -12,7 +12,7 @@ unsafe fn change_status_request_hook(boma: &mut BattleObjectModuleAccessor, stat
             let player_number = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32;
             let pos = GroundModule::hang_cliff_pos_3f(boma);
 
-            for object_id in util::get_all_player_battle_object_ids() {
+            for object_id in util::get_all_active_battle_object_ids() {
                 let object = ::utils::util::get_battle_object_from_id(object_id);
                 if !object.is_null() {
                     if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) == WorkModule::get_int(&mut *(*object).module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID)
@@ -56,7 +56,7 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
             let player_number = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32;
             let pos = GroundModule::hang_cliff_pos_3f(boma);
 
-            for object_id in util::get_all_player_battle_object_ids() {
+            for object_id in util::get_all_active_battle_object_ids() {
                 let object = ::utils::util::get_battle_object_from_id(object_id);
                 if !object.is_null() {
                     if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) == WorkModule::get_int(&mut *(*object).module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID)

--- a/fighters/common/src/function_hooks/ledges.rs
+++ b/fighters/common/src/function_hooks/ledges.rs
@@ -47,7 +47,7 @@ unsafe fn can_entry_cliff_hook(boma: &mut BattleObjectModuleAccessor) -> u64 {
     // Ledgehog code
     let pos = GroundModule::hang_cliff_pos_3f(boma);
     let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32;
-    for object_id in util::get_all_player_battle_object_ids() {
+    for object_id in util::get_all_active_battle_object_ids() {
         let object = ::utils::util::get_battle_object_from_id(object_id);
         if !object.is_null() {
             if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) == WorkModule::get_int(&mut *(*object).module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID)

--- a/utils/src/game_modes/airdash.rs
+++ b/utils/src/game_modes/airdash.rs
@@ -16,7 +16,7 @@ pub unsafe fn update() {
     }
 
     // println!("doing airdash update!");
-    for object_id in util::get_all_player_battle_object_ids() {
+    for object_id in util::get_all_active_battle_object_ids() {
         let object = util::get_battle_object_from_id(object_id);
         if !object.is_null() {
             let fighter = util::get_fighter_common_from_accessor(&mut *(*object).module_accessor);

--- a/utils/src/game_modes/hitfall.rs
+++ b/utils/src/game_modes/hitfall.rs
@@ -16,7 +16,7 @@ pub unsafe fn update() {
     }
 
     //println!("doing hitfall update!");
-    for object_id in util::get_all_player_battle_object_ids() {
+    for object_id in util::get_all_active_battle_object_ids() {
         let object = util::get_battle_object_from_id(object_id);
         if !object.is_null() {
             let fighter = util::get_fighter_common_from_accessor(&mut *(*object).module_accessor);

--- a/utils/src/game_modes/turbo.rs
+++ b/utils/src/game_modes/turbo.rs
@@ -16,7 +16,7 @@ pub unsafe fn update() {
     }
 
     //println!("doing turbo update!");
-    for object_id in util::get_all_player_battle_object_ids() {
+    for object_id in util::get_all_active_battle_object_ids() {
         let object = util::get_battle_object_from_id(object_id);
         if !object.is_null() {
             let fighter = util::get_fighter_common_from_accessor(&mut *(*object).module_accessor);


### PR DESCRIPTION
## Problem:

Transforming characters fail to properly ledgehog, due to a failure of battle object aggregation to properly account for transforming characters. This should have been addressed in #1266, but was unfortunately overlooked (oops!)

This had other side effects, such as in custom game modes.

## Solution:

Rewrite the utility function which gets all active battle object ids to properly account for edge cases.