### PR TITLE
Ground bounce threshold adjustment

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -119,7 +119,7 @@
   <float hash="damage_fly_length_mul_min">1</float>
   <int hash="damage_fly_attack_frame">999</int>
   <int hash="damage_fly_escape_frame">999</int>
-  <float hash="damage_fly_reflect_d_speed">1</float>
+  <float hash="damage_fly_reflect_d_speed">3</float>
   <float hash="damage_fly_reflect_d_speed_mul">0.7</float>
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <int hash="damage_fly_reflect_disable_escape_frame">999</int>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -119,7 +119,7 @@
   <float hash="damage_fly_length_mul_min">1</float>
   <int hash="damage_fly_attack_frame">999</int>
   <int hash="damage_fly_escape_frame">999</int>
-  <float hash="damage_fly_reflect_d_speed">3</float>
+  <float hash="damage_fly_reflect_d_speed">2.5</float>
   <float hash="damage_fly_reflect_d_speed_mul">0.7</float>
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <int hash="damage_fly_reflect_disable_escape_frame">999</int>


### PR DESCRIPTION
Knockback velocity required to trigger ground bounce (rather than a splat) increased 1.0 -> 2.5

Splats will now occur *much* more often (they most likely weren't occurring at all for some characters before), generally until 100-125%, but of course it will vary per move.

For reference, Captain Falcon's dair will cause Inkling to splat up until ~100%, after which Inkling will bounce.