### PR TITLE
Mario PM Fireball

### DIFF
--- a/romfs/source/fighter/mario/param/vl.prcxml
+++ b/romfs/source/fighter/mario/param/vl.prcxml
@@ -5,6 +5,19 @@
       <float hash="p1_y">21.5</float>
     </struct>
   </list>
+  <list hash="param_fireball">
+    <struct index="0">
+      <float hash= "speed">1.5</float>
+      <float hash= "gravity_accel">0.08</float>
+      <float hash= "angle">-10</float>
+      <float hash= "bound_ref_speed_mul">0.92</float>
+      <float hash="bounded_speed_y_min">1.5</float>
+      <float hash="bounded_speed_y_max">2.5</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
   <list hash="param_special_s">
     <struct index="0">
       <float hash="special_s_attack_spd_y">0.8</float>

--- a/romfs/source/fighter/mario/param/vl.prcxml
+++ b/romfs/source/fighter/mario/param/vl.prcxml
@@ -8,11 +8,11 @@
   <list hash="param_fireball">
     <struct index="0">
       <float hash= "speed">1.5</float>
-      <float hash= "gravity_accel">0.08</float>
+      <float hash= "gravity_accel">0.07</float>
       <float hash= "angle">-10</float>
-      <float hash= "bound_ref_speed_mul">0.92</float>
+      <float hash= "bound_ref_speed_mul">0.90</float>
       <float hash="bounded_speed_y_min">1.5</float>
-      <float hash="bounded_speed_y_max">2.5</float>
+      <float hash="bounded_speed_y_max">3.0</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Gives Mario a somewhat accurate recreation of PM Fireball.

Changes:
- projectile speed increased from 1.4 -> 1.5
- gravity acceleration decreased from 0.1 -> 0.08
- the rebound speed multiplier decreased from 0.97 -> 0.92.
- the rebound min y speed cap (how low the fireball can bounce) increased from 1.4 -> 1.5.
- the rebound max y speed cap (how high the fireball can bounce) increased from 1.6 -> 2.5.

**Edit**: Changed some fireball params, final changes are: 

- gravity acceleration decreased from 0.08 -> 0.07
- the rebound speed multiplier decreased from 0.92 -> 0.90.
- the rebound max y speed cap (how high the fireball can bounce) increased from 2.5 -> 3.0.

Video of the current changes:

https://user-images.githubusercontent.com/115908645/222334792-22a7116f-eb86-4cff-b813-66eec33cc889.mp4



