### PR TITLE
Little Mac Recovery Adjustments

### DIFF
--- a/fighters/littlemac/src/acmd/specials.rs
+++ b/fighters/littlemac/src/acmd/specials.rs
@@ -163,6 +163,9 @@ unsafe fn littlemac_special_air_n2_sound(fighter: &mut L2CAgentBase) {
 unsafe fn littlemac_special_s_jump_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    if is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL_NO_HIT);
+    }
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         shield!(fighter, *MA_MSC_CMD_REFLECTOR, *COLLISION_KIND_REFLECTOR, 0, hash40("top"), 5.1, 0.0, 7.4, 3.0, 0.0, 7.4, 3.2, 0.0, 0.0, 1, false, 0.0, *FIGHTER_REFLECTOR_GROUP_HOMERUNBAT);

--- a/romfs/source/fighter/littlemac/param/vl.prcxml
+++ b/romfs/source/fighter/littlemac/param/vl.prcxml
@@ -31,7 +31,7 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="special_air_hi_pass_mul">1.2675</float>
-      <float hash="special_hi_dir_mul">35</float>
+      <float hash="special_hi_dir_mul">25</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Brings Little Mac in line to HDR's Recovery philosophy

<==LITTLE MAC==>
SPECIALS
-Up Special
~[-] Horizontal Drift decreased from 35 to 25
-Side Special
~[-] Can only be performed once per airtime