### PR TITLE
Kirby - fix voice clip on landing hammer

### DIFF
--- a/fighters/kirby/src/lib.rs
+++ b/fighters/kirby/src/lib.rs
@@ -42,4 +42,8 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frames!(
+        hammer_fastfall_landcancel
+    );
 }

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -35,18 +35,20 @@ unsafe fn final_cutter_cancel(boma: &mut BattleObjectModuleAccessor, id: usize, 
     }
 }
 
-// Kirby Hammer Fast Fall & Land Cancel
-unsafe fn hammer_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat2: i32, stick_y: f32) {
-    if status_kind == *FIGHTER_KIRBY_STATUS_KIND_SPECIAL_S_ATTACK {
-        if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
-            MotionModule::change_motion_force_inherit_frame(boma, Hash40::new("special_s"), 43.0, 1.0, 1.0); // 55 FAF - F43 = 12F landing lag
+#[fighter_frame( agent = FIGHTER_KIND_KIRBY )]
+pub fn hammer_fastfall_landcancel(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    unsafe {
+    if fighter.is_status(*FIGHTER_KIRBY_STATUS_KIND_SPECIAL_S_ATTACK) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) && fighter.is_prev_situation(*SITUATION_KIND_AIR) {
+            MotionModule::change_motion_force_inherit_frame(fighter.module_accessor, Hash40::new("special_s"), 43.0, 1.0, 1.0); // 55 FAF - F43 = 12F landing lag
         }
-        if situation_kind == *SITUATION_KIND_AIR {
-            if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66 && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
+        if fighter.is_situation(*SITUATION_KIND_AIR) {
+            if fighter.is_cat_flag(Cat2::FallJump) && fighter.stick_y() < -0.66 && KineticModule::get_sum_speed_y(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
+                WorkModule::set_flag(fighter.module_accessor, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
             }
         }
     }
+}
 }
 
 // Magic Series
@@ -297,7 +299,6 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     final_cutter_cancel(boma, id, status_kind, cat[0], frame);
-    hammer_fastfall_landcancel(boma, status_kind, situation_kind, cat[1], stick_y);
 
 
     // Frame Data


### PR DESCRIPTION
Fixes an issue where grounded sideB voice clip would play on uncharged aerial sideB landing.