### PR TITLE
Peach Updates

### DIFF
--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -63,7 +63,8 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
                                                        *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind)) 
            || (boma.kind() == *FIGHTER_KIND_KOOPAJR && boma.is_status(*FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING))
            || (boma.kind() == *FIGHTER_KIND_SHEIK && [*FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_ATTACK,
-                                                       *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind)) {
+                                                       *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind))
+           || (boma.kind() == *FIGHTER_KIND_PEACH && [*FIGHTER_STATUS_KIND_SPECIAL_LW].contains(&status_kind)) {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
     }
@@ -100,7 +101,8 @@ unsafe fn correct_hook(boma: &mut BattleObjectModuleAccessor, kind: GroundCorrec
             || (fighter_kind == *FIGHTER_KIND_KOOPA && status_kind == *FIGHTER_KOOPA_STATUS_KIND_SPECIAL_HI_G)
             || (fighter_kind == *FIGHTER_KIND_DONKEY && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI)
             || (fighter_kind == *FIGHTER_KIND_GAOGAEN && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
-            || (fighter_kind == *FIGHTER_KIND_LUIGI && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N) {
+            || (fighter_kind == *FIGHTER_KIND_LUIGI && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
+            || (fighter_kind == *FIGHTER_KIND_PEACH && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW) {
             return original!()(boma, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
         }
     }

--- a/fighters/peach/src/acmd/aerials.rs
+++ b/fighters/peach/src/acmd/aerials.rs
@@ -165,10 +165,10 @@ unsafe fn peach_attack_air_lw_game(fighter: &mut L2CAgentBase) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
     frame(lua_state, 12.0);
-    for _ in 0..3 {
+    for _ in 0..4 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 70, 30, 0, 13, 5.5, 0.0, -1.0, 1.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 1.0, 70, 30, 0, 13, 4.5, 0.0, 4.0, -0.5, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 80, 30, 0, 25, 5.5, 0.0, -1.0, 1.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 80, 30, 0, 25, 4.5, 0.0, 4.0, -0.5, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
@@ -176,13 +176,10 @@ unsafe fn peach_attack_air_lw_game(fighter: &mut L2CAgentBase) {
         }
         wait(lua_state, 4.0);
     }
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 75, 80, 0, 70, 6.5, 0.0, -1.0, 1.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 75, 80, 0, 70, 5.5, 0.0, 4.0, -0.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-    }
     wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
+        FT_MOTION_RATE(fighter, 0.3);
     }
     frame(lua_state, 38.0);
     if is_excute(fighter) {

--- a/fighters/peach/src/acmd/aerials.rs
+++ b/fighters/peach/src/acmd/aerials.rs
@@ -179,7 +179,7 @@ unsafe fn peach_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        FT_MOTION_RATE(fighter, 0.3);
+        FT_MOTION_RATE(fighter, 4.0/(38.0-32.0));;
     }
     frame(lua_state, 38.0);
     if is_excute(fighter) {

--- a/fighters/peach/src/acmd/mod.rs
+++ b/fighters/peach/src/acmd/mod.rs
@@ -5,6 +5,7 @@ mod ground;
 mod other;
 mod smashes;
 mod specials;
+mod throws;
 mod tilts;
 
 pub fn install() {
@@ -13,5 +14,6 @@ pub fn install() {
     other::install();
     smashes::install();
     specials::install();
+    throws::install();
     tilts::install();
 }

--- a/fighters/peach/src/acmd/smashes.rs
+++ b/fighters/peach/src/acmd/smashes.rs
@@ -11,9 +11,9 @@ unsafe fn peach_attack_lw4_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 6.0);
     for _ in 0..6 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 0, 100, 20, 0, 3.5, -2.5, 2.0, 0.0, Some(2.5), Some(2.0), Some(0.0), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BODY);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 180, 100, 25, 0, 4.5, -2.5, 2.0, 7.5, Some(2.5), Some(2.0), Some(7.5), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BODY);
-            ATTACK(fighter, 2, 0, Hash40::new("top"), 2.0, 180, 100, 25, 0, 4.5, -2.5, 2.0, -7.5, Some(2.5), Some(2.0), Some(-7.5), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BODY);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 140, 95, 0, 50, 3.5, -2.5, 2.0, 0.0, Some(2.5), Some(2.0), Some(0.0), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 10.0, 140, 95, 0, 50, 4.5, -2.5, 2.0, 7.5, Some(2.5), Some(2.0), Some(7.5), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+            ATTACK(fighter, 2, 0, Hash40::new("top"), 10.0, 140, 95, 0, 50, 4.5, -2.5, 2.0, -7.5, Some(2.5), Some(2.0), Some(-7.5), 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
             AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_LOW), false);
         }
         wait(lua_state, 2.0);
