### PR TITLE
Luigi Recovery Adustments

### DIFF
--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -426,7 +426,6 @@ unsafe fn game_specialairlw(fighter: &mut L2CAgentBase) {
     }
     wait(lua_state, 4.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.8);
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_LW_FLAG_LIMIT_X_DEC);
         WorkModule::off_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_LW_FLAG_RISE);
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_INSTANCE_WORK_ID_FLAG_SPECIAL_LW_BUOYANCY);

--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -202,10 +202,10 @@ unsafe fn sound_specialairn(fighter: &mut L2CAgentBase) {
 unsafe fn game_specialairsstart(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        KineticModule::mul_speed(boma, &Vector3f{x: 1.0, y: 0.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-    }
+    //frame(lua_state, 1.0);
+    //if is_excute(fighter) {
+        //KineticModule::mul_speed(boma, &Vector3f{x: 1.0, y: 0.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    //}
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_FLAG_REVERSE_LR);
@@ -426,6 +426,7 @@ unsafe fn game_specialairlw(fighter: &mut L2CAgentBase) {
     }
     wait(lua_state, 4.0);
     if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 0.8);
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_LW_FLAG_LIMIT_X_DEC);
         WorkModule::off_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_LW_FLAG_RISE);
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_INSTANCE_WORK_ID_FLAG_SPECIAL_LW_BUOYANCY);

--- a/fighters/luigi/src/opff.rs
+++ b/fighters/luigi/src/opff.rs
@@ -4,15 +4,16 @@ use super::*;
 use globals::*;
 
  
-unsafe fn luigi_missle_ledgegrab(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_RAM, *FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_END]) {
-        // allows ledgegrab during Luigi Missile
-        fighter.sub_transition_group_check_air_cliff();
-    }
-}
+//unsafe fn luigi_missle_ledgegrab(fighter: &mut L2CFighterCommon) {
+//    if fighter.is_status_one_of(&[*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_RAM, *FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_END]) {
+//        // allows ledgegrab during Luigi Missile
+//        fighter.sub_transition_group_check_air_cliff();
+//    }
+//}
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    luigi_missle_ledgegrab(fighter);
+    //luigi_missle_ledgegrab(fighter);
+    special_s_charge_init(fighter, status_kind);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LUIGI )]
@@ -26,5 +27,11 @@ pub fn luigi_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 pub unsafe fn luigi_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
         moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+    }
+}
+
+unsafe fn special_s_charge_init(fighter: &mut smash::lua2cpp::L2CFighterCommon, status_kind: i32) {
+    if [*FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_LOSE, *FIGHTER_STATUS_KIND_ENTRY].contains(&status_kind)  || !sv_information::is_ready_go() {
+        VarModule::off_flag(fighter.object(), vars::luigi::instance::IS_MISFIRE_STORED);
     }
 }

--- a/romfs/source/fighter/luigi/param/vl.prcxml
+++ b/romfs/source/fighter/luigi/param/vl.prcxml
@@ -43,7 +43,7 @@
       <float hash="limit_x">2.35</float>
       <float hash="air_limit_x">0.8</float>
       <float hash="buoyancy">1.1</float>
-      <float hash="buoyancy_max">1.3</float>
+      <float hash="buoyancy_max">1.45</float>
       <float hash="limit_x_dec">0.66</float>
     </struct>
     <hash40 index="1">dummy</hash40>


### PR DESCRIPTION
Bringing Luigi more in line with our future philosophy of recoveries.

Please replace the Luigi motion files from hdr-assets>fighters>luigi with the following folder: 
[luigi.zip](https://github.com/HDR-Development/HewDraw-Remix/files/10532253/luigi.zip)

<== LUIGI ==>
SPECIALS
-Down B (Cyclone)
~[+] Buoyancy_max increased from 1.3 to 1.45 (This allows Luigi to rise more with more mashing)
-Side B (Green Missile)
~[-] No longer grabs ledge
~[+] Brought back jumping side b momentum shenanigans :)
~[-] Stored misfire is lost upon death
~[-] Removed invincible frames on side b discharge