### PR TITLE
Remove magnifying glass shrinking

### DIFF
--- a/romfs/source/ui/param/info/hud_param.prcxml
+++ b/romfs/source/ui/param/info/hud_param.prcxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+  <struct hash="hud_loupe_param">
+    <float hash="loupe_min_scale">1</float>
+    <float hash="loupe_max_scale">1</float>
+  </struct>
+</struct>


### PR DESCRIPTION
In Ultimate, the closer you got to the blastzone, the smaller your magnifying glass would shrink. This was appropriate when paired with balloon knockback, but now that that is gone, this feature contributes to knockback feeling "slow" at times.

This reverts the behavior to the previous games': the magnifying glass's size now stays static.

Example:

https://user-images.githubusercontent.com/47401664/219884955-567d10e6-0325-4513-afff-821ff9a86cfc.mp4
