### PR TITLE
Reset projectile lifetime on parry

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::globals::*;
+use std::arch::asm;
 pub mod energy;
 pub mod effect;
 pub mod edge_slipoffs;
@@ -328,6 +329,10 @@ pub fn install() {
         skyline::patching::Patch::in_text(0x3a85c0).nop();
         skyline::patching::Patch::in_text(0x3a85d8).nop();
         skyline::patching::Patch::in_text(0x3a85f0).nop();
+
+        // Resets projectile lifetime on parry, rather than using remaining lifetime
+        skyline::patching::Patch::in_text(0x33bd358).nop();
+        skyline::patching::Patch::in_text(0x33bd35c).data(0x2a0a03e1);
     }
     skyline::install_hooks!(
         kinetic_module__call_update_energy_hook,

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -19,6 +19,7 @@
   <int hash="just_shield_hitstop_frame_max">23</int>
   <float hash="just_shield_reflect_attack_mul">0.5</float>
   <float hash="just_shield_reflect_speed_mul">1.0</float>
+  <float hash="just_shield_reflect_life_mul">1</float>
   <int hash="just_shield_reflect_count_max">7</int>
   <float hash="rebound_reaction_mul">0.3</float>
   <float hash="rebound_reaction_add">2.0</float>


### PR DESCRIPTION
Previously, when a projectile was parried, its _remaining_ lifetime would be multiplied by 2.
Now, its lifetime is _reset_ to its initial value.

https://user-images.githubusercontent.com/47401664/223023503-53521b7e-a6b5-441f-a4d8-64d8e73cbc71.mp4
