### PR TITLE
Sheik - fix jump cancel & reinstate airdodge cancel on Bouncing Fish return

### DIFF
--- a/fighters/sheik/src/opff.rs
+++ b/fighters/sheik/src/opff.rs
@@ -5,9 +5,10 @@ use globals::*;
 
  
 unsafe fn bouncing_fish_return_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
-    if status_kind == *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_RETURN && boma.status_frame() <= 14 {
+    if status_kind == *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_RETURN && boma.status_frame() > 14 {
         if situation_kind == *SITUATION_KIND_AIR {
             boma.check_jump_cancel(false);
+            boma.check_airdodge_cancel();
         }
     }
 }


### PR DESCRIPTION
Previously, Sheik could only jump cancel Bouncing Fish return before or on frame 14.
Now, Sheik can both jump cancel or airdodge cancel *after* frame 14.