### PR TITLE
OPFF motion frame logic cleanup

### DIFF
--- a/fighters/bayonetta/src/opff.rs
+++ b/fighters/bayonetta/src/opff.rs
@@ -155,6 +155,9 @@ unsafe fn aerial_cancels(fighter: &mut L2CFighterCommon) {
 }
 
 unsafe fn special_cancels(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     // Special Cancels
     if fighter.is_status(*FIGHTER_BAYONETTA_STATUS_KIND_SPECIAL_AIR_S_U)
     && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT)
@@ -227,6 +230,9 @@ unsafe fn clear_proration(fighter: &mut L2CFighterCommon, boma: *mut BattleObjec
 }
 
 unsafe fn abk_flight_drift(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if fighter.is_status(*FIGHTER_BAYONETTA_STATUS_KIND_SPECIAL_AIR_S_U) && fighter.motion_frame() < 26.0 && !StopModule::is_stop(fighter.module_accessor){
         let stick_y =  ControlModule::get_stick_y(fighter.module_accessor);
         if stick_y != 0.0 && !fighter.is_in_hitlag(){

--- a/fighters/buddy/src/opff.rs
+++ b/fighters/buddy/src/opff.rs
@@ -10,6 +10,9 @@ static mut BAYONET_EGGS:[i32;8] = [0; 8]; //I have no idea why varmod doesn't wo
 utils::import_noreturn!(common::opff::fighter_common_opff);
 
 unsafe fn blue_eggs_land_cancels(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N)
     && fighter.is_situation(*SITUATION_KIND_GROUND)
     && fighter.is_prev_situation(*SITUATION_KIND_AIR)
@@ -28,6 +31,9 @@ unsafe fn blue_eggs_land_cancels(fighter: &mut L2CFighterCommon) {
 
 // Banjo Grenade Airdodge Cancel
 unsafe fn grenade_ac(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if fighter.is_status_one_of(&[*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_LW_SHOOT, *FIGHTER_STATUS_KIND_SPECIAL_LW])
     && fighter.motion_frame() > 16.0
     {
@@ -48,6 +54,9 @@ unsafe fn dair_bounce(fighter: &mut L2CFighterCommon){
 
 // Banjo Wondering Fail on command
 unsafe fn wonderwing_fail(fighter: &mut L2CFighterCommon){
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if ((fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S) && fighter.motion_frame() > 17.0)
     || (fighter.is_status(*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_S_END) && fighter.motion_frame() < 4.0))
     && fighter.is_button_on(Buttons::Guard)
@@ -57,6 +66,9 @@ unsafe fn wonderwing_fail(fighter: &mut L2CFighterCommon){
 }
 
 unsafe fn dash_attack_jump_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_ATTACK_DASH
     && situation_kind == *SITUATION_KIND_AIR
     && MotionModule::frame(boma) >= 27.0 {
@@ -65,6 +77,9 @@ unsafe fn dash_attack_jump_cancels(fighter: &mut L2CFighterCommon, boma: &mut Ba
 }
 
 unsafe fn indicator_breegull_fatigue(fighter: &mut L2CFighterCommon){
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
 	let eggs_shot = WorkModule::get_int(fighter.module_accessor, *FIGHTER_BUDDY_INSTANCE_WORK_ID_INT_SPECIAL_N_BAKYUN_BULLET_SHOOT_COUNT);
     let eggs_Weakest = WorkModule::get_param_int(fighter.module_accessor,hash40("param_special_n"),hash40("bakyun_power_down_2_num"));
     let eggs_Weak = WorkModule::get_param_int(fighter.module_accessor,hash40("param_special_n"),hash40("bakyun_power_down_1_num"));
@@ -83,6 +98,9 @@ unsafe fn indicator_breegull_fatigue(fighter: &mut L2CFighterCommon){
 
 //Banjo can airdodge cancel a bonk only after frame 15 if he did not hit a shield
 unsafe fn bonk_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){ 
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let side_special_wall = fighter.is_status(*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_S_WALL);
     if (!side_special_wall) {return;}
     let has_hit_shield = AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_SHIELD);
@@ -99,6 +117,9 @@ unsafe fn bonk_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 
 
 unsafe fn beakbomb_checkForCancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let side_special = fighter.is_status(*FIGHTER_BUDDY_STATUS_KIND_SPECIAL_S_DASH);
     if !side_special {return;}
 
@@ -168,6 +189,9 @@ unsafe fn beakbomb_update(fighter: &mut L2CFighterCommon, boma: &mut BattleObjec
 
 //Check to see if Banjo hit the ground or a shield during beakbomb.
 unsafe fn beakbomb_checkForHit(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let has_hit_shield = AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_SHIELD);
     if (!has_hit_shield) {return;}
     
@@ -227,6 +251,9 @@ unsafe fn beakbomb_checkForFail(fighter: &mut L2CFighterCommon, boma: &mut Battl
 }
 
 unsafe fn breegull_bayonet(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor,status: i32){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let entry = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 
     if (VarModule::is_flag(boma.object(), vars::buddy::instance::BAYONET_ACTIVE))
@@ -300,6 +327,9 @@ unsafe fn buddy_meter_update_HUD(fighter: &mut L2CFighterCommon, boma: &mut Batt
 
 //Control meter HUD display based on HUD_DISPLAY_TIME and current status
 unsafe fn buddy_meter_display(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor,RedFeather: bool){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let status = StatusModule::status_kind(fighter.module_accessor);
     let side_special = [
         *FIGHTER_STATUS_KIND_SPECIAL_S,
@@ -324,6 +354,9 @@ unsafe fn buddy_meter_display(fighter: &mut L2CFighterCommon, boma: &mut BattleO
 }
 //This causes vectoring?
 unsafe fn buddy_meter_controller(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor,status: i32){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if (status == *FIGHTER_STATUS_KIND_WIN) { 
 		EffectModule::kill_kind(boma, Hash40::new("buddy_special_s_count"), false, true);
         return;

--- a/fighters/captain/src/opff.rs
+++ b/fighters/captain/src/opff.rs
@@ -16,6 +16,9 @@ unsafe fn air_falcon_kick_jump_reset(fighter: &mut L2CFighterCommon) {
 }
 
 unsafe fn repeated_falcon_punch_turnaround(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     let frame = fighter.motion_frame();
     if fighter.is_status(*FIGHTER_CAPTAIN_STATUS_KIND_SPECIAL_N_TURN)
     && 22.0 < frame && frame < 41.0

--- a/fighters/chrom/src/opff.rs
+++ b/fighters/chrom/src/opff.rs
@@ -18,6 +18,9 @@ unsafe fn soaring_slash_drift(fighter: &mut L2CFighterCommon) {
 
 // Chrome Soaring Slash Cancel
 unsafe fn soaring_slash_cancel(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     let frame = fighter.motion_frame();
     if fighter.is_status(*FIGHTER_ROY_STATUS_KIND_SPECIAL_HI_2)
     && 28.0 < frame && frame < 31.0

--- a/fighters/common/src/opff/cancels.rs
+++ b/fighters/common/src/opff/cancels.rs
@@ -22,7 +22,7 @@ unsafe fn ditcit(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: 
     }
 
     if status_kind == *FIGHTER_STATUS_KIND_ITEM_THROW_DASH {
-        if MotionModule::frame(boma) > 3.0 && MotionModule::frame(boma) < 7.0
+        if boma.status_frame() > 2 && boma.status_frame() < 6
             && ((boma.is_cat_flag(Cat1::AttackHi4))
              || (boma.is_cat_flag(Cat1::AttackLw4))
              || (boma.is_cat_flag(Cat1::AttackS4))
@@ -73,7 +73,7 @@ unsafe fn footstool_defense(boma: &mut BattleObjectModuleAccessor, status_kind: 
     // Prevent airdodging after a footstool until after F20
     if (status_kind == *FIGHTER_STATUS_KIND_JUMP && prev_status_0 == *FIGHTER_STATUS_KIND_TREAD_JUMP)
         || (status_kind == *FIGHTER_STATUS_KIND_JUMP_AERIAL && prev_status_0 == *FIGHTER_STATUS_KIND_JUMP && prev_status_1 == *FIGHTER_STATUS_KIND_TREAD_JUMP)
-        && MotionModule::frame(boma) < 21.0 {
+        && boma.status_frame() < 20 {
         VarModule::on_flag(boma.object(), vars::common::instance::FOOTSTOOL_AIRDODGE_LOCKOUT);
     } else if VarModule::is_flag(boma.object(), vars::common::instance::FOOTSTOOL_AIRDODGE_LOCKOUT) {
         VarModule::off_flag(boma.object(), vars::common::instance::FOOTSTOOL_AIRDODGE_LOCKOUT);

--- a/fighters/common/src/opff/fe.rs
+++ b/fighters/common/src/opff/fe.rs
@@ -2,6 +2,9 @@ use super::*;
 use smash::app::BattleObjectModuleAccessor;
 // Up Special Reverse
 unsafe fn up_special_reverse(boma: &mut BattleObjectModuleAccessor, fighter_kind: i32, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     // No reversal for Chrom
     if fighter_kind == *FIGHTER_KIND_CHROM {
         return;

--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -6,18 +6,11 @@ use smash_script::macros::*;
 
 // Robin, Dark Samus, Mewtwo float
 pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
-    
     let mut motion_value = 0.0;
 
     // Default to float option 0 upon match start/entry status kind
     if status_kind == *FIGHTER_STATUS_KIND_ENTRY {
         VarModule::set_int(boma.object(), vars::common::instance::FLOAT_STYLE, 0);
-    }
-
-
-    // Track double jump frame for float leniency window
-    if status_kind == *FIGHTER_STATUS_KIND_JUMP_AERIAL {
-        VarModule::set_float(boma.object(), vars::common::instance::DOUBLE_JUMP_FRAME, MotionModule::frame(boma));
     }
 
     // Set the max float duration for the current character
@@ -111,7 +104,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             }
             else {
                 // "superjump" bugfix
-                if WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) && status_kind == *FIGHTER_STATUS_KIND_JUMP && MotionModule::frame(boma) <= 1.0 {
+                if WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) && status_kind == *FIGHTER_STATUS_KIND_JUMP && StatusModule::is_changing(boma) {
                     ControlModule::reset_trigger(boma);
                     StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_FALL, true);
                 }
@@ -119,7 +112,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
 
             // FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME will sometimes erroneously decrement once every 2 frames (effectively allowing for double the max float time); this overrides that
             if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) {
-                if (([*FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_JUMP_AERIAL, *FIGHTER_STATUS_KIND_CLIFF_JUMP1, *FIGHTER_STATUS_KIND_CLIFF_JUMP2, *FIGHTER_STATUS_KIND_CLIFF_JUMP3].contains(&status_kind) && MotionModule::frame(boma) > 1.0) || [*FIGHTER_STATUS_KIND_FALL, *FIGHTER_STATUS_KIND_FALL_AERIAL, *FIGHTER_STATUS_KIND_ATTACK_AIR].contains(&status_kind)) && !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) {
+                if (([*FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_JUMP_AERIAL, *FIGHTER_STATUS_KIND_CLIFF_JUMP1, *FIGHTER_STATUS_KIND_CLIFF_JUMP2, *FIGHTER_STATUS_KIND_CLIFF_JUMP3].contains(&status_kind) && !StatusModule::is_changing(boma)) || [*FIGHTER_STATUS_KIND_FALL, *FIGHTER_STATUS_KIND_FALL_AERIAL, *FIGHTER_STATUS_KIND_ATTACK_AIR].contains(&status_kind)) && !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) {
                     let fall_slowly_frame = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
                     WorkModule::on_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY);
                     VarModule::on_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT);
@@ -129,7 +122,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
 
             // Omnidirectional float for Dark Samus and Mewtwo
             if fighter_kind == *FIGHTER_KIND_SAMUSD || fighter_kind == *FIGHTER_KIND_MEWTWO {
-                if ([*FIGHTER_STATUS_KIND_FALL, *FIGHTER_STATUS_KIND_FALL_AERIAL].contains(&status_kind) && MotionModule::frame(boma) > 3.0) // Omnidirection float only after F3 of initiating the float
+                if ([*FIGHTER_STATUS_KIND_FALL, *FIGHTER_STATUS_KIND_FALL_AERIAL].contains(&status_kind) && boma.status_frame() > 2) // Omnidirection float only after F3 of initiating the float
                     || (status_kind == *FIGHTER_STATUS_KIND_ATTACK_AIR && (WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0)) /* If in aerial attack and float has been initiated and are current floating */ {
                     if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 {
                         if boma.left_stick_y() != 0.0 {

--- a/fighters/common/src/opff/ledges.rs
+++ b/fighters/common/src/opff/ledges.rs
@@ -18,7 +18,7 @@ unsafe fn ledge_act(boma: &mut BattleObjectModuleAccessor, status_kind: i32, fig
         *FIGHTER_STATUS_KIND_CLIFF_CATCH,
         *FIGHTER_STATUS_KIND_CLIFF_WAIT].contains(&status_kind) {
         if fighter_kind != *FIGHTER_KIND_NANA {
-            if MotionModule::frame(boma) > 7.0 {
+            if boma.status_frame() > 6 {
                 WorkModule::on_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHANGE_STATUS_DLAY_MOTION);
             }
         }
@@ -29,7 +29,9 @@ unsafe fn ledge_act(boma: &mut BattleObjectModuleAccessor, status_kind: i32, fig
 //== LEDGE OCCUPANCY
 //=================================================================
 unsafe fn occupy_ledge(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, fighter_kind: i32) {
-
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_CLIFF_ATTACK,
         *FIGHTER_STATUS_KIND_CLIFF_CLIMB,

--- a/fighters/common/src/opff/momentum_transfer_line.rs
+++ b/fighters/common/src/opff/momentum_transfer_line.rs
@@ -20,7 +20,9 @@ use smash::hash40;
 //== Performs some extra calculations to help with momentum handling
 //===================================================================
 pub unsafe fn momentum_transfer_helper(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, fighter_kind: i32, curr_frame: f32) {
-
+	if StatusModule::is_changing(boma) {
+        return;
+    }
 	if (fighter_kind == *FIGHTER_KIND_PFUSHIGISOU && status_kind == *FIGHTER_PFUSHIGISOU_STATUS_KIND_SPECIAL_LW_OUT)
 		|| (fighter_kind == *FIGHTER_KIND_PLIZARDON && status_kind == *FIGHTER_PLIZARDON_STATUS_KIND_SPECIAL_LW_OUT)
 		|| (fighter_kind == *FIGHTER_KIND_PZENIGAME && status_kind == *FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_LW_OUT)

--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -92,6 +92,9 @@ unsafe fn super_fs_cancel(boma: &mut BattleObjectModuleAccessor) -> bool {
 
 // Shotos Hadoken FADC and Super (FS) cancels
 unsafe fn hadoken_fadc_sfs_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, cat: [i32; 4], frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
 
     let mut agent_base = fighter.fighter_base.agent_base;
     let cat1 = cat[0];

--- a/fighters/dedede/src/opff.rs
+++ b/fighters/dedede/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
 // Up B early fall attack
 unsafe fn super_dedede_jump_quickfall(boma: &mut BattleObjectModuleAccessor, frame: f32){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status(*FIGHTER_DEDEDE_STATUS_KIND_SPECIAL_HI_JUMP)
     && (frame > 16.0 && frame < 36.0)
     {

--- a/fighters/demon/src/opff.rs
+++ b/fighters/demon/src/opff.rs
@@ -30,7 +30,7 @@ unsafe fn slaughter_high_kick_devastator(boma: &mut BattleObjectModuleAccessor, 
 
 unsafe fn jaw_breaker(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, motion_kind: u64, frame: f32) {
     if [*FIGHTER_STATUS_KIND_ESCAPE].contains(&status_kind)
-        && frame > 18.0 {
+        && boma.status_frame() > 17 {
         if compare_mask(cat1, *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N){
             VarModule::on_flag(boma.object(), vars::demon::instance::JAW_BREAKER);
             boma.change_status_req(*FIGHTER_STATUS_KIND_ATTACK_HI3, false);

--- a/fighters/diddy/src/opff.rs
+++ b/fighters/diddy/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn peanut_popgun_ac(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_DIDDY_STATUS_KIND_SPECIAL_N_SHOOT && frame > 5.0 {
         boma.check_airdodge_cancel();
     }

--- a/fighters/dolly/src/opff.rs
+++ b/fighters/dolly/src/opff.rs
@@ -20,6 +20,10 @@ unsafe fn power_wave_dash_cancel_super_cancels(fighter: &mut L2CFighterCommon, b
     let cat4 = cat[3];
     let prev_situation_kind = StatusModule::prev_situation_kind(boma);
 
+    if StatusModule::is_changing(boma) {
+        return;
+    }
+
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         // Super Cancel
         if frame > 22.0 {
@@ -140,6 +144,9 @@ unsafe fn power_dunk_break(boma: &mut BattleObjectModuleAccessor) {
 
 // Cancel supers early
 unsafe fn cancel_supers_early(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL,
         *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2].contains(&status_kind) {
         if frame < 26.0 {

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -4,6 +4,9 @@ use super::*;
 use globals::*;
 
 unsafe fn dash_attack_jump_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     //PM-like neutral-b canceling
     if status_kind == *FIGHTER_STATUS_KIND_ATTACK_DASH
     && situation_kind == *SITUATION_KIND_AIR
@@ -71,6 +74,9 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 
 // DK Headbutt aerial stall
 unsafe fn headbutt_aerial_stall(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
         let motion_value = KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
         let motion_vec = Vector3f{x: 1.0, y: 0.0, z: 1.0};
@@ -96,6 +102,9 @@ unsafe fn headbutt_aerial_stall(fighter: &mut L2CFighterCommon, boma: &mut Battl
 
 // Down Special Cancels
 unsafe fn down_special_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_SPECIAL_LW,
         *FIGHTER_DONKEY_STATUS_KIND_SPECIAL_LW_LOOP,
         *FIGHTER_DONKEY_STATUS_KIND_SPECIAL_LW_END].contains(&status_kind) {

--- a/fighters/duckhunt/src/opff.rs
+++ b/fighters/duckhunt/src/opff.rs
@@ -6,7 +6,7 @@ use globals::*;
  
 unsafe fn duck_jump_cancel(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_FLY)
-    && fighter.motion_frame() > 21.0
+    && fighter.status_frame() > 20
     && fighter.is_cat_flag(Cat1::SpecialHi) {
         fighter.change_status_req(*FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_END, true);
     }

--- a/fighters/falco/src/opff.rs
+++ b/fighters/falco/src/opff.rs
@@ -20,7 +20,8 @@ unsafe fn laser_ff_land_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
 }
 
 // Falco Shine Jump Cancels and Turnaround
-unsafe fn shine_jc_turnaround(fighter: &mut L2CFighterCommon, frame: f32) {
+unsafe fn shine_jc_turnaround(fighter: &mut L2CFighterCommon) {
+    let frame = fighter.status_frame();
     if fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) {
         let facing = PostureModule::lr(fighter.module_accessor);
         let stick_x = fighter.stick_x();
@@ -35,17 +36,14 @@ unsafe fn shine_jc_turnaround(fighter: &mut L2CFighterCommon, frame: f32) {
         KineticModule::suspend_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
         let fighter_gravity = KineticModule::get_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) as *mut FighterKineticEnergyGravity;
         if fighter.is_status (*SITUATION_KIND_AIR) {
-            if frame <= 1.0 {
+            if frame <= 3 {
                 KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.0, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
             }
-            if frame > 1.0 && fighter.motion_frame() <= 3.0 {
-                KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.0, 0.0, 0.0), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            }
-            if frame > 3.0 {
+            if frame > 3 {
                 smash::app::lua_bind::FighterKineticEnergyGravity::set_accel(fighter_gravity, -0.02666667);
             }
         }
-        if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && frame > 3.0)  // Allows for jump cancel on frame 4 in game
+        if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && frame > 2)  // Allows for jump cancel on frame 4 in game
         || fighter.is_status_one_of(&[
             *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_HIT,
             *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_LOOP,
@@ -93,7 +91,7 @@ unsafe fn aim_throw_lasers(boma: &mut BattleObjectModuleAccessor) {
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
 
     laser_ff_land_cancel(boma, status_kind, situation_kind, cat[1], stick_y);
-    shine_jc_turnaround(fighter, frame);
+    shine_jc_turnaround(fighter);
     firebird_startup_ledgegrab(fighter);
     aim_throw_lasers(boma);
 }

--- a/fighters/fox/src/opff.rs
+++ b/fighters/fox/src/opff.rs
@@ -21,7 +21,7 @@ unsafe fn shine_jump_cancel(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) && WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) <= 1 {
         GroundModule::correct(fighter.module_accessor, app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
     }
-    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.motion_frame() > 5.0)  // Allows for jump cancel on frame 5 in game
+    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 2)  // Allows for jump cancel on frame 4 in game
     || fighter.is_status_one_of(&[
         *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_HIT,
         *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_LOOP,

--- a/fighters/gamewatch/src/opff.rs
+++ b/fighters/gamewatch/src/opff.rs
@@ -15,7 +15,7 @@ unsafe fn ff_chef_land_cancel(boma: &mut BattleObjectModuleAccessor, status_kind
                 WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
             }
         }
-        if MotionModule::frame(boma) <= 1.0 {
+        if StatusModule::is_changing(boma) {
             let nspec_halt = Vector3f{x: 0.9, y: 1.0, z: 1.0};
             KineticModule::mul_speed(boma, &nspec_halt, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
@@ -61,6 +61,9 @@ pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i3
 }
 
 unsafe fn frame_data(boma: &mut BattleObjectModuleAccessor, status_kind: i32, motion_kind: u64, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if frame <= 19.0 {
             MotionModule::set_rate(boma, 2.0);

--- a/fighters/gaogaen/src/opff.rs
+++ b/fighters/gaogaen/src/opff.rs
@@ -100,7 +100,9 @@ unsafe fn catch_lean(boma: &mut BattleObjectModuleAccessor, lean_frame: f32, ret
 }
 
 unsafe fn angled_grab(fighter: &mut L2CFighterCommon) {
-
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if fighter.is_status(*FIGHTER_STATUS_KIND_CATCH) {
         catch_lean(fighter.boma(), 8.0, 31.0, 50.0, 30.0);
     } else if fighter.is_status(*FIGHTER_STATUS_KIND_CATCH_TURN) {

--- a/fighters/gekkouga/src/opff.rs
+++ b/fighters/gekkouga/src/opff.rs
@@ -15,7 +15,7 @@ unsafe fn max_water_shuriken_dc(boma: &mut BattleObjectModuleAccessor, status_ki
 // Greninja Shadow Sneak Smash Attack Cancel
 unsafe fn shadow_sneak_smash_attack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK {
-        if frame < 7.0 {
+        if boma.status_frame() < 6 {
             if situation_kind == *SITUATION_KIND_GROUND {
                 if boma.is_cat_flag(Cat1::AttackS4) {
                     StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_S4_START, false);

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -52,6 +52,9 @@ unsafe fn quickdraw_jump_attack_cancels(boma: &mut BattleObjectModuleAccessor, i
 }
 
 unsafe fn quickdraw_instakill(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     // Glow blue when attack is charged enough
     let cbm_vec1 = Vector4f{ /* Red */ x: 0.85, /* Green */ y: 0.85, /* Blue */ z: 0.85, /* Alpha */ w: 0.2}; // Brightness vector
     let cbm_vec2 = Vector4f{ /* Red */ x: 0.125, /* Green */ y: 0.4, /* Blue */ z: 1.0, /* Alpha */ w: 0.45}; // Diffuse vector

--- a/fighters/inkling/src/opff.rs
+++ b/fighters/inkling/src/opff.rs
@@ -29,7 +29,7 @@ unsafe fn dair_splatter(boma: &mut BattleObjectModuleAccessor, motion_kind: u64,
 }
 
 unsafe fn roller_jump_cancel(boma: &mut BattleObjectModuleAccessor){
-    if boma.is_status(*FIGHTER_INKLING_STATUS_KIND_SPECIAL_S_END) && boma.is_situation(*SITUATION_KIND_GROUND) && MotionModule::frame(boma) > 11.0 {
+    if boma.is_status(*FIGHTER_INKLING_STATUS_KIND_SPECIAL_S_END) && boma.is_situation(*SITUATION_KIND_GROUND) && boma.status_frame() > 10 {
         boma.check_jump_cancel(true);
     }
     if boma.is_motion(Hash40::new("special_s_jump_end")){

--- a/fighters/kamui/src/opff.rs
+++ b/fighters/kamui/src/opff.rs
@@ -11,6 +11,9 @@ unsafe fn dragon_fang_shot_dash_cancel(boma: &mut BattleObjectModuleAccessor, st
 }
 
 unsafe fn pin_drop_waveland(fighter: &mut L2CFighterCommon, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     let boma = fighter.boma();
     if status_kind == *FIGHTER_KAMUI_STATUS_KIND_SPECIAL_S_WALL_END {
         if !fighter.is_in_hitlag() 

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn final_cutter_cancel(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KIRBY_STATUS_KIND_SPECIAL_HI2].contains(&status_kind){
         if(AttackModule::is_infliction(boma, 2)){
             VarModule::on_flag(boma.object(), vars::kirby::status::FINAL_CUTTER_HIT);
@@ -309,6 +312,9 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 }
 
 unsafe fn frame_data(boma: &mut BattleObjectModuleAccessor, status_kind: i32, motion_kind: u64, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if motion_kind == hash40("special_air_s_start") {
         MotionModule::set_rate(boma, 1.75);
     }

--- a/fighters/koopa/src/opff.rs
+++ b/fighters/koopa/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn bowser_bomb_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_KOOPA_STATUS_KIND_SPECIAL_LW_G].contains(&status_kind) {
         if frame > 20.0 && frame < 31.0 {
             if situation_kind == *SITUATION_KIND_AIR {
@@ -16,6 +19,9 @@ unsafe fn bowser_bomb_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32
 
 // Ground Bowser Bomb jump drift
 unsafe fn ground_bowser_bomb_jump_drift(boma: &mut BattleObjectModuleAccessor, status_kind: i32, stick_x: f32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_SPECIAL_LW, *FIGHTER_KOOPA_STATUS_KIND_SPECIAL_LW_G].contains(&status_kind) {
         if frame > 14.0 && frame < 31.0 {
             if stick_x != 0.0 {
@@ -28,6 +34,9 @@ unsafe fn ground_bowser_bomb_jump_drift(boma: &mut BattleObjectModuleAccessor, s
 
 // Bowser Flame Cancel
 unsafe fn flame_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if frame < 23.0 {
             if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {

--- a/fighters/lucas/src/opff.rs
+++ b/fighters/lucas/src/opff.rs
@@ -6,7 +6,7 @@ use globals::*;
 
 unsafe fn psi_magnet_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
     if [*FIGHTER_LUCAS_STATUS_KIND_SPECIAL_LW_HIT, *FIGHTER_LUCAS_STATUS_KIND_SPECIAL_LW_END].contains(&status_kind) {
-        if frame > 1.0 {
+        if boma.status_frame() > 0 {
             if !boma.is_in_hitlag() {
                 boma.check_jump_cancel(false);
             }
@@ -343,6 +343,9 @@ unsafe fn joint_rotator(fighter: &mut L2CFighterCommon, frame: f32, joint: Hash4
 }
 
 unsafe fn smash_s_angle_handler(fighter: &mut L2CFighterCommon, frame: f32) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_ATTACK_S4, *FIGHTER_STATUS_KIND_ATTACK_S4_START]) {
         // Up Tilted Side Smash
         if VarModule::is_flag(fighter.object(), vars::lucas::instance::ATTACK_S4_ANGLE_UP) {

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -73,6 +73,9 @@ unsafe fn dair_mash_rise(fighter: &mut L2CFighterCommon, boma: &mut BattleObject
 
 // Super Jump Punch Wall Jump
 unsafe fn up_b_wall_jump(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI {
         if situation_kind == *SITUATION_KIND_AIR {
             if frame >= 24.0 && frame <= 26.0 {

--- a/fighters/mariod/src/opff.rs
+++ b/fighters/mariod/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
 // Super Sheet Stall
 unsafe fn super_sheet_stall(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S {
         let motion_vec = Vector3f{x: 0.0, y: 2.5, z: 0.0};
         let motion_vec_2 = Vector3f{x: 0.75, y: 0.0, z: 0.0};

--- a/fighters/master/src/opff.rs
+++ b/fighters/master/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn areadbhar_autocancel(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_MASTER_STATUS_KIND_SPECIAL_S_FRONT,
         *FIGHTER_STATUS_KIND_SPECIAL_S].contains(&status_kind) {
         if situation_kind == *SITUATION_KIND_AIR {
@@ -52,6 +55,9 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
 }
 
 unsafe fn aymr_slowdown(boma: &mut BattleObjectModuleAccessor) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status(*FIGHTER_MASTER_STATUS_KIND_SPECIAL_LW_HIT)  {
         if AttackModule::is_infliction(boma, *COLLISION_KIND_MASK_HIT) && MotionModule::frame(boma) < 11.0 {
             SlowModule::set_whole(boma, 7, 100);

--- a/fighters/metaknight/src/opff.rs
+++ b/fighters/metaknight/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn dim_cape_early_attack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
         if frame > 11.0 {
             if compare_mask(ControlModule::get_pad_flag(boma), *FIGHTER_PAD_FLAG_ATTACK_TRIGGER) {

--- a/fighters/mewtwo/src/opff.rs
+++ b/fighters/mewtwo/src/opff.rs
@@ -5,8 +5,11 @@ use globals::*;
 
  
 unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI
-    && boma.motion_frame() <= 1.0 {
+    && StatusModule::is_changing(boma) {
         VarModule::off_flag(boma.object(), vars::mewtwo::instance::GROUNDED_TELEPORT);
         if situation_kind == *SITUATION_KIND_GROUND {
             VarModule::on_flag(boma.object(), vars::mewtwo::instance::GROUNDED_TELEPORT);
@@ -35,7 +38,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
 unsafe fn dj_upB_jump_refresh(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
         // If first 3 frames of dj
-        if fighter.motion_frame() <= 3.0 {
+        if fighter.status_frame() <= 2 {
             VarModule::on_flag(fighter.battle_object, vars::mewtwo::instance::UP_SPECIAL_JUMP_REFRESH);
         }
         else {

--- a/fighters/miifighter/src/opff.rs
+++ b/fighters/miifighter/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_MIIFIGHTER_STATUS_KIND_SPECIAL_HI1_2 {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT)
             || AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_SHIELD) {

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -42,7 +42,7 @@ unsafe fn absorb_vortex_jc_turnaround_shinejump_cancel(boma: &mut BattleObjectMo
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW1_END,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW1_LOOP].contains(&status_kind) {
         if !boma.is_in_hitlag() {
-            if (status_kind == *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD && frame > 4.0)
+            if (status_kind == *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD && boma.status_frame() > 3)
                 || (status_kind != *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD)
             {
                 boma.check_jump_cancel(false);
@@ -87,6 +87,9 @@ unsafe fn remove_homing_missiles(boma: &mut BattleObjectModuleAccessor, status_k
 }
 
 unsafe fn missile_land_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_AIR,
         *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_AIR].contains(&status_kind) {
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
@@ -109,6 +112,9 @@ unsafe fn missile_land_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleO
 }
 
 unsafe fn arm_rocket_airdash(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
 	let prev_status_kind = StatusModule::prev_status_kind(boma, 0);
 	if [*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_HI3_RUSH].contains(&status_kind) {
 		// Transition into rush_end early

--- a/fighters/miiswordsman/src/opff.rs
+++ b/fighters/miiswordsman/src/opff.rs
@@ -6,6 +6,9 @@ use globals::*;
  // Mii Swordfighter Airborne Assault Aerial FAF Frame 75
 
 unsafe fn airborne_assault_lag(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
 if fighter.is_status(*FIGHTER_MIISWORDSMAN_STATUS_KIND_SPECIAL_S1_END) {
     if  fighter.is_situation(*SITUATION_KIND_AIR) && fighter.motion_frame() > 76.0 {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
@@ -42,7 +45,7 @@ unsafe fn gale_stab_jc_attack(fighter: &mut L2CFighterCommon, boma: &mut BattleO
     if [*FIGHTER_MIISWORDSMAN_STATUS_KIND_SPECIAL_S2_ATTACK].contains(&status_kind) {
         // Jump cancels
         let pad_flag = ControlModule::get_pad_flag(boma);
-        if frame > 7.0 && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag() {
+        if boma.status_frame() > 6 && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag() {
             boma.check_jump_cancel(true);
         }
     }
@@ -129,6 +132,9 @@ unsafe fn aerial_acrobatics(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
 
 // Skyward Slash Dash actionability
 unsafe fn skyward_slash_dash_act(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
 	if status_kind == *FIGHTER_MIISWORDSMAN_STATUS_KIND_SPECIAL_HI2_RUSH {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
             VarModule::on_flag(fighter.battle_object, vars::miiswordsman::instance::SKYWARD_SLASH_DASH_HIT);
@@ -170,6 +176,9 @@ unsafe fn kinesis_blade(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
 
 // Transition into hitgrab on hit
 unsafe fn hitgrab_transition(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, motion_kind: u64) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
 	if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && ((motion_kind == hash40("special_lw3") && MotionModule::frame(boma) > 17.0) || (motion_kind == hash40("special_air_lw3") && MotionModule::frame(boma) > 11.0)) {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !fighter.is_in_hitlag() {
             //println!("Swordfighter gon' give it to ya");

--- a/fighters/murabito/src/opff.rs
+++ b/fighters/murabito/src/opff.rs
@@ -4,6 +4,9 @@ use super::*;
 use globals::*;
 
 unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status_one_of(&[*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_AIR, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_DASH_B, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_DASH_F, 
@@ -29,6 +32,9 @@ unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind
 }
 
 unsafe fn uspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status_one_of(&[*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_FLAP, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_TURN, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_WAIT]) {

--- a/fighters/ness/src/opff.rs
+++ b/fighters/ness/src/opff.rs
@@ -13,7 +13,7 @@ unsafe fn psi_magnet_jump_cancel_turnaround(fighter: &mut L2CFighterCommon) {
             PostureModule::update_rot_y_lr(fighter.module_accessor);
         }
     }
-    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 3)  // Allows for jump cancel on frame 5 in game
+    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 5)  // Allows for jump cancel on frame 7 in game
     || fighter.is_status_one_of(&[
         *FIGHTER_NESS_STATUS_KIND_SPECIAL_LW_HIT,
         *FIGHTER_NESS_STATUS_KIND_SPECIAL_LW_HOLD,

--- a/fighters/ness/src/opff.rs
+++ b/fighters/ness/src/opff.rs
@@ -13,7 +13,7 @@ unsafe fn psi_magnet_jump_cancel_turnaround(fighter: &mut L2CFighterCommon) {
             PostureModule::update_rot_y_lr(fighter.module_accessor);
         }
     }
-    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.motion_frame() > 8.0)  // Allows for jump cancel on frame 5 in game
+    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 3)  // Allows for jump cancel on frame 5 in game
     || fighter.is_status_one_of(&[
         *FIGHTER_NESS_STATUS_KIND_SPECIAL_LW_HIT,
         *FIGHTER_NESS_STATUS_KIND_SPECIAL_LW_HOLD,

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -18,6 +18,9 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
 
 // Pac-Man Bonus Fruit Toss Airdodge Cancel
 unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_PACMAN_STATUS_KIND_SPECIAL_N_SHOOT {
         if frame > 11.0 {
             boma.check_airdodge_cancel();

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -14,8 +14,11 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 }
 
 unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI
-    && boma.motion_frame() <= 1.0 {
+    && StatusModule::is_changing(boma) {
         VarModule::off_flag(boma.object(), vars::palutena::instance::GROUNDED_TELEPORT);
         if situation_kind == *SITUATION_KIND_GROUND {
             VarModule::on_flag(boma.object(), vars::palutena::instance::GROUNDED_TELEPORT);
@@ -44,7 +47,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
 unsafe fn dj_upB_jump_refresh(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
         // If first 3 frames of dj
-        if fighter.motion_frame() <= 3.0 {
+        if fighter.status_frame() <= 2 {
             VarModule::on_flag(fighter.battle_object, vars::palutena::instance::UP_SPECIAL_JUMP_REFRESH);
         }
         else {

--- a/fighters/pfushigisou/src/opff.rs
+++ b/fighters/pfushigisou/src/opff.rs
@@ -6,6 +6,9 @@ use globals::*;
 
 // Ivysaur Razor Leaf Airdodge Cancel
 unsafe fn razorleaf_adc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S && frame > 24.0 {
         boma.check_airdodge_cancel();
     }

--- a/fighters/pikachu/src/opff.rs
+++ b/fighters/pikachu/src/opff.rs
@@ -6,6 +6,9 @@ use globals::*;
  
 // Disable QA jump cancels if not directly QA into the ground
 unsafe fn disable_qa_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_WARP {
         // only allow QAC from QA1
         if WorkModule::get_int(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_INT_QUICK_ATTACK_COUNT) > 1 {
@@ -32,7 +35,7 @@ unsafe fn reset_jc_disable_flag(boma: &mut BattleObjectModuleAccessor, id: usize
 // JC Quick Attack/Agility
 unsafe fn jc_qa_agility(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL
-    && frame > 4.0
+    && boma.status_frame() > 3
     && situation_kind == *SITUATION_KIND_GROUND
     && StatusModule::prev_status_kind(boma, 0) == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END
     && !VarModule::is_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC)

--- a/fighters/pikmin/src/opff.rs
+++ b/fighters/pikmin/src/opff.rs
@@ -14,6 +14,9 @@ unsafe fn winged_pikmin_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
 }
 
 pub unsafe fn solimar_scaling(boma: &mut BattleObjectModuleAccessor, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let pikmin_count = WorkModule::get_int(boma, *FIGHTER_PIKMIN_INSTANCE_WORK_INT_PIKMIN_HOLD_PIKMIN_NUM);
     if pikmin_count == 0 {
         let olimar_hand_scale = Vector3f{x: 1.5, y: 1.35, z: 1.35};

--- a/fighters/pit/src/opff.rs
+++ b/fighters/pit/src/opff.rs
@@ -20,6 +20,9 @@ unsafe fn power_of_flight_cancel(boma: &mut BattleObjectModuleAccessor, status_k
 }
  
 unsafe fn upperdash_arm_jump_and_aerial_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32, id: usize) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S || (status_kind == *FIGHTER_PIT_STATUS_KIND_SPECIAL_S_END && frame > 6.0) {
         if frame > 28.0 {
             boma.check_jump_cancel(true);

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -26,7 +26,7 @@ unsafe fn bow_ff_lc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, sit
 // Dark Pit Guardian Orbitar Jump Cancels
 unsafe fn guardian_orbitar_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_HOLD {
-        if frame > 2.0 && !boma.is_in_hitlag(){
+        if boma.status_frame() > 1 && !boma.is_in_hitlag(){
             boma.check_jump_cancel(false);
         }
     }

--- a/fighters/plizardon/src/opff.rs
+++ b/fighters/plizardon/src/opff.rs
@@ -9,7 +9,9 @@ unsafe fn flame_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
     if status_kind != *FIGHTER_STATUS_KIND_SPECIAL_N || situation_kind != *SITUATION_KIND_GROUND || prev_situation != *SITUATION_KIND_AIR {
         return;
     }
-
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if frame < 19.0 {
         MotionModule::set_frame(boma, 18.0, true);
     }

--- a/fighters/popo/src/opff.rs
+++ b/fighters/popo/src/opff.rs
@@ -111,7 +111,7 @@ unsafe fn nana_death_effect(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
             nana_pos_x = PostureModule::pos_x(nana_boma[id] as *mut BattleObjectModuleAccessor);
             nana_pos_y = PostureModule::pos_y(nana_boma[id] as *mut BattleObjectModuleAccessor);
         }
-        if status_kind == *FIGHTER_STATUS_KIND_REBIRTH && MotionModule::frame(boma) <= 1.0 && effect_on {
+        if status_kind == *FIGHTER_STATUS_KIND_REBIRTH && fighter.status_frame() <= 1 && effect_on {
             let pos =  Vector3f {x: nana_pos_x, y: nana_pos_y, z: 0.0};
             let rot =  Vector3f {x: 0.0, y: 0.0, z: 0.0};
             EffectModule::req(boma, Hash40::new("sys_recovery"), &pos, &rot, 1.0, *EFFECT_SUB_ATTRIBUTE_NO_JOINT_SCALE as u32, 0, true, 0);

--- a/fighters/pzenigame/src/opff.rs
+++ b/fighters/pzenigame/src/opff.rs
@@ -43,7 +43,7 @@ unsafe fn withdraw_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status_k
         }
     }
 
-    if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_END].contains(&status_kind) && frame < 11.0 && !boma.is_in_hitlag() {
+    if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_END].contains(&status_kind) && boma.status_frame() < 10 && !boma.is_in_hitlag() {
         boma.check_jump_cancel(true);
     }
 

--- a/fighters/robot/src/opff.rs
+++ b/fighters/robot/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn gyro_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     let current_fuel = WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
     let max_fuel = WorkModule::get_param_float(boma, hash40("param_special_hi"), hash40("energy_max_frame"));
     // Use 50% fuel to dash cancel gyro

--- a/fighters/rockman/src/opff.rs
+++ b/fighters/rockman/src/opff.rs
@@ -37,7 +37,7 @@ use globals::*;
 
 // Jump cancel dtilt on hit
 unsafe fn jc_dtilt_hit(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
-    if status_kind == *FIGHTER_STATUS_KIND_ATTACK_LW3 {
+    if boma.is_motion(Hash40::new("attack_lw3")) {
         if (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag()) && frame > 12.0 {
             boma.check_jump_cancel(false);
         }
@@ -47,7 +47,7 @@ unsafe fn jc_dtilt_hit(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
 // Mega Man Metal Blad Toss Airdodge Cancel
 unsafe fn blade_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
-        if frame > 17.0 {
+        if boma.status_frame() > 16 {
             boma.check_airdodge_cancel();
         }
     }

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -18,6 +18,9 @@ extern "Rust" {
 
 //Rosalina Teleport
 unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
+	if StatusModule::is_changing(boma) {
+        return;
+    }
 				let fighter_kind = smash::app::utility::get_kind(boma);
 				let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
 				let frame = MotionModule::frame(boma);

--- a/fighters/samus/src/opff.rs
+++ b/fighters/samus/src/opff.rs
@@ -22,6 +22,9 @@ extern "Rust" {
 
 // Shinespark charge
 unsafe fn shinespark_charge(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_RUN, *FIGHTER_STATUS_KIND_TURN_RUN].contains(&status_kind) && frame > 31.0 {
         if  !VarModule::is_flag(boma.object(), vars::samus::instance::SHINESPARK_READY) {
             VarModule::on_flag(boma.object(), vars::samus::instance::SHINESPARK_READY);
@@ -47,6 +50,9 @@ unsafe fn shinespark_reset(boma: &mut BattleObjectModuleAccessor, id: usize, sta
 // Morph Ball Crawl
 // PUBLIC
 pub unsafe fn morphball_crawl(boma: &mut BattleObjectModuleAccessor, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_SAMUS_STATUS_KIND_SPECIAL_GROUND_LW, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_AIR_LW].contains(&status_kind) {
         if frame >= 32.0 {
             if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW))

--- a/fighters/samusd/src/opff.rs
+++ b/fighters/samusd/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
 
 pub unsafe fn morphball_crawl(boma: &mut BattleObjectModuleAccessor, status_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_SAMUS_STATUS_KIND_SPECIAL_GROUND_LW, *FIGHTER_SAMUS_STATUS_KIND_SPECIAL_AIR_LW].contains(&status_kind) {
         if frame >= 32.0 {
             if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW))

--- a/fighters/sheik/src/opff.rs
+++ b/fighters/sheik/src/opff.rs
@@ -5,7 +5,7 @@ use globals::*;
 
  
 unsafe fn bouncing_fish_return_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
-    if status_kind == *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_RETURN && frame <= 15.0 {
+    if status_kind == *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_RETURN && boma.status_frame() <= 14 {
         if situation_kind == *SITUATION_KIND_AIR {
             boma.check_jump_cancel(false);
         }

--- a/fighters/shizue/src/opff.rs
+++ b/fighters/shizue/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn fishing_rod_shield_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if [*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_SHIZUE_STATUS_KIND_SPECIAL_S_START].contains(&status_kind) {
         if frame < 25.0 {
             if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) {
@@ -69,6 +72,9 @@ unsafe fn balloon_special_cancel(fighter: &mut L2CFighterCommon) {
 
 // Reel in
 unsafe fn reel_in(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_SHIZUE_STATUS_KIND_SPECIAL_S_END {
         if frame < 4.0 {
             if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) {
@@ -101,7 +107,7 @@ pub fn fishingrod_callback(weapon : &mut L2CFighterBase) {
 // Lloid Trap Fire Jump Cancel
 unsafe fn lloid_trap_fire_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_SHIZUE_STATUS_KIND_SPECIAL_LW_FIRE {
-        if frame > 6.0 && !boma.is_in_hitlag() {
+        if boma.status_frame() > 5 && !boma.is_in_hitlag() {
             boma.check_jump_cancel(false);
         }
     }
@@ -109,6 +115,9 @@ unsafe fn lloid_trap_fire_jc(boma: &mut BattleObjectModuleAccessor, status_kind:
 
 // Balloon Trip Cancel
 unsafe fn balloon_cancel(fighter: &mut L2CFighterCommon) {
+    if StatusModule::is_changing(fighter.module_accessor) {
+        return;
+    }
     if (MotionModule::frame(fighter.module_accessor) > 6.0 && fighter.is_motion_one_of(&[Hash40::new("special_hi"), Hash40::new("special_air_hi")])) || fighter.is_status_one_of(&[*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_WAIT, *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_FLAP]) {
         // Cancel balloon trip early if character is holding shield, allowing for movement
         if fighter.is_button_on(Buttons::Guard) || fighter.is_button_on(Buttons::Catch) || fighter.is_button_on(Buttons::AttackAll) {

--- a/fighters/shulk/src/opff.rs
+++ b/fighters/shulk/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn air_slash_cancels(boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
             if frame > 23.0 {

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn holy_water_ac(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
         if frame > 20.0 {
             boma.check_airdodge_cancel();

--- a/fighters/szerosuit/src/opff.rs
+++ b/fighters/szerosuit/src/opff.rs
@@ -14,6 +14,9 @@ unsafe fn paralyzer_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_ki
 
 // ZSS Flip Jump - Jump Cancel and Flipstool Handilng
 unsafe fn flip_jump_jc_flipstool(boma: &mut BattleObjectModuleAccessor, status_kind: i32, motion_kind: u64, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW
         || motion_kind == hash40("special_lw_start")
         || motion_kind == hash40("special_air_lw_start") {

--- a/fighters/trail/src/opff.rs
+++ b/fighters/trail/src/opff.rs
@@ -118,6 +118,9 @@ unsafe fn magic_cancels(boma: &mut BattleObjectModuleAccessor) {
 
 // Actionability after hitting aerial sweep
 unsafe fn aerial_sweep_hit_actionability(boma: &mut BattleObjectModuleAccessor) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if boma.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI){
         if MotionModule::frame(boma) > 38.0 {
             if AttackModule::is_infliction(boma, *COLLISION_KIND_MASK_HIT) {

--- a/fighters/wario/src/opff.rs
+++ b/fighters/wario/src/opff.rs
@@ -10,6 +10,9 @@ unsafe fn bite_early_throw_turnaround(boma: &mut BattleObjectModuleAccessor, sta
             boma.change_status_req(*FIGHTER_WARIO_STATUS_KIND_SPECIAL_N_BITE_END, false);
         }
     }
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_N_BITE_END {
         if frame < 7.0 {
             if facing * stick_x < 0.0 {

--- a/fighters/wolf/src/opff.rs
+++ b/fighters/wolf/src/opff.rs
@@ -5,6 +5,9 @@ use globals::*;
 
  
 unsafe fn airdodge_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if frame > 17.0 {
             FighterStatusModuleImpl::set_fighter_status_data(
@@ -29,7 +32,7 @@ unsafe fn shine_jump_cancel(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) && WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) <= 1 {
         GroundModule::correct(fighter.module_accessor, app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
     }
-    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.motion_frame() > 7.0)  // Allows for jump cancel on frame 5 in game
+    if ((fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 2)  // Allows for jump cancel on frame 4 in game
         || fighter.is_status_one_of(&[
             *FIGHTER_WOLF_STATUS_KIND_SPECIAL_LW_HIT,
             *FIGHTER_WOLF_STATUS_KIND_SPECIAL_LW_LOOP,

--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -70,6 +70,9 @@ unsafe fn phantom_special_cancel(fighter: &mut L2CFighterCommon, boma: &mut Batt
 // }
 
 unsafe fn nayru_fastfall_land_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat2: i32, stick_y: f32, frame: f32) {
+    if StatusModule::is_changing(boma) {
+        return;
+    }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if situation_kind == *SITUATION_KIND_GROUND {
             if StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR && frame < 55.0 {


### PR DESCRIPTION
Adds `StatusModule::is_changing` checks to some OPFF for compatibility with new Smashline update --- namely, OPFF which use motion frame checks within status kind checks.

Also replaces motion frame usage in OPFF with status frames, where applicable.

Additionally, spacies' shine JCs come out on the proper frames now.