### PR TITLE
Tourney mode SSS

### DIFF
--- a/plugin/src/lua.rs
+++ b/plugin/src/lua.rs
@@ -29,7 +29,7 @@ macro_rules! lua_settop {
 unsafe extern "C" fn luaL_tolstring(lua_state: u64, index: i32, size: *mut usize) -> *const u8;
 
 unsafe extern "C" fn lua_print_impl(lua_state: u64) -> i32 {
-    let num_args = lua_gettop!(lua_state);
+    let num_args = lua_gettop!(lua_state) - 1;
     for x in 1..=num_args {
         let mut size = 0;
         let c_str = luaL_tolstring(lua_state, x as i32, &mut size);

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,6 +19,8 @@ skyline-web = { git = "https://github.com/skyline-rs/skyline-web" }
 smash_script = { git = "https://github.com/blu-dev/smash-script", branch = "development" }
 once_cell = "1.15.0"
 colorgrad = "0.6.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [patch.'https://github.com/jam1garner/smash-arc']
 smash-arc = "0.5"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(seek_stream_len)]
 #[macro_use]
 extern crate lazy_static;
 

--- a/utils/src/modules/param.rs
+++ b/utils/src/modules/param.rs
@@ -282,6 +282,10 @@ const STAGE_DB_PRC: &str = "ui/param/database/ui_stage_db.prc";
 const STAGE_SELECT_LAYOUT: &str = "ui/layout/menu/stage_select/stage_select/layout.arc";
 const STAGE_SELECT_PATCH_LAYOUT: &str = "ui/layout/patch/stage_select2/stage_select2/layout.arc";
 const STAGE_SELECT_TOURNEY_LAYOUT: &str = "ui/layout/menu/stage_select/stage_select/layout.tourney.arc";
+const DEFAULT_ROW_LENGTH: usize = 7;
+
+const STAGE_SELECT_ACTOR_LUA: &str = "ui/script_patch/common/stage_select_actor3.lua";
+const STAGE_SELECT_ACTOR_LUA_TOURNEY: &str = "ui/script_patch/common/stage_select_actor3.tourney.lua";
 
 use serde::{Deserialize, Serialize};
 use serde_json::Result;
@@ -292,33 +296,82 @@ use prc::{ParamList, ParamStruct};
 struct TourneyConfig {
     /// whether the tourney mode is enabled
     enabled: bool,
-    /// the ordered list of stages which should be enabled,
-    /// or `None` if the stage list should not be modified
-    stages: Option<Vec<String>>
+    /// the ordered list of starters stages which should be enabled,
+    /// or `None` if there are no starters
+    starters: Option<Vec<String>>,
+    /// the ordered list of counterpick stages which should be enabled,
+    /// or `None` if there are no counterpicks
+    counterpicks: Option<Vec<String>>
+}
+
+impl TourneyConfig {
+    fn is_valid(&self) -> bool {
+        // if tourney mode is not enabled, we are not configured
+        if !self.enabled {
+            println!("tourney mode stages are not enabled");
+            return false;
+        }
+
+        // if the stages are not defined, we are not configured
+        if self.starters.is_none() && self.starters.is_none() {
+            println!("tourney mode stages are enabled, but the stages are missing!");
+            return false;
+        }
+
+        // if there are too many stages for the allowed number per row, this is invalid.
+        if self.starters.as_ref().unwrap().len() > DEFAULT_ROW_LENGTH 
+        || self.counterpicks.as_ref().unwrap().len() > DEFAULT_ROW_LENGTH {
+            println!("Too many starters or counterpicks were enabled! Invalid stage config!")
+        }
+
+        // otherwise, we are configured
+        return true;
+    }
+    /// loads the tourney config from the sdcard
+    fn load() -> Option<TourneyConfig> {
+        // load the tourney config
+        let config: Option<TourneyConfig> = match std::fs::read_to_string("sd:/ultimate/hdr-config/tourney_mode.json") {
+            Ok(json) => serde_json::from_str(&json).expect("A tourney_mode.json was found, but its contents were invalid!"),
+            Err(e) => {
+                println!("No tourney mode config was found. Assuming tourney mode is disabled.");
+                None
+            }
+        };
+        return config;
+    }
 }
 
 /// This is used for tournament mode. Modifies on-the-fly whether individual stages will 
 /// be shown or not on the stage select screen.
+/// 
+/// This logic works by modifying the display order (`disp_order`) of the stages, based
+/// on what has been configured in the tournament configuration json file, and then
+/// recreating the prc file contents to *only* include those stages.
+/// 
+/// More specifically, if both counterpicks and starters are specified, then
+/// the `RandomEnd` stage is used as a buffer between the two sets of stages.
+/// - Starter stages are given 1
+/// - RandomEnd is given 2
+/// - Counterpick stages are given 3
+/// 
+/// The result is that the stages are given to the UI in a list,
+/// ordered as `[(starters), RandomEnd...RandomEnd, (counterpicks)]`. The UI then hides
+/// all RandomEnd stages, and makes them non-interactable, so that the UI looks as expected.
 #[arc_callback]
 fn ui_stage_db_prc_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
     // ensure this is the file data it should be
     assert_eq!(hash, hash40(STAGE_DB_PRC));
 
-    // load the tourney config
-    let config: TourneyConfig = match std::fs::read_to_string("sd:/ultimate/hdr-config/tourney_mode.json") {
-        Ok(json) => serde_json::from_str(&json).expect("A tourney_mode.json was found, but its contents were invalid!"),
-        Err(e) => {
-            println!("No tourney mode config was found. Assuming tourney mode is disabled.");
-            return None;
-        }
-    };
-
-    // if tourney mode is not enabled or no stage list is configured,
-    // then we shouldn't modify the file.
-    if !config.enabled || config.stages.is_none() {
+    let config = TourneyConfig::load();
+    if config.is_none() {
         return None;
     }
-
+    let config = config.unwrap();
+    if !config.is_valid() {
+        println!("not loading tourney config for stage PRC - config is not valid.");
+        return None;
+    }
+    
     // load the original file data first
     let size = load_original_file(hash, &mut data).expect("Unable to load ui_stage_db.prc!");
 
@@ -337,11 +390,13 @@ fn ui_stage_db_prc_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
     let list_kind = (&mut db_root.1);
     let param_list = list_kind.try_into_mut::<ParamList>().expect("Failed to load db_root list from ui_stage_db.prc!");
     let list = &mut param_list.0;
+    let mut out_list: Vec<ParamKind> = vec!();
 
-    let stages = config.stages.unwrap();
+    let starters = config.starters.unwrap();
+    let counterpicks = config.counterpicks.unwrap();
 
-    // disable and enable the appropriate stages
-    for entry in list {
+    // disable and enable the appropriate stages in the original structure
+    for entry in list.iter_mut() {
         let stage_entry = &mut (entry.try_into_mut::<ParamStruct>().expect("failed to get struct from ui_stage_db.prc entry!").0);
         
         // the name_id of the stage: BattleField, Yoshi_Story, Kirby_Pupupu64, etc
@@ -360,17 +415,43 @@ fn ui_stage_db_prc_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
             .1
             .try_into_mut::<i8>()
             .expect("Could not get disp_order as an i8 for a stage entry in tourney mode");
-        
-        // set the display order to show or hide the stage
-        match stages.contains(&name_id) {
+
+
+        *disp_order = -1;
+
+        // set the disp_order if this is a starter to 1 (see fn docs)
+        match starters.contains(&name_id) {
             true => {
                 *disp_order = 1;
+                out_list.push(entry.clone());
+                continue;
             },
-            false => {
-                *disp_order = -1;
+            false => {}
+        };
+
+        // set Random to 2 (see fn docs)
+        if name_id == "RandomEnd" {
+            *disp_order = 2;
+            // pad with a bunch of RandomEnd stages, which will be hidden
+            let len = starters.len();
+            for _ in 0..(DEFAULT_ROW_LENGTH-len) {
+                out_list.push(entry.clone());
             }
+            continue;
+        }
+
+        // set the disp_order if this is a counterpick to 3 (see fn docs)
+        match counterpicks.contains(&name_id) {
+            true => {
+                *disp_order = 3;
+                out_list.push(entry.clone());
+                continue;
+            },
+            false => {}
         };
     }
+
+    *list = out_list;
 
     // write the data back into the buffer
     let buf = &mut std::io::Cursor::new(data);
@@ -382,26 +463,55 @@ fn ui_stage_db_prc_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
 
 #[arc_callback]
 fn stage_select_layout_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
-    // load the tourney config
-    let config: TourneyConfig = match std::fs::read_to_string("sd:/ultimate/hdr-config/tourney_mode.json") {
-        Ok(json) => serde_json::from_str(&json).expect("A tourney_mode.json was found, but its contents were invalid!"),
-        Err(e) => {
-            println!("No tourney mode config was found. Assuming tourney mode is disabled.");
-            return None;
-        }
-    };
-
-    // if tourney mode is not enabled or no stage list is configured,
-    // then we shouldn't load the tourney layout
-    if !config.enabled || config.stages.is_none() {
-        println!("tourney mode stages are not enabled");
-        return None;
+    // ensure that the tourney config is loaded, and if not, return
+    match TourneyConfig::load() {
+        Some(config) => match config.is_valid() {
+            true => {},
+            false => return None
+        },
+        None => return None
     }
 
     println!("loading tourney mode layout");
 
     // load the tourney layout
     let size = load_original_file(hash40(STAGE_SELECT_TOURNEY_LAYOUT), &mut data).expect("Unable to load '/ui/layout/menu/stage_select/stage_select/layout.tourney.arc'");
+    Some(size)
+}
+
+/// this callback is used to allocate more space than normal for the stage
+#[arc_callback]
+fn stage_select_actor_callback(hash: u64, mut data: &mut [u8]) -> Option<usize> {
+    // ensure that the tourney config is loaded, and if not, return
+    match TourneyConfig::load() {
+        Some(config) => match config.is_valid() {
+            true => {},
+            false => return None
+        },
+        None => return None
+    }
+
+    println!("loading tourney mode sss lua");
+
+    // load the actor lua in hdr-dev (REMOVE THIS)
+    let mut bytes = match std::fs::read("mods:/ui/script_patch/common/stage_select_actor3.tourney.lua") {
+        Ok(b) => b,
+        Err(e) => {
+            println!("\n\n\n\n\nFAILED TO LOAD DEV STAGE SELECT ACTOR!\n\n\n\n\n");
+            return None;
+        }
+    };
+
+    // pad the file bytes
+    let last = *bytes.last().unwrap();
+    while bytes.len() < data.len() {
+        bytes.push(last as u8)
+    }
+
+    let bytes_slice = bytes.as_slice();
+    data.copy_from_slice(&bytes_slice);
+    
+    let size = data.len();
     Some(size)
 }
 
@@ -777,6 +887,7 @@ pub(crate) fn init() {
     ui_stage_db_prc_callback::install(STAGE_DB_PRC, /* 20kb */ 20480);
     stage_select_layout_callback::install(STAGE_SELECT_LAYOUT, /* 10mb */ 10485760);
     stage_select_layout_callback::install(STAGE_SELECT_PATCH_LAYOUT, /* 10mb */ 10485760);
+    stage_select_actor_callback::install(STAGE_SELECT_ACTOR_LUA, /* 150kb-ish */ 150000);
 
     common_param_callback::install("fighter/common/hdr/param/common.prc", hdr_macros::size_of_rom_file!("fighter/common/hdr/param/common.prc"));
     for (file, (_, size)) in AGENT_PARAM_REVERSE.iter() {


### PR DESCRIPTION
This PR adds new infrastructure to go along with launcher changes, which introduces a new tournament mode config that supports separating starters and counterpicks on the SSS, with up to 7 starters and 7 counterpicks.

This is a first pass at the implementation, and further cleanup will occur down the line.
![image](https://user-images.githubusercontent.com/42820193/222938495-ea78804f-2f2b-4e71-b4de-ff94a3e8f882.png)

![20230304_214826](https://user-images.githubusercontent.com/42820193/222939170-695634d8-e581-485f-86ab-7d65b71f2656.jpg)
