### PR TITLE
Allow Neutral Wavedash

### DIFF
--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -305,10 +305,7 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
         let situation_kind = fighter.global_table[SITUATION_KIND].clone();
         fighter.global_table[PREV_SITUATION_KIND].assign(&situation_kind);
         if VarModule::is_flag(fighter.battle_object, vars::common::instance::ENABLE_AIR_ESCAPE_JUMPSQUAT) {
-            // check if we are doing directional airdodge
-            let stick = app::sv_math::vec2_length(fighter.global_table[STICK_X].get_f32(), fighter.global_table[STICK_Y].get_f32());
-            if stick >= WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("escape_air_slide_stick"))
-                && fighter.global_table[STICK_Y].get_f32() <= 0.2
+            if fighter.global_table[STICK_Y].get_f32() <= 0.2
             {
                 VarModule::on_flag(fighter.battle_object, vars::common::instance::PERFECT_WAVEDASH);
                 // change kinetic/ground properties for wavedash
@@ -317,7 +314,7 @@ unsafe fn uniq_process_JumpSquat_exec_status_param(fighter: &mut L2CFighterCommo
                 WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR);
             } else {
                 VarModule::off_flag(fighter.battle_object, vars::common::instance::PERFECT_WAVEDASH);
-                // change kinetic properties for rising nairdodge
+                // change kinetic properties for rising airdodge
                 GroundModule::correct(fighter.module_accessor, app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP);
             }


### PR DESCRIPTION
Allow "neutral" wavedash (cherry-picked from #1343)

  - If a wavedash is buffered while the stick is in neutral, we currently jump and then buffer airdodge. This allows a huge punish off a simple misinput. Instead, we could "neutral" wavedash in-place, which is functionally similar to a wavedash down from the ground.
  - Current behavior was originally implemented before we had Rivals-style airdodges, so its use case is no longer valid