### PR TITLE
Rosalina Down B tweaks

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -403,6 +403,7 @@ pub mod vars {
 
 			// flag
             pub const IS_TICO_DEAD: i32 = 0x0105;
+            pub const IS_WARP:      i32 = 0x0106;
         }
         pub mod status {
             // int

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -21,71 +21,84 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 	if StatusModule::is_changing(boma) {
         return;
     }
-				let fighter_kind = smash::app::utility::get_kind(boma);
-				let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
-				let frame = MotionModule::frame(boma);
-				if !smash::app::sv_information::is_ready_go(){
-					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
-					VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
+	let fighter_kind = smash::app::utility::get_kind(boma);
+	let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
+	let frame = MotionModule::frame(boma);
+	if !smash::app::sv_information::is_ready_go(){
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
+		VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
+	};
+	let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
+	let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
+	let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
+	let tico_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
+	let x_dif = (rosa_x-tico_x).abs();
+	let y_dif = (rosa_y-tico_y).abs();
+	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, (GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: rosa_x, y: rosa_y}, &Vector2f{ x: tico_x, y: tico_y}, false)) as i32);
+	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, x_dif as i32);
+	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, y_dif as i32);
+	//Teleport!
+	if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);
+		if frame == 1.0 {
+			VarModule::on_flag(fighter.battle_object, vars::rosetta::instance::IS_WARP);
+		};
+		if VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_WARP) {
+			if frame <= 10.0 { 
+				if ControlModule::check_button_off(boma, *CONTROL_PAD_BUTTON_SPECIAL) || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) != 0 || VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) {
+					VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_WARP);
 				};
-				let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
-				let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
-				let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
-				let tico_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, (GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: rosa_x, y: rosa_y}, &Vector2f{ x: tico_x, y: tico_y}, false)) as i32);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (rosa_x-tico_x) as i32);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (rosa_y-tico_y) as i32);
-				//Teleport!
-				if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
-					if frame == 13.0 {
-						macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
-					};
-					if frame > 17.0 && frame < 20.0 {
-						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
-						VisibilityModule::set_whole(boma, false);
-						JostleModule::set_status(boma, false);	
-						let new_x = tico_x;
-						let new_y = tico_y;
-						let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
-						PostureModule::set_pos(boma, &pos);
-						PostureModule::init_pos(boma, &pos, true, true);
-						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
-					};
-					if frame == 26.0 {
-						macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
-					};
-					if frame > 26.0{
-						VisibilityModule::set_whole(boma, true);
-						JostleModule::set_status(boma, true);	
-						VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
-						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
-					};
-					if frame > 38.0{
-						CancelModule::enable_cancel(boma);
-					};
-				} else {
-					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
-					VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);
-					if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW {
-						HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
-						JostleModule::set_status(boma, true);	
-						VisibilityModule::set_whole(boma, true);
-						if frame > 38.0 {
-							CancelModule::enable_cancel(boma);
-						};
-					};
-				};
-				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
-					VarModule::dec_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN);
-				};
-				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
-					gimmick_flash(boma);
-				};
-				if status_kind == *FIGHTER_STATUS_KIND_DEAD {
-					VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);
-				};
+				if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST) == 1 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) > 130 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) > 70 {
+					VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_WARP); 
+				}; //non-cd checks above were moved to opff check for warp, will be removed in recovery sweep
+			};
+			if frame == 13.0 {
+				macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
+			};
+			if frame > 17.0 && frame < 20.0 {
+				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
+				VisibilityModule::set_whole(boma, false);
+				JostleModule::set_status(boma, false);	
+				let new_x = tico_x;
+				let new_y = tico_y;
+				let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
+				PostureModule::set_pos(boma, &pos);
+				PostureModule::init_pos(boma, &pos, true, true);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
+			};
+			if frame == 26.0 {
+				macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
+			};
+			if frame > 26.0 {
+				VisibilityModule::set_whole(boma, true);
+				JostleModule::set_status(boma, true);	
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
+				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+			};
+			if frame > 38.0 {
+				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+				JostleModule::set_status(boma, true);	
+				VisibilityModule::set_whole(boma, true);
+				CancelModule::enable_cancel(boma);
+			};
+		};
+		if frame == 38.0 && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_WARP) {
+			let cd = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN);
+			VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, cd + 90);
+		};
+	};
+	if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 {
+		VarModule::dec_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN);
+	};
+	if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 1 {
+		gimmick_flash(boma);
+	};
+	if status_kind == *FIGHTER_STATUS_KIND_DEAD {
+		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);
+	};
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -109,6 +122,7 @@ pub unsafe fn rosetta_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 #[weapon_frame( agent = WEAPON_KIND_ROSETTA_TICO )]
 fn tico_frame(weapon: &mut L2CFighterBase) {
     unsafe { 
+			let boma = weapon.boma();
 			let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
 			let rosetta = utils::util::get_battle_object_from_id(owner_id);
 			let rosetta_boma = &mut *(*rosetta).module_accessor;
@@ -145,6 +159,9 @@ fn tico_frame(weapon: &mut L2CFighterBase) {
 			} else {
 				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_X, PostureModule::pos_x(weapon.module_accessor) as i32);
 				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_Y, PostureModule::pos_y(weapon.module_accessor) as i32);
+			};
+			if VarModule::get_int(rosetta, vars::rosetta::instance::COOLDOWN) == 1 {
+				gimmick_flash(boma);
 			};
 	};
 }

--- a/fighters/rosetta/src/status.rs
+++ b/fighters/rosetta/src/status.rs
@@ -1,9 +1,9 @@
 use super::*;
 /// Prevents down b being reused
 unsafe extern "C" fn should_use_special_lw_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 0 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST) == 1 ||
-	(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) > 130 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) < -130)||
-	(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) > 70 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) < -70){
+    if VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) > 180 { //|| VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST) == 1 || commented out so that the grav pull can be initiated,
+	//(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) > 130 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST) < -130)|| opff checks for these before allowing warp
+	//(VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) > 70 || VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST) < -70){
         false.into()
     } else {
         true.into()


### PR DESCRIPTION
Can now use vanilla gravity pull if you release the special button before 10 frames. Move is only locked out for 2 seconds of the 5 second warp cooldown. You still cannot warp unless you are in vision range of luma, within range, and have waited for the 5 second timer to completely run out which is indicated by a flash on the UI, Rosalina, and her Luma if alive. Each use adds 1.5 seconds back to the cooldown, so spamming it will keep your warp from refreshing. 