### PR TITLE
Teleport wallride logic improvement

### DIFF
--- a/fighters/mewtwo/src/opff.rs
+++ b/fighters/mewtwo/src/opff.rs
@@ -73,10 +73,11 @@ pub unsafe fn mewtwo_teleport_wall_ride(fighter: &mut smash::lua2cpp::L2CFighter
     let touch_left = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
 
     if boma.is_status(*FIGHTER_MEWTWO_STATUS_KIND_SPECIAL_HI_2) {
-        if touch_right || touch_left || VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            if !VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-                VarModule::on_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-            }
+        let touch_normal_y_left = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
+        let touch_normal_y_right = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
+        if (touch_right && touch_normal_y_right != 0.0)
+        || (touch_left && touch_normal_y_left != 0.0)
+        {
             let init_speed_y = VarModule::get_float(boma.object(), vars::common::status::TELEPORT_INITIAL_SPEED_Y);
 
             if init_speed_y > 0.0 {
@@ -92,11 +93,6 @@ pub unsafe fn mewtwo_teleport_wall_ride(fighter: &mut smash::lua2cpp::L2CFighter
                 let wall_ride = Vector3f{x: 0.0, y: 1.0, z: 1.0};
                 KineticModule::mul_speed(boma, &wall_ride, *FIGHTER_KINETIC_ENERGY_ID_STOP);
             }
-        }
-    }
-    else {
-        if VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            VarModule::off_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
         }
     }
 }

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -68,10 +68,11 @@ pub unsafe fn palutena_teleport_wall_ride(fighter: &mut smash::lua2cpp::L2CFight
     let touch_left = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
 
     if boma.is_status(*FIGHTER_PALUTENA_STATUS_KIND_SPECIAL_HI_2) {
-        if touch_right || touch_left || VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            if !VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-                VarModule::on_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-            }
+        let touch_normal_y_left = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
+        let touch_normal_y_right = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
+        if (touch_right && touch_normal_y_right != 0.0)
+        || (touch_left && touch_normal_y_left != 0.0)
+        {
             let init_speed_y = VarModule::get_float(boma.object(), vars::common::status::TELEPORT_INITIAL_SPEED_Y);
 
             if init_speed_y > 0.0 {
@@ -87,11 +88,6 @@ pub unsafe fn palutena_teleport_wall_ride(fighter: &mut smash::lua2cpp::L2CFight
                 let wall_ride = Vector3f{x: 0.0, y: 1.0, z: 1.0};
                 KineticModule::mul_speed(boma, &wall_ride, *FIGHTER_KINETIC_ENERGY_ID_STOP);
             }
-        }
-    }
-    else {
-        if VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            VarModule::off_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
         }
     }
 }

--- a/fighters/sheik/src/opff.rs
+++ b/fighters/sheik/src/opff.rs
@@ -28,48 +28,6 @@ extern "Rust" {
     fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
 }
 
-pub unsafe fn teleport_wall_ride(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, id: usize) {
-    /*
-    if status_kind == *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_HI_MOVE {
-        if compare_mask(ControlModule::get_pad_flag(boma), *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER) {
-            StatusModule::change_status_request_from_script(boma, *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_HI_END, false);
-        }
-    }
-    */
-
-    // Wall Ride momentum fixes
-    let touch_right = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
-    let touch_left = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
-
-    if boma.is_status(*FIGHTER_SHEIK_STATUS_KIND_SPECIAL_HI_MOVE) {
-        if touch_right || touch_left || VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            if !VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-                VarModule::on_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-            }
-            let init_speed_y = VarModule::get_float(boma.object(), vars::common::status::TELEPORT_INITIAL_SPEED_Y);
-
-            if init_speed_y > 0.0 {
-                fighter.clear_lua_stack();
-                lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, 0.0, init_speed_y);
-                app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
-            }
-        }
-    }
-    else if boma.is_status(*FIGHTER_SHEIK_STATUS_KIND_SPECIAL_HI_END) {
-        if touch_right || touch_left {
-            if KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) > 0.0 {
-                let wall_ride = Vector3f{x: 0.0, y: 1.0, z: 1.0};
-                KineticModule::mul_speed(boma, &wall_ride, *FIGHTER_KINETIC_ENERGY_ID_STOP);
-            }
-        }
-    }
-    else {
-        if VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            VarModule::off_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-        }
-    }
-}
-
 // pub unsafe fn hitfall_aerials(fighter: &mut L2CFighterCommon, frame: f32) {
 //     if fighter.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR) {
 //         // only allow the last hit of uair to be hitfalled
@@ -87,7 +45,6 @@ pub unsafe fn teleport_wall_ride(fighter: &mut L2CFighterCommon, boma: &mut Batt
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bouncing_fish_return_cancel(fighter, boma, status_kind, situation_kind, cat[0], frame);
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
-    teleport_wall_ride(fighter, boma, status_kind, id);
     //hitfall_aerials(fighter, frame);
 }
 

--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -16,10 +16,11 @@ unsafe fn teleport_tech(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &m
     let touch_left = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
 
     if boma.is_status(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2) {
-        if touch_right || touch_left || VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            if !VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-                VarModule::on_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
-            }
+        let touch_normal_y_left = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
+        let touch_normal_y_right = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
+        if (touch_right && touch_normal_y_right != 0.0)
+        || (touch_left && touch_normal_y_left != 0.0)
+        {
             let init_speed_y = VarModule::get_float(boma.object(), vars::common::status::TELEPORT_INITIAL_SPEED_Y);
 
             if init_speed_y > 0.0 {
@@ -35,11 +36,6 @@ unsafe fn teleport_tech(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &m
                 let wall_ride = Vector3f{x: 0.0, y: 1.0, z: 1.0};
                 KineticModule::mul_speed(boma, &wall_ride, *FIGHTER_KINETIC_ENERGY_ID_STOP);
             }
-        }
-    }
-    else {
-        if VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE) {
-            VarModule::off_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE);
         }
     }
 }


### PR DESCRIPTION
Teleport wallride behavior (to prevent bouncing off of sloped walls) now only applies on sloped walls, where it was previously being applied on flat walls as well.

This applies to:
- Palutena
- Mewtwo
- Zelda

Wallride logic is no longer run at all for Sheik, as she never had the bouncing issue in the first place.