### PR TITLE
Double air traction when above max jump speed

### DIFF
--- a/fighters/common/src/function_hooks/energy/control.rs
+++ b/fighters/common/src/function_hooks/energy/control.rs
@@ -323,12 +323,22 @@ unsafe fn control_update(energy: &mut FighterKineticEnergyControl, boma: &mut Ba
         }
     }
 
+    // Double air brake value when above max horizontal jump speed
     let status_module = *(boma as *const BattleObjectModuleAccessor as *const u64).add(0x8);
     if !*(status_module as *const bool).add(0x12a)
     && boma.status_frame() > 0 {
-        // Double air brake value when above max jump speed
+        let run_speed_max = WorkModule::get_param_float(boma, hash40("run_speed_max"), 0);
+        let ratio = VarModule::get_float(boma.object(), vars::common::instance::JUMP_SPEED_RATIO);
+        // get the multiplier for any special mechanics that require additional jump speed max (meta quick, etc)
+        let mut jump_speed_max_mul = VarModule::get_float(boma.object(), vars::common::instance::JUMP_SPEED_MAX_MUL);
+        match jump_speed_max_mul {
+            // if its not between 0.1 and 3.0, it is likely not a real value and we should ignore it
+            0.1..=3.0 => {},
+            _ => { jump_speed_max_mul = 1.0 }
+        }
+        let jump_speed_x_max = run_speed_max * ratio * jump_speed_max_mul;
         if StatusModule::situation_kind(boma) == *SITUATION_KIND_AIR 
-        && energy.speed.x.abs() >= WorkModule::get_param_float(boma, hash40("jump_speed_x_max"), 0) {
+        && energy.speed.x.abs() >= jump_speed_x_max {
             energy.speed_brake.x *= 2.0;
         }
     }

--- a/fighters/common/src/function_hooks/energy/control.rs
+++ b/fighters/common/src/function_hooks/energy/control.rs
@@ -323,6 +323,16 @@ unsafe fn control_update(energy: &mut FighterKineticEnergyControl, boma: &mut Ba
         }
     }
 
+    let status_module = *(boma as *const BattleObjectModuleAccessor as *const u64).add(0x8);
+    if !*(status_module as *const bool).add(0x12a)
+    && boma.status_frame() > 0 {
+        // Double air brake value when above max jump speed
+        if StatusModule::situation_kind(boma) == *SITUATION_KIND_AIR 
+        && energy.speed.x.abs() >= WorkModule::get_param_float(boma, hash40("jump_speed_x_max"), 0) {
+            energy.speed_brake.x *= 2.0;
+        }
+    }
+
     energy.process(boma);
 
     let status_module = *(boma as *const BattleObjectModuleAccessor as *const u64).add(0x8);


### PR DESCRIPTION
Much like how on the ground, you undergo double traction while moving above your character's max walk speed, you will now undergo double air traction (air brake) when moving above your character's max jump speed in the air.

This is meant to balance the significant aerial momentum some characters gain when performing the recently implemented platdrop momentum transfer.