@@ -22,10 +22,10 @@ unsafe fn peach_attack_lw4_game(fighter: &mut L2CAgentBase) {
         }
         wait(lua_state, 2.0);
     }
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 361, 201, 0, 40, 4.5, 0.0, 1.8, 8.25, Some(0.0), Some(1.8), Some(-8.25), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BODY);
-        AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_LOW), false);
-    }
+    // if is_excute(fighter) {
+    //     ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 361, 201, 0, 40, 4.5, 0.0, 1.8, 8.25, Some(0.0), Some(1.8), Some(-8.25), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BODY);
+    //     AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_LOW), false);
+    // }
     wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
@@ -33,8 +33,43 @@ unsafe fn peach_attack_lw4_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "peach", script = "sound_attacklw4", category = ACMD_SOUND, low_priority )]
+unsafe fn peach_attack_lw4_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 4.0);
+    if is_excute(fighter) {
+        STOP_SE(fighter, Hash40::new("se_common_smash_start_03"));
+    }
+    wait(lua_state, 1.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("vc_peach_attack07"));
+    }
+    wait(lua_state, 1.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_peach_smash_s02"));
+    }
+    wait(lua_state, 5.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_peach_smash_s02"));
+    }
+    wait(lua_state, 5.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_peach_smash_s02"));
+    }
+    wait(lua_state, 5.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_peach_smash_s02"));
+    }
+    wait(lua_state, 5.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_peach_smash_s02"));
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         peach_attack_lw4_game,
+        peach_attack_lw4_sound,
     );
 }

--- a/fighters/peach/src/acmd/specials.rs
+++ b/fighters/peach/src/acmd/specials.rs
@@ -138,10 +138,61 @@ unsafe fn peach_special_air_hi_start_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "peach", script = "game_specialhiopen", category = ACMD_GAME, low_priority )]
+unsafe fn peach_special_hi_open(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+
+    FT_MOTION_RATE(fighter, 0.1);
+    if is_excute(fighter) {
+        ArticleModule::change_motion(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KASSAR, Hash40::new("special_hi_open"), false, -1.0);
+    }
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 1.0);
+        ATTACK(fighter, 0, 0, Hash40::new("havel"), 2.0, 80, 15, 0, 65, 2.0, -3.1, 6.5, 0.0, Some(3.1), Some(6.5), Some(0.0), 0.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 18, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PEACH_PARASOL, *ATTACK_REGION_PARASOL);
+        AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
+    }
+}
+
+// #[acmd_script( agent = "peach", script = "game_speciallw", category = ACMD_GAME, low_priority )]
+// unsafe fn peach_special_lw(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     if WorkModule::get_int(boma, *FIGHTER_PEACH_STATUS_SPECIAL_LW_WORK_INT_IS_DAIKON_GENERATABLE) == 1 {
+//         if(methodlib::L2CValue::operator==(lib::L2CValueconst&)const(*FIGHTER_PEACH_STATUS_SPECIAL_LW_WORK_INT_UNIQ_ITEM_KIND, *ITEM_KIND_NONE)){
+//             if is_excute(fighter) {
+//                 KineticModule::add_speed(boma, &vec);
+//                 ArticleModule::generate_article(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_DAIKON, false, -1);
+//             }
+//         }
+//         if(methodlib::L2CValue::operator==(lib::L2CValueconst&)const(*FIGHTER_PEACH_STATUS_SPECIAL_LW_WORK_INT_UNIQ_ITEM_KIND, *ITEM_KIND_BOMBHEI)){
+//             if is_excute(fighter) {
+//                 KineticModule::add_speed(boma, &vec);
+//                 ItemModule::have_item(boma, *ITEM_KIND_BOMBHEI);
+//             }
+//         }
+//         if(methodlib::L2CValue::operator==(lib::L2CValueconst&)const(false, *FIGHTER_PEACH_STATUS_SPECIAL_LW_WORK_INT_UNIQ_ITEM_KIND, *ITEM_KIND_DOSEISAN)){
+//             if is_excute(fighter) {
+//                 KineticModule::add_speed(boma, &vec);
+//                 ItemModule::have_item(boma, *ITEM_KIND_DOSEISAN);
+//             }
+//         }
+//         if(methodlib::L2CValue::operator==(lib::L2CValueconst&)const(false, *FIGHTER_PEACH_STATUS_SPECIAL_LW_WORK_INT_UNIQ_ITEM_KIND, *ITEM_KIND_BEAMSWORD)){
+//             if is_excute(fighter) {
+//                 KineticModule::add_speed(boma, &vec);
+//                 ItemModule::have_item(boma, *ITEM_KIND_BEAMSWORD);
+//             }
+//         }
+//     }
+// }
+
 pub fn install() {
     install_acmd_scripts!(
         peach_special_s_hit_end_game,
         peach_special_hi_start_game,
         peach_special_air_hi_start_game,
+        peach_special_hi_open,
+        //peach_special_lw,
     );
 }

