### PR TITLE
Allow common OPFF to be placed on Exec status

### DIFF
--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -35,4 +35,5 @@ pub fn install() {
     // tag::install();
     general_statuses::install();
     function_hooks::install();
+    opff::install();
 }

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -25,6 +25,8 @@ pub mod floats;
 pub mod other;
 pub mod fe;
 
+use other::*;
+
 /*
 pub fn install() {
     // acmd::add_custom_hooks!(sys_line_system_control_fighter_hook);
@@ -113,4 +115,12 @@ pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
     // Character Moveset Changes
     // moveset_changes::run(boma, id, cat, status_kind, situation_kind, motion_kind, fighter_kind, stick_x, stick_y, facing, frame);
     floats::run(fighter, boma, info.cat, info.status_kind, info.situation_kind, info.fighter_kind, info.stick_x, info.stick_y, info.facing);
+}
+
+pub fn install() {
+    // Reserved for common OPFF to be placed on exec status
+    // rather than main status (default behavior)
+    smashline::install_agent_frame_callbacks!(
+        decrease_knockdown_bounce_heights
+    );
 }

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -136,27 +136,32 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
     }
 }
 
-pub unsafe fn decrease_knockdown_bounce_heights(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_DOWN) {
-        let mut hip_offset = Vector3f::zero();
-        ModelModule::joint_global_offset_from_top(fighter.module_accessor, Hash40::new("hip"), &mut hip_offset);
-        if fighter.motion_frame() <= 1.0 {
-            VarModule::set_float(fighter.battle_object, vars::common::status::RESTING_HIP_OFFSET_Y, hip_offset.y);
-        }
+#[smashline::fighter_frame_callback()]
+pub fn decrease_knockdown_bounce_heights(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        if smash::app::utility::get_category(&mut *fighter.module_accessor) == *BATTLE_OBJECT_CATEGORY_FIGHTER {
+            if fighter.is_status(*FIGHTER_STATUS_KIND_DOWN) {
+                let mut hip_offset = Vector3f::zero();
+                ModelModule::joint_global_offset_from_top(fighter.module_accessor, Hash40::new("hip"), &mut hip_offset);
+                if fighter.motion_frame() <= 1.0 {
+                    VarModule::set_float(fighter.battle_object, vars::common::status::RESTING_HIP_OFFSET_Y, hip_offset.y);
+                }
 
-        // Checks if our hip bone position is above our "resting" position (hip position when laying on the floor)
-        // which determines whether we are bouncing or not
-        let lower_limit = VarModule::get_float(fighter.battle_object, vars::common::status::RESTING_HIP_OFFSET_Y);
-        if hip_offset.y > lower_limit {
-            // Halves hip bone's vertical movement and applies offset to rot bone
-            // Cannot apply offset to hip as it is already offset from rot, while rot is directly offset from top bone
-            let mut rot_translate = Vector3f::zero();
-            MotionModule::joint_local_tra(fighter.module_accessor, Hash40::new("rot"), false, &mut rot_translate);
-            let bounce_height_mul = 0.5;
-            let bounce_height = hip_offset.y - lower_limit;
-            
-            rot_translate.y += bounce_height * -bounce_height_mul;
-            ModelModule::set_joint_translate(fighter.module_accessor, Hash40::new("rot"), &Vector3f{ x: 0.0, y: rot_translate.y, z: 0.0 }, false, false);
+                // Checks if our hip bone position is above our "resting" position (hip position when laying on the floor)
+                // which determines whether we are bouncing or not
+                let lower_limit = VarModule::get_float(fighter.battle_object, vars::common::status::RESTING_HIP_OFFSET_Y);
+                if hip_offset.y > lower_limit {
+                    // Halves hip bone's vertical movement and applies offset to rot bone
+                    // Cannot apply offset to hip as it is already offset from rot, while rot is directly offset from top bone
+                    let mut rot_translate = Vector3f::zero();
+                    MotionModule::joint_local_tra(fighter.module_accessor, Hash40::new("rot"), false, &mut rot_translate);
+                    let bounce_height_mul = 0.5;
+                    let bounce_height = hip_offset.y - lower_limit;
+                    
+                    rot_translate.y += bounce_height * -bounce_height_mul;
+                    ModelModule::set_joint_translate(fighter.module_accessor, Hash40::new("rot"), &Vector3f{ x: 0.0, y: rot_translate.y, z: 0.0 }, false, false);
+                }
+            }
         }
     }
 }
@@ -167,6 +172,5 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleA
     suicide_throw_mashout(fighter, boma);
     cliff_xlu_frame_counter(fighter);
     ecb_shift_disabled_motions(fighter);
-    decrease_knockdown_bounce_heights(fighter);
 }
 


### PR DESCRIPTION
Allows a manner in which to override the default install placement of common OPFF, which is before Main status.

As a result, this fixes knockdown bounce height reduction not working in Nightly.