### PR TITLE
Revert Meta Knight

### DIFF
--- a/fighters/metaknight/src/lib.rs
+++ b/fighters/metaknight/src/lib.rs
@@ -43,6 +43,7 @@ pub fn install(is_runtime: bool) {
         utils::singletons::init();
     }
 
-    //acmd::install();
+    acmd::install();
+    //status::install();
     opff::install(is_runtime);
 }


### PR DESCRIPTION
A small error caused Meta Knight to be mostly reverted to vanilla