--- a/fighters/peach/src/acmd/throws.rs
+++ b/fighters/peach/src/acmd/throws.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+#[acmd_script( agent = "peach", script = "game_throwf", category = ACMD_GAME, low_priority )]
+unsafe fn game_throwf(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 10.0, 45, 105, 0, 48, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+    }
+    if IS_EXIST_ARTICLE(fighter, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO) {
+        if is_excute(fighter) {
+            ArticleModule::change_motion(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, Hash40::new("throw_f"), false, -1.0);
+        }
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 361, 50, 0, 55, 4.5, 0.0, 7.5, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
+        AttackModule::set_catch_only_all(boma, true, false);
+        CHECK_FINISH_CAMERA(fighter, 11, 5);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
+        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
+        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 36.0);
+    if is_excute(fighter) {
+        ArticleModule::remove_exist(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
+    }
+}
+
+#[acmd_script( agent = "peach", script = "game_throwb", category = ACMD_GAME, low_priority )]
+unsafe fn game_throwb(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 125, 65, 0, 35, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+    }
+    if IS_EXIST_ARTICLE(fighter, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO) {
+        if is_excute(fighter) {
+            ArticleModule::change_motion(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, Hash40::new("throw_b"), false, -1.0);
+        }
+    }
+    frame(lua_state, 20.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 70, 200, 0, 10, 6.2, 0.0, 7.2, -6.8, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HIP);
+        AttackModule::set_catch_only_all(boma, true, false);
+        CHECK_FINISH_CAMERA(fighter, -10, 5);
+    }
+    frame(lua_state, 22.0);
+    if is_excute(fighter) {
+        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
+        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
+        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 38.0);
+    if is_excute(fighter) {
+        ArticleModule::remove_exist(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
+    }
+    frame(lua_state, 45.0);
+    if is_excute(fighter) {
+        REVERSE_LR(fighter);
+    }
+}
+
+#[acmd_script( agent = "peach", script = "game_throwhi", category = ACMD_GAME, low_priority )]
+unsafe fn game_throwhi(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 88, 56, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+    }
+    if IS_EXIST_ARTICLE(fighter, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO) {
+        if is_excute(fighter) {
+            ArticleModule::change_motion(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, Hash40::new("throw_hi"), false, -1.0);
+        }
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("handr"), 2.0, 80, 100, 20, 0, 3.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        AttackModule::set_catch_only_all(boma, true, false);
+        CHECK_FINISH_CAMERA(fighter, 0, 24);
+    }
+    frame(lua_state, 21.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 26.0);
+    if is_excute(fighter) {
+        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
+        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
+        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+    }
+    frame(lua_state, 40.0);
+    if is_excute(fighter) {
+        ArticleModule::remove_exist(boma, *FIGHTER_PEACH_GENERATE_ARTICLE_KINOPIO, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
+    }
+}
+
+pub fn install() {
+    install_acmd_scripts!(
+        game_throwf,
+        game_throwb,
+        game_throwhi
+    );
+}

