### PR TITLE
Banjo Recovery Changes

### DIFF
--- a/fighters/buddy/src/opff.rs
+++ b/fighters/buddy/src/opff.rs
@@ -4,6 +4,7 @@ use globals::*;
 const HUD_DISPLAY_TIME_MAX: i32 = 90;
 const FEATHERS_RED_COOLDOWN_GROUND_RATE: f32 = 1.25;
 const FEATHERS_RED_COOLDOWN_MAX: f32 = 450.0;
+const BEAKBOMB_END_FRAME: i32 = 25; //Dash timer is shared between ground and air in vl.prc
 
 static mut BAYONET_EGGS:[i32;8] = [0; 8]; //I have no idea why varmod doesn't work with this, so this will have to do
  
@@ -102,6 +103,9 @@ unsafe fn beakbomb_checkForCancel(fighter: &mut L2CFighterCommon, boma: &mut Bat
     let side_special = fighter.is_status(*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_S_DASH);
     if !side_special {return;}
 
+    let has_hit_shield = AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_SHIELD);
+    if (has_hit_shield) {return;}
+
     let in_Air = fighter.is_situation(*SITUATION_KIND_AIR);
     if (!in_Air) {return;}
 
@@ -116,6 +120,13 @@ unsafe fn beakbomb_checkForCancel(fighter: &mut L2CFighterCommon, boma: &mut Bat
 }
 
 unsafe fn beakbomb_control(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
+    //If past the end frame, transition into end
+    if (VarModule::get_int(boma.object(), vars::buddy::instance::BEAKBOMB_FRAME) >= BEAKBOMB_END_FRAME)
+    {
+        fighter.change_status_req(*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_S_END, true);
+        return;
+    }
+
     //Do not update flight during hitstop
     let in_Hitstop = SlowModule::frame(fighter.module_accessor, *FIGHTER_SLOW_KIND_HIT) > 0 ;
     if in_Hitstop {return;}
@@ -143,8 +154,8 @@ unsafe fn beakbomb_update(fighter: &mut L2CFighterCommon, boma: &mut BattleObjec
         if (VarModule::is_flag(boma.object(), vars::buddy::instance::BEAKBOMB_ACTIVE))
         {
             beakbomb_control(fighter,boma);
-            beakbomb_checkForHit(fighter,boma);
-            beakbomb_checkForFail(fighter,boma);
+            //beakbomb_checkForHit(fighter,boma);
+            beakbomb_checkForGround(fighter,boma);
             beakbomb_checkForCancel(fighter,boma);
 
             GroundModule::set_attach_ground(fighter.module_accessor, false);
@@ -167,7 +178,7 @@ unsafe fn beakbomb_update(fighter: &mut L2CFighterCommon, boma: &mut BattleObjec
 
 }
 
-//Check to see if Banjo hit the ground or a shield during beakbomb.
+//Check to see if Banjo hit a shield during beakbomb.
 unsafe fn beakbomb_checkForHit(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
     let has_hit_shield = AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_SHIELD);
     if (!has_hit_shield) {return;}
@@ -202,7 +213,8 @@ unsafe fn beakbomb_wall(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
     }
 }
 
-unsafe fn beakbomb_checkForFail(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
+//Check if landed on the ground
+unsafe fn beakbomb_checkForGround(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
     let is_grounded = fighter.is_situation(*SITUATION_KIND_GROUND);
     let fail_safeFrames = 5;
     let fail_cutoff = 25;

--- a/romfs/source/fighter/buddy/param/vl.prcxml
+++ b/romfs/source/fighter/buddy/param/vl.prcxml
@@ -53,9 +53,9 @@
       <float hash="start_speed_y_mul_air">0</float>
       <float hash="start_speed_y_add_air">-10</float>
 	  
-      <float hash="dash_speed_x_air">4.55</float>
+      <float hash="dash_speed_x_air">3.5</float>
       <float hash="dash_accel_x_air">-0.11</float>
-      <float hash="dash_speed_x_limit_air">4.6</float>
+      <float hash="dash_speed_x_limit_air">3.5</float>
       <float hash="dash_speed_x_min_air">2.0</float>
 	  
       <float hash="dash_gravity_mul">0.0</float>
@@ -64,7 +64,7 @@
       <float hash="attack_mul_on_hit_on_ground">1</float>
       <float hash="speed_x_mul_on_hit_on_ground">1.0</float>
       <float hash="attack_mul_on_hit_on_air">1</float>
-      <float hash="speed_x_mul_on_hit_on_air">1.0</float>
+      <float hash="speed_x_mul_on_hit_on_air">0.1</float>
       <int hash="dash_time">36</int>
 	  
       <float hash="dash_end_speed_x_mul_air">1.0</float>


### PR DESCRIPTION
- Beakbomb Speed reduced from 4.5 -> 3.5
- Speed dramatically reduced on hit, Shield Bonking removed
- Beakbomb cannot be canceled after hitting a shield
- First Active Frame of Special Air Fail increased 17->37 (requires romf package)

Current:
https://user-images.githubusercontent.com/13909643/215362800-c4f6bfc0-a60f-4950-8f5d-4d501702074f.mp4

Changes:
https://user-images.githubusercontent.com/13909643/215362796-be23dc74-195c-4e74-82f7-83253ed89ac4.mp4

romfs:
[buddy_motion_body.zip](https://github.com/HDR-Development/HewDraw-Remix/files/10531148/buddy_motion_body.zip)

