### PR TITLE
Wario Shake-It Pummel

### DIFF
--- a/fighters/wario/src/acmd/throws.rs
+++ b/fighters/wario/src/acmd/throws.rs
@@ -8,7 +8,7 @@ unsafe fn game_catch_attack(fighter: &mut L2CAgentBase) {
     
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.3, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.4, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.8, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
         AttackModule::set_damage_shake_scale(boma, 0.0);
         AttackModule::set_attack_camera_quake_forced(boma, 0, *CAMERA_QUAKE_KIND_NONE, false);

--- a/fighters/wario/src/acmd/throws.rs
+++ b/fighters/wario/src/acmd/throws.rs
@@ -8,13 +8,15 @@ unsafe fn game_catch_attack(fighter: &mut L2CAgentBase) {
     
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.8, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.3, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
+        AttackModule::set_damage_shake_scale(boma, 0.0);
+        AttackModule::set_attack_camera_quake_forced(boma, 0, *CAMERA_QUAKE_KIND_NONE, false);
     }
     wait(lua_state, 1.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        MotionModule::set_frame(boma.get_grabbed_opponent_boma(), 0.0, false);
+        MotionModule::set_frame(boma.get_grabbed_opponent_boma(), 0.1, false);
     }
     frame(fighter.lua_state_agent,12.0);
     if is_excute(fighter) {

--- a/fighters/wario/src/acmd/throws.rs
+++ b/fighters/wario/src/acmd/throws.rs
@@ -8,7 +8,7 @@ unsafe fn game_catch_attack(fighter: &mut L2CAgentBase) {
     
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.4, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.8, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.3, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
         AttackModule::set_damage_shake_scale(boma, 0.0);
         AttackModule::set_attack_camera_quake_forced(boma, 0, *CAMERA_QUAKE_KIND_NONE, false);

--- a/fighters/wario/src/acmd/throws.rs
+++ b/fighters/wario/src/acmd/throws.rs
@@ -8,7 +8,7 @@ unsafe fn game_catch_attack(fighter: &mut L2CAgentBase) {
     
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.3, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 1.6, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"),  1.3, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 0.95, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
         AttackModule::set_damage_shake_scale(boma, 0.0);
         AttackModule::set_attack_camera_quake_forced(boma, 0, *CAMERA_QUAKE_KIND_NONE, false);

--- a/fighters/wario/src/acmd/throws.rs
+++ b/fighters/wario/src/acmd/throws.rs
@@ -2,27 +2,31 @@
 use super::*;
 
 #[acmd_script( agent = "wario", script = "game_catchattack" , category = ACMD_GAME , low_priority)]
-unsafe fn catch_attack(fighter: &mut L2CAgentBase) {
+unsafe fn game_catch_attack(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 1, Hash40::new("top"), 0.8, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 2.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.8, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
     }
     wait(lua_state, 1.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
+        MotionModule::set_frame(boma.get_grabbed_opponent_boma(), 0.0, false);
     }
-    wait(lua_state, 1.0);
+    frame(fighter.lua_state_agent,12.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.8, 361, 100, 30, 0, 5.0, 0.0, 10.0, 7.0, None, None, None, 2.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, true, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
-        AttackModule::set_catch_only_all(boma, true, false);
+        let defender= boma.get_grabbed_opponent_boma();
+        MotionModule::set_frame(defender, 14.0, false);
+        MotionModule::set_rate(defender, 1.0);
     }
-    wait(lua_state, 1.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
+}
+#[acmd_script( agent = "wario", script = "effect_catchattack", category = ACMD_EFFECT )]
+unsafe fn effect_catch_attack(fighter: &mut L2CAgentBase) {
+    if macros::is_excute(fighter) {
+        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("sys_attack_speedline"), Hash40::new("top"), 0.0, 7.25, 11.0, 260, 0, 0, 1.1, true);
     }
 }
 
@@ -55,7 +59,8 @@ unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
-        catch_attack,
+        game_catch_attack,
+        effect_catch_attack,
         game_throwlw,
     );
 }

--- a/fighters/wario/src/lib.rs
+++ b/fighters/wario/src/lib.rs
@@ -3,8 +3,7 @@
 #![allow(non_snake_case)]
 
 pub mod acmd;
-
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +39,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/wario/src/status.rs
+++ b/fighters/wario/src/status.rs
@@ -36,5 +36,5 @@ unsafe fn catch_attack_end(fighter: &mut L2CFighterCommon) -> L2CValue {
         &Vector3f::zero(),
         0
     );
-    return false.into();
+    return original!(fighter);
 }

--- a/fighters/wario/src/status.rs
+++ b/fighters/wario/src/status.rs
@@ -1,0 +1,40 @@
+use super::*;
+use globals::*;
+ 
+
+pub fn install() {
+    install_status_scripts!(
+        catch_attack_exec,
+        catch_attack_end,
+    );
+}
+
+
+//Force opponent rotation
+#[status_script(agent = "wario", status = FIGHTER_STATUS_KIND_CATCH_ATTACK, condition = LUA_SCRIPT_STATUS_FUNC_EXEC_STATUS)]
+unsafe fn catch_attack_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
+
+    let boma = fighter.boma();
+
+    let mut vec =Vector3f{x: 0.0, y: 0.0, z: 0.0};
+    let offset = ModelModule::joint_global_rotation(boma,Hash40::new("throw"),&mut vec,false);
+    let rot = Vector3f{x: vec.x, y: 0.0, z: 0.0};
+    PostureModule::set_rot(
+        boma.get_grabbed_opponent_boma(),
+        &rot,
+        0
+    );
+    return false.into();
+}
+//Reset opponent rotation
+#[status_script(agent = "wario", status = FIGHTER_STATUS_KIND_CATCH_ATTACK, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn catch_attack_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let boma = fighter.boma();
+
+    PostureModule::set_rot(
+        boma.get_grabbed_opponent_boma(),
+        &Vector3f::zero(),
+        0
+    );
+    return false.into();
+}


### PR DESCRIPTION

https://user-images.githubusercontent.com/13909643/223880629-803fc4fd-2680-4a70-bc51-a4c36aaf566e.mp4


Requires the following file to be extracted and placed in `fighter/wario/motion/body/c00`
[pummel.zip](https://github.com/HDR-Development/HewDraw-Remix/files/10936093/pummel.zip)

Changes:
- Pummel 1 Damage Increased (0.8->1.3)
- Pummel 1 Hitstun Decreased (2.3->1.6)
- Pummel Second Hitbox Removed (Total Attack Damage: 1.6->1.3)
- Opponents will now rotate based on the throw bone during this attack