### PR TITLE
Fix Cloud Air Cross Slash

### DIFF
--- a/fighters/cloud/src/acmd/specials.rs
+++ b/fighters/cloud/src/acmd/specials.rs
@@ -126,6 +126,7 @@ unsafe fn cloud_special_air_s2_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 2.0);
     if is_excute(fighter) {
+        KineticModule::clear_speed_all(boma);
         if PostureModule::lr(boma) < 0.0 {
             ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 95, 25, 0, 33, 7.5, 0.0, 13.5, 17.7, Some(0.0), Some(9.0), Some(15.7), 0.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
             ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 60, 25, 0, 43, 4.5, 0.0, 8.5, 9.5, Some(0.0), Some(8.5), Some(8.5), 0.8, 0.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);


### PR DESCRIPTION
If Cloud has horizontal momentum on landing Cross Slash in the air, the move will almost never work because Cloud continues to drift horizontally and the opponent does not move with him.

This eliminates Cloud's horizontal momentum on air Cross Slash 2.
One line was added to air Cross Slash 2's acmd: 
"KineticModule::clear_speed_all(boma);"
