### PR TITLE
Pichu - Discharge buffs

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -903,6 +903,7 @@ pub mod vars {
             pub const CHARGE_DAMAGE_MUL: i32 = 0x0100;
             pub const CHARGE_RECOIL_MUL: i32 = 0x0101;
             pub const DISCHARGE_POWER_MUL: i32 = 0x0102;
+            pub const DISCHARGE_SIZE_MUL: i32 = 0x0103;
         }
     }
 

--- a/fighters/pichu/src/acmd/specials.rs
+++ b/fighters/pichu/src/acmd/specials.rs
@@ -189,12 +189,16 @@ unsafe fn pichu_special_lw_game(fighter: &mut L2CAgentBase) {
         else {
             let charge_state_time = ParamModule::get_int(boma.object(), ParamType::Agent, "charge_state_time") as f32;
             let charge_state_remaining = VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER) as f32;
-            // 1 second to use full power Discharge before it starts decreasing in power
-            let discharge_decrease_power_frame = charge_state_time - 60.0;
-            // 50% power at minimum
+            // 3 seconds to use full strength Discharge before it starts decreasing in power
+            let discharge_decrease_power_frame = charge_state_time - 180.0;
+            // 50% damage at minimum
             let discharge_min_power_mul = ParamModule::get_float(boma.object(), ParamType::Agent, "discharge_min_power_mul");
-            let discharge_power_mul = 1.0 - ((1.0 - (charge_state_remaining.min(discharge_decrease_power_frame)/discharge_decrease_power_frame)) * discharge_min_power_mul);
+            let discharge_power_mul = 1.0 - ((1.0 - (charge_state_remaining.min(discharge_decrease_power_frame)/discharge_decrease_power_frame)) * (1.0 - discharge_min_power_mul));
             VarModule::set_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL, discharge_power_mul);
+            // 75% size at minimum
+            let discharge_min_size_mul = ParamModule::get_float(boma.object(), ParamType::Agent, "discharge_min_size_mul");
+            let discharge_size_mul = 1.0 - ((1.0 - (charge_state_remaining.min(discharge_decrease_power_frame)/discharge_decrease_power_frame)) * (1.0 - discharge_min_size_mul));
+            VarModule::set_float(boma.object(), vars::pichu::instance::DISCHARGE_SIZE_MUL, discharge_size_mul);
             VarModule::on_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK);
             VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, 0);
         }
@@ -215,6 +219,8 @@ unsafe fn pichu_special_lw_game(fighter: &mut L2CAgentBase) {
 unsafe fn pichu_special_lw_hit_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    let discharge_power_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
+    let discharge_size_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_SIZE_MUL);
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         if !VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
@@ -223,9 +229,8 @@ unsafe fn pichu_special_lw_hit_game(fighter: &mut L2CAgentBase) {
             ATTACK(fighter, 0, 0, Hash40::new("top"), 14.0, 361, 71, 0, 90, 11.0, 0.0, 10.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
         }
         else {
-            let discharge_power_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
             FT_ADD_DAMAGE(fighter, 8.0 * discharge_power_mul);
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 20.0 * discharge_power_mul, 361, 80, 0, 50, 18.0 * discharge_power_mul, 0.0, 10.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 2, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 20.0 * discharge_power_mul, 361, 80, 0, 70, 18.0 * discharge_size_mul, 0.0, 10.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 2, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
             VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, 0);
         }
     }
@@ -234,7 +239,7 @@ unsafe fn pichu_special_lw_hit_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
         MeterModule::watch_damage(fighter.battle_object, false);
         if VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
-            FT_MOTION_RATE(fighter, 1.5);
+            FT_MOTION_RATE(fighter, 1.5 * discharge_power_mul);
         }
     }
 }
@@ -251,7 +256,7 @@ unsafe fn pichu_special_lw_hit_effect(fighter: &mut L2CAgentBase) {
     WorkModule::is_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_KAMINARI_ATTACK_HIT);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
-            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
+            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_SIZE_MUL);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_kaminari_hit2"), Hash40::new("hip"), 0, 0, 0, 0, 90, 0, 1.15 * discharge_effect_mul, true);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_final_explosion"), Hash40::new("hip"), 0, 0, 0, 0, 0, 0, 0.3 * discharge_effect_mul, false);
         }
@@ -370,7 +375,7 @@ unsafe fn pichu_special_air_lw_hit_effect(fighter: &mut L2CAgentBase) {
     WorkModule::is_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_KAMINARI_ATTACK_HIT);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::pichu::instance::IS_CHARGE_ATTACK) {
-            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_POWER_MUL);
+            let discharge_effect_mul = VarModule::get_float(boma.object(), vars::pichu::instance::DISCHARGE_SIZE_MUL);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_kaminari_hit2"), Hash40::new("hip"), 0, 0, 0, 0, 90, 0, 1.15 * discharge_effect_mul, true);
             EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pichu_final_explosion"), Hash40::new("hip"), 0, 0, 0, 0, 0, 0, 0.3 * discharge_effect_mul, false);
         }

--- a/romfs/source/fighter/pichu/param/hdr.xml
+++ b/romfs/source/fighter/pichu/param/hdr.xml
@@ -4,4 +4,5 @@
     <float hash="charge_state_damage_mul">1.2</float>
     <float hash="charge_state_recoil_mul">1.25</float>
     <float hash="discharge_min_power_mul">0.5</float>
+    <float hash="discharge_min_size_mul">0.75</float>
 </struct>


### PR DESCRIPTION
- You now have 3 seconds after Charge State activates to use a full-strength Discharge before it starts decreasing in damage/size, rather than 1 second
- Discharge is now only 25% smaller at minimum size, rather than 50% smaller
- BKB increased 50 -> 70
- Your FAF now scales with Discharge's strength (lower FAF from weaker Discharge)

Minimum size before:
![2023021314291100-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/47401664/219228573-1ca89479-9c01-43d9-bb25-55dad109c1ae.jpg)

Minimum size after:
![2023021518182000-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/47401664/219228595-5036eace-09ce-4905-b526-4767526c858d.jpg)