--- a/fighters/peach/src/acmd/tilts.rs
+++ b/fighters/peach/src/acmd/tilts.rs
@@ -31,11 +31,16 @@ unsafe fn game_attacks3(fighter: &mut L2CAgentBase) {
 unsafe fn game_attackhi3(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+
+    if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 0.7);
+    }
+
     frame(lua_state, 9.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 92, 80, 0, 65, 5.0, 0.0, 10.0, 2.0, Some(0.0), Some(10.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 10.0, 92, 80, 0, 65, 5.0, 0.0, 13.0, 2.0, Some(0.0), Some(13.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
-        ATTACK(fighter, 2, 0, Hash40::new("top"), 12.0, 90, 66, 0, 50, 8.0, 0.0, 24.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 92, 35, 0, 75, 5.0, 0.0, 10.0, 2.0, Some(0.0), Some(10.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 92, 35, 0, 75, 5.0, 0.0, 13.0, 2.0, Some(0.0), Some(13.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 9.0, 90, 15, 0, 75, 8.0, 0.0, 24.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_MAGIC);
     }
     frame(lua_state, 14.0);
     if is_excute(fighter) {

--- a/fighters/peach/src/opff.rs
+++ b/fighters/peach/src/opff.rs
@@ -35,9 +35,18 @@ unsafe fn wall_bounce(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
     }
 }
 
+unsafe fn parasol_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
+    let direction = ControlModule::get_stick_y(boma);
+    if status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_HI_AIR_END && direction < 0.0 {
+        let vec = Vector3f{x: 0.0, y: -0.1, z: 0.0};
+        KineticModule::add_speed(boma, &vec);
+    }
+}
+
 pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     float_cancel(boma, status_kind);
     wall_bounce(boma, status_kind);
+    parasol_ff(boma, status_kind);
 }
 
 #[::utils::macros::opff(FIGHTER_KIND_PEACH )]

--- a/romfs/source/fighter/peach/param/vl.prcxml
+++ b/romfs/source/fighter/peach/param/vl.prcxml
@@ -34,7 +34,8 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="special_hi_start_trans_speed_mul">0.925</float>
-      <int hash="special_hi_landing_mot_frame">30</int>
+      <float hash="special_hi_fall_accel_y_mul">0.3</float>
+      <int hash="special_hi_landing_mot_frame">10</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
General:
Speed up double jump rise animation
https://user-images.githubusercontent.com/115596132/226137823-7f63f1d6-3fc5-49ce-a160-ed5303b7f794.mp4

[hdr-dev-assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11009535/hdr-dev-assets.zip) Goes in 
\\hdr-pr-assets\fighter\peach\motion\body\c00

Throws:
Fthrow  
	- Damage 8.0 >> 10.0
	- KBG 83 >> 105
	- Notes: Redesigned as a kill throw. Design is to have her get better rewards off of aggressive play (ie. when putting on shield pressure) as opposed to passive play (Bthrow being the kill throw = sitting at ledge and shield grabbing)

Bthrow  
	- Angle 140 >> 125
	- KBG 88 >> 65
	- Notes: Nerfed this to tie into Fthrow change. Redistributing kill power from back to front.

Uthrow  
	- KBG 80 >> 56
	- BKB 72 >> 65
	- Notes: Uthrow previously sent too high to be useful for combos, now functions better as a combo throw

Aerials:
Dair    
	- Damage 2.0 >> 3.0
	- KBG 70 >> 80
	- BKB 13 >> 25
	- Ending hitbox removed
	- Endlag of move sped up
	- Notes: Changed to Melee functionality. No ending hit, intention is to combo into nair/bair. 

Tilts:
Utilt   
	- Damage 10.0/12.0 >> 7.0/9.0
	- KBG 80/66 >> 15/35
	- BKB 65/50 >> 75
	- Hitbox spawn on 9 >> 7
	- FAF 38 >> 27
	- Notes: Changed to mimic dtilt in terms of functionality, is now a quick combo setup tool. Weak hit is the side hit and strong hit is the heart hitbox. Heart hitbox has lower KBG than the weak hit so it can continue to combo at higher %s.

Smashes:
Dsmash 
	- Damage 2.0 >> 10.0
	- Angle 0 >> 140
	- KBG 100 > 95
	- FKB 20/25 >> 0
	- BKB 0 >> 50
	- Shield damage reduced by 5
	- Notes: Reworked to function similar to melee but in a much nerfed state (less % damage, functionally reduced KB, deliberately reduced shield damage, and smaller hitboxes compared to Melee/PM) 

Specials:
Upb     
	- Parasol reopen action sped up by 90%
	- Landing lag 30 >> 10
	- Ability to fastfall added
	- Notes: Upb previously was much more punishable on landing than it was in previous smash games. Added functionality to make it feel more usable. 

Downb   
	- Added edge slipoffs
	- Notes: Current implementation has turnip spawn on frame 1 which leads to strange behavior in combination with this. Intention is to have the turnip spawn on frame 4 or 5 but can't currently implement this as the downb scripts aren't building.

Todo:
- Fix turnip to spawn later