### PR TITLE
Nerf knockback smoke even more

### DIFF
--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -15,7 +15,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             status_DamageFly_Main_hook,
             calc_damage_motion_rate_hook,
             sub_DamageFlyCommon_hook,
-            exec_damage_elec_hit_stop_hook
+            exec_damage_elec_hit_stop_hook,
+            FighterStatusDamage__is_enable_damage_fly_effect_hook
         );
     }
 }
@@ -516,4 +517,14 @@ pub unsafe fn exec_damage_elec_hit_stop_hook(fighter: &mut L2CFighterCommon) {
         WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_PARALYZE_STOP);
         check_asdi(fighter);
     }
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FighterStatusDamage__is_enable_damage_fly_effect)]
+pub unsafe fn FighterStatusDamage__is_enable_damage_fly_effect_hook(fighter: &mut L2CFighterCommon, arg2: L2CValue, arg3: L2CValue, arg4: L2CValue, arg5: L2CValue) -> L2CValue {
+    let ret = call_original!(fighter, arg2, arg3, arg4, arg5);
+    let hit_stop_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_DAMAGE_WORK_INT_HIT_STOP_FRAME);
+    if ret.get_bool() && WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_DAMAGE_WORK_FLOAT_FLY_DIST) < 3.0 {
+        return L2CValue::Bool(false);
+    }
+    ret
 }

--- a/romfs/source/fighter/common/param/effect.prcxml
+++ b/romfs/source/fighter/common/param/effect.prcxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
-  <float hash="fly_effect_smoke_speed">3.08</float>
+  <float hash="fly_effect_smoke_speed">4</float>
   <float hash="fly_effect_aura_speed">999</float>
   <int hash="vector_adjust_effect_remove_frame">1</int>
 </struct>


### PR DESCRIPTION
- Knockback speed threshold required to trigger knockback smoke increased 3.08 -> 4.0
- Knockback smoke farts were still occurring in some instances, so it now starts generating a few frames later into your kb arc than before