### PR TITLE
feat: add 0/1 player smash and remove no contest screen

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(deprecated)]
 #![allow(unused)]
-#![allow(non_snake_case)]#![allow(unused_imports)]#![allow(unused_variables)]
+#![allow(non_snake_case)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
 #![feature(proc_macro_hygiene)]
 
 #[cfg(feature = "main_nro")]
@@ -18,7 +20,7 @@ mod online;
 use skyline::libc::c_char;
 #[cfg(feature = "main_nro")]
 use skyline_web::*;
-use std::{path::Path, fs};
+use std::{fs, path::Path};
 
 #[cfg(feature = "updater")]
 mod updater;
@@ -30,7 +32,7 @@ pub fn install() {
 
 #[cfg(not(feature = "main_nro"))]
 #[export_name = "hdr_delayed_install"]
-pub extern "Rust" fn delayed_install() {
+pub fn delayed_install() {
     fighters::delayed_install();
 }
 
@@ -42,10 +44,13 @@ extern "Rust" {
 
 #[cfg(feature = "main_nro")]
 #[export_name = "hdr_is_available"]
-pub extern "Rust" fn is_available() -> bool { true }
+pub fn is_available() -> bool {
+    true
+}
 
 pub fn is_on_ryujinx() -> bool {
-    unsafe { // Ryujinx skip based on text addr
+    unsafe {
+        // Ryujinx skip based on text addr
         let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
         if text_addr == 0x8004000 {
             println!("we are on Ryujinx");
@@ -64,24 +69,24 @@ use once_cell::sync::OnceCell;
 #[cfg(feature = "main_nro")]
 pub fn get_romfs_version() -> &'static String {
     static INSTANCE: OnceCell<String> = OnceCell::new();
-    INSTANCE.get_or_init(|| {
-        match std::fs::read_to_string("mods:/ui/romfs_version.txt") {
+    INSTANCE.get_or_init(
+        || match std::fs::read_to_string("mods:/ui/romfs_version.txt") {
             Ok(version_value) => version_value.trim().to_string(),
             Err(_) => String::from("UNKNOWN"),
-        }
-    })
+        },
+    )
 }
 
 /// gets the main plugin version string for display
 #[cfg(feature = "main_nro")]
 pub fn get_plugin_version() -> &'static String {
     static INSTANCE: OnceCell<String> = OnceCell::new();
-    INSTANCE.get_or_init(|| {
-        match std::fs::read_to_string("mods:/ui/hdr_version.txt") {
+    INSTANCE.get_or_init(
+        || match std::fs::read_to_string("mods:/ui/hdr_version.txt") {
             Ok(version_value) => version_value.trim().to_string(),
-            Err(_) => String::from("UNKNOWN")
-        }
-    })
+            Err(_) => String::from("UNKNOWN"),
+        },
+    )
 }
 
 extern "C" {
@@ -97,20 +102,19 @@ fn change_version_string_hook(arg: u64, string: *const c_char) {
         let hdr_version = match std::fs::read_to_string("mods:/ui/hdr_version.txt") {
             Ok(version_value) => version_value.trim().to_string(),
             Err(_) => {
-                
                 #[cfg(feature = "main_nro")]
                 if !is_on_ryujinx() {
-                    skyline_web::DialogOk::ok("hdr-assets is not enabled! Please enable hdr-assets in arcropolis config.");
+                    skyline_web::DialogOk::ok(
+                        "hdr-assets is not enabled! Please enable hdr-assets in arcropolis config.",
+                    );
                 }
-                
+
                 String::from("UNKNOWN")
             }
         };
         let new_str = format!(
             "{}\nHDR Ver. {}\nAssets Ver. {}\0",
-            original_str,
-            hdr_version,
-            romfs_version
+            original_str, hdr_version, romfs_version
         );
 
         call_original!(arg, skyline::c_str(&new_str))
@@ -145,7 +149,8 @@ unsafe fn main_menu_quick(ctx: &skyline::hooks::InlineCtx) {
     *(sp.add(0x60) as *mut u64) = 0x1100000000;
     let mut slice = std::slice::from_raw_parts_mut(sp.add(0x68), 18);
     slice.copy_from_slice(b"MenuSequenceScene\0");
-    let mode = (skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + 0x53030f0) as *const u64;
+    let mode = (skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64 + 0x53030f0)
+        as *const u64;
     // if we are in the controls menu mode, there is no ui overlay, so dont update the hud
     println!("{:#x}", *mode);
 }
@@ -155,8 +160,12 @@ fn load_file_by_hash40(tables: u64, hash: u64);
 
 #[skyline::hook(offset = 0x1864310, inline)]
 unsafe fn title_screen_play(_: &skyline::hooks::InlineCtx) {
-    let tables = *((skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *const u8).add(0x5330f20) as *const u64);
-    load_file_by_hash40(tables, smash::hash40("ui/layout/menu/main_menu/main_menu/layout.arc"));
+    let tables = *((skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *const u8)
+        .add(0x5330f20) as *const u64);
+    load_file_by_hash40(
+        tables,
+        smash::hash40("ui/layout/menu/main_menu/main_menu/layout.arc"),
+    );
 }
 
 std::arch::global_asm!(
@@ -193,8 +202,8 @@ std::arch::global_asm!(
 );
 
 use skyline::hooks::InlineCtx;
-use smash::lua2cpp::*;
 use smash::lib::lua_const::*;
+use smash::lua2cpp::*;
 #[skyline::from_offset(0x15433b0)]
 unsafe fn ask_game_state_nicely(arg: *mut u64, game_state: u64, hash: u64);
 #[skyline::from_offset(0x135a0d0)]
@@ -207,7 +216,9 @@ unsafe fn push_something(game_state: u64, amt: u32) {
     let mut val2 = *game_state.add(0x108 / 8);
     let mut val3 = if val2 - val1 != 0 {
         (val2 - val1) * 0x20 - 1
-    } else { 0 };
+    } else {
+        0
+    };
 
     let mut val4 = *game_state.add(0x120 / 8) + *game_state.add(0x118 / 8);
     if val4 == val3 {
@@ -228,7 +239,9 @@ unsafe fn push_hash(game_state: u64, hash: u64) {
     let mut val2 = *game_state.add(0xd0 / 8);
     let mut val3 = if val2 - val1 != 0 {
         (val2 - val1) * 0x40 - 1
-    } else { 0 };
+    } else {
+        0
+    };
     let mut val4 = *game_state.add(0xe8 / 8) + *game_state.add(0xe0 / 8);
     if val4 == val3 {
         push_hash_base(game_state as u64 + 0xc0);
@@ -244,21 +257,44 @@ unsafe fn push_hash(game_state: u64, hash: u64) {
 // this will exit the game without going to results at the end.
 #[skyline::hook(offset = 0x14d6570)]
 unsafe fn game_end(game_state: u64) {
-    push_something(game_state, 2);
-    push_hash(game_state, smash::hash40("statewaitforruletofinish"));
-    push_hash(game_state, smash::hash40("statewaitendproduction"));
-    push_hash(game_state, smash::hash40("stateapplyparameters"));
-    push_hash(game_state, smash::hash40("statewaitforsyncwhenending"));
-    push_hash(game_state, smash::hash40("statefadeoutwhenending"));
-    push_hash(game_state, smash::hash40("stateexit"));
+    let one =
+        *(skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8).add(0x52c31b2);
+    if one == 0 {
+        push_something(game_state, 2);
+        // push_hash(game_state, smash::hash40("statewaitforruletofinish"));
+        // push_hash(game_state, smash::hash40("statewaitendproduction"));
+        push_hash(game_state, smash::hash40("stateapplyparameters"));
+        // push_hash(game_state, smash::hash40("statewaitforsyncwhenending"));
+        push_hash(game_state, smash::hash40("statefadeoutwhenending"));
+        push_hash(game_state, smash::hash40("stateexit"));
+        return;
+    }
+    call_original!(game_state);
 }
 
+#[skyline::hook(offset = 0x14d7ed0)]
+unsafe fn game_exit(game_state: u64, arg: u64) {
+    let one =
+        *(skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8).add(0x52c31b2);
+    if one == 0 { 
+        push_something(game_state, 2);
+        // push_hash(game_state, smash::hash40("statewaitforruletofinish"));
+        // push_hash(game_state, smash::hash40("statewaitendproduction"));
+        push_hash(game_state, smash::hash40("stateapplyparameters"));
+        // push_hash(game_state, smash::hash40("statewaitforsyncwhenending"));
+        push_hash(game_state, smash::hash40("statefadeoutwhenending"));
+        push_hash(game_state, smash::hash40("stateexit"));
+        return
+    }
+
+    call_original!(game_state, arg);
+}
 
 #[repr(C)]
 pub struct FuckingAssStringStructureShit {
     pub fuck_if_i_know: u32,
     pub len: u32,
-    pub shit_ass_string: [u8; 40]
+    pub shit_ass_string: [u8; 40],
 }
 
 impl FuckingAssStringStructureShit {
@@ -279,13 +315,53 @@ unsafe fn sss_to_css(ctx: &InlineCtx) {
 unsafe fn css_to_sss(ctx: &InlineCtx) {
     let thing = *ctx.registers[1].x.as_ref() as *mut FuckingAssStringStructureShit;
     (*thing).set("StageSelectScene");
-
 }
 
+#[repr(C)]
+pub struct UnknownFighterInfoStruct {
+    unk: [u64; 2],
+    hash1: u64,
+    hash2: u64,
+}
+
+static mut IS_LOADING: bool = false;
+
+#[skyline::hook(offset = 0x1785348)]
+unsafe fn load_ingame_call_sequence_scene(arg: u64) {
+    IS_LOADING = true;
+    call_original!(arg)
+}
+
+#[skyline::hook(offset = 0x1850190)]
+unsafe fn load_melee_scene(arg: u64) {
+    println!("{}", arg);
+    IS_LOADING = false;
+    call_original!(arg);
+}
+
+#[skyline::from_offset(0x1742da0)]
+unsafe fn check_mode(mode: &mut u32, submode: &mut u32);
+
+#[skyline::hook(offset = 0x16b7f70)]
+unsafe fn copy_fighter_info(
+    dst: &mut UnknownFighterInfoStruct,
+    src: &mut UnknownFighterInfoStruct,
+) {
+    let one =
+        *(skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as *mut u8).add(0x52c31b2);
+    if src.hash1 & 0xFF_FFFFFFFF == smash::hash40("ui_chara_random") && one == 0 && IS_LOADING {
+        dst.hash1 = 0xC1FFFF00_00000000;
+        dst.hash2 = 0xC1FFFF00_00000000;
+        src.hash1 = 0xC1FFFF00_00000000;
+        src.hash2 = 0xC1FFFF00_00000000;
+    }
+    call_original!(dst, src);
+}
 
 #[no_mangle]
 pub extern "C" fn main() {
-    #[cfg(feature = "main_nro")] {
+    #[cfg(feature = "main_nro")]
+    {
         quick_validate_install();
         skyline::install_hooks!(change_version_string_hook);
         random::install();
@@ -294,17 +370,42 @@ pub extern "C" fn main() {
         online::install();
         skyline::patching::Patch::in_text(0x14f97bc).nop().unwrap();
         skyline::patching::Patch::in_text(0x1509dc4).nop().unwrap();
-        skyline::install_hooks!(training_reset_music1, training_reset_music2, main_menu_quick, title_screen_play, sss_to_css, css_to_sss);
+        skyline::install_hooks!(
+            training_reset_music1,
+            training_reset_music2,
+            main_menu_quick,
+            title_screen_play,
+            sss_to_css,
+            css_to_sss,
+            copy_fighter_info,
+            load_ingame_call_sequence_scene,
+            load_melee_scene,
+            game_end,
+            game_exit
+        );
     }
 
     #[cfg(not(feature = "runtime"))]
-    { utils::init(); }
+    {
+        utils::init();
+    }
     fighters::install();
     #[cfg(all(not(feature = "add_status"), feature = "main_nro"))]
-    { if !(delayed_install as *const ()).is_null() { unsafe { delayed_install(); } } }
+    {
+        if !(delayed_install as *const ()).is_null() {
+            unsafe {
+                delayed_install();
+            }
+        }
+    }
 
-    #[cfg(all(feature = "add_status", not(all(not(feature = "add_status"), feature = "main_nro"))))]
-    { fighters::delayed_install(); }
+    #[cfg(all(
+        feature = "add_status",
+        not(all(not(feature = "add_status"), feature = "main_nro"))
+    ))]
+    {
+        fighters::delayed_install();
+    }
 
     #[cfg(feature = "updater")]
     {
@@ -316,15 +417,14 @@ pub extern "C" fn main() {
             .unwrap()
             .join();
     }
-
-    
-
 }
-
 
 #[cfg(feature = "main_nro")]
 pub fn quick_validate_install() {
-    let has_smashline_hook = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libsmashline_hook.nro").is_file();
+    let has_smashline_hook = Path::new(
+        "sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libsmashline_hook.nro",
+    )
+    .is_file();
     if has_smashline_hook {
         println!("libsmashline_hook.nro is present");
     } else {
@@ -335,7 +435,10 @@ pub fn quick_validate_install() {
         }
     }
 
-    let has_arcropolis_nro = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libarcropolis.nro").is_file();
+    let has_arcropolis_nro = Path::new(
+        "sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libarcropolis.nro",
+    )
+    .is_file();
     if has_arcropolis_nro {
         println!("libarcropolis.nro is present");
     } else {
@@ -346,8 +449,9 @@ pub fn quick_validate_install() {
         }
     }
 
-    
-    let has_nro_hook = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libnro_hook.nro").is_file();
+    let has_nro_hook =
+        Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libnro_hook.nro")
+            .is_file();
     if has_nro_hook {
         println!("libnro_hook.nro is present");
     } else {
@@ -370,36 +474,47 @@ pub fn quick_validate_install() {
                     skyline::nn::oe::RequestToRelaunchApplication();
                 }
             } else {
-                skyline_web::DialogOk::ok("Warning, we will likely crash soon because of this conflict.");
+                skyline_web::DialogOk::ok(
+                    "Warning, we will likely crash soon because of this conflict.",
+                );
             }
         }
     }
 
-    let has_development_nro = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro").is_file();
+    let has_development_nro =
+        Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro")
+            .is_file();
     let has_dev_folder = Path::new("sd:/ultimate/mods/hdr-dev/").is_dir();
     if has_development_nro && !has_dev_folder {
         if is_on_ryujinx() {
-            println!("development.nro found, but there is no hdr-dev folder! This is likely a mistake.");
+            println!(
+                "development.nro found, but there is no hdr-dev folder! This is likely a mistake."
+            );
         } else {
             let should_delete = skyline_web::Dialog::yes_no("development.nro found, but there is no hdr-dev folder! This is likely a mistake. Would you like to delete it?");
             if should_delete {
-                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro");
+                fs::remove_file(
+                    "sd:/atmosphere/contents/01006a800016e000/romfs/smashline/development.nro",
+                );
                 unsafe {
                     skyline::nn::oe::RequestToRelaunchApplication();
                 }
-            } 
+            }
         }
     }
-    
 
-    let has_stale_hdr = Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro").is_file();
+    let has_stale_hdr =
+        Path::new("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro")
+            .is_file();
     if has_stale_hdr {
         if is_on_ryujinx() {
             println!("stale libhdr.nro found! This will conflict with your newer hdr! Expect a crash soon.");
         } else {
             let should_delete = skyline_web::Dialog::yes_no("Stale libhdr.nro found in atmos/contents! This will conflict with new hdr packaging! Would you like to delete it?");
             if should_delete {
-                fs::remove_file("sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro");
+                fs::remove_file(
+                    "sd:/atmosphere/contents/01006a800016e000/romfs/skyline/plugins/libhdr.nro",
+                );
                 unsafe {
                     skyline::nn::oe::RequestToRelaunchApplication();
                 }
@@ -432,5 +547,4 @@ pub fn quick_validate_install() {
     }
 
     println!("simple validation complete.");
-
 }


### PR DESCRIPTION
If you pick time battle, all players set to random to nothing.

This also requires removing the no contest/result screen in time battles to not soft lock the game. I also removed the no contest in stock battle, it just goes back to CSS when you quit now.