### PR TITLE
Fix hanging on Salty Runback/Quick Exit inputs

### DIFF
--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -1,11 +1,4 @@
-use utils::{
-    *,
-    ext::*,
-    consts::*
-};
-use smash::app::{self, lua_bind::*, sv_system, sv_kinetic_energy};
-use smash::phx::*;
-use smash::hash40;
+use super::*;
 use smash::lib::{lua_const::*, L2CValue, L2CAgent};
 use smash::lua2cpp::L2CFighterCommon;
 use smash::lua2cpp::L2CFighterBase;
@@ -57,20 +50,25 @@ pub unsafe fn fighter_common_opff(fighter: &mut L2CFighterCommon) {
     }
 }
 
+static mut IS_SALTY_INPUT: bool = false;
+
 /// Performs salty runback check based off of the button input
 /// This is to make it WiFi safe
 unsafe fn salty_check(fighter: &mut L2CFighterCommon) -> bool {
+    if IS_SALTY_INPUT {
+        return false;
+    }
     if fighter.is_button_on(Buttons::StockShare) {
         if fighter.is_button_on(Buttons::AttackRaw) && !fighter.is_button_on(!(Buttons::AttackRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
-            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_assist_out"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false);
+            EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_assist_out"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), 1.5, true, 0, 0, 0, 0, 0, false, false);
             utils::util::trigger_match_reset();
             utils::game_modes::signal_new_game();
             true
         } else if fighter.is_button_on(Buttons::SpecialRaw) && !fighter.is_button_on(!(Buttons::SpecialRaw | Buttons::StockShare)) {
             app::FighterUtil::flash_eye_info(fighter.module_accessor);
             if !fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_STANDBY]) {
-                StatusModule::change_status_request(fighter.module_accessor, *FIGHTER_STATUS_KIND_DEAD, false);
+                StatusModule::change_status_force(fighter.module_accessor, *FIGHTER_STATUS_KIND_DEAD, false);
             }
             utils::util::trigger_match_exit();
             true
@@ -91,8 +89,18 @@ pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_CLIFF_XLU);
     }
 
+    if fighter.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_WIN,
+        *FIGHTER_STATUS_KIND_LOSE,
+        *FIGHTER_STATUS_KIND_ENTRY])
+    || !sv_information::is_ready_go()
+    {
+        IS_SALTY_INPUT = false;
+    }
+
     // General Engine Edits
     if salty_check(fighter) {
+        IS_SALTY_INPUT = true;
         return;
     }
 


### PR DESCRIPTION
Fixes an issue where the game would hang for a second if the Salty Runback/Quick Exit inputs were held.
Nana will no longer perform Salty inputs 6f after Popo as well.

Fixes #1347 
Fixes #1348 