### PR TITLE
Charizard recovery adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -655,6 +655,12 @@ pub mod vars {
         }
     }
 
+    pub mod plizardon {
+        pub mod instance {
+            pub const DISABLE_SPECIAL_S: i32 = 0x0100;
+        }
+    }
+
     pub mod pzenigame {
         pub mod instance {
             pub const WITHDRAW_FRAME: i32 = 0x0100;

--- a/fighters/plizardon/src/acmd/specials.rs
+++ b/fighters/plizardon/src/acmd/specials.rs
@@ -47,6 +47,35 @@ unsafe fn game_specialhi(fighter: &mut L2CAgentBase) {
     frame(lua_state, 46.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_MOVE_TRANS);
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_CHANGE_KINE);
+    }
+    frame(lua_state, 47.0);
+    if is_excute(fighter) {
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let air_speed_x_stable = WorkModule::get_param_float(boma, hash40("air_speed_x_stable"), 0);
+        let fall_x_mul = WorkModule::get_param_float(
+            boma,
+            hash40("param_special_hi"),
+            hash40("fall_x_mul")
+        );
+        sv_kinetic_energy!(
+            set_stable_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            air_speed_x_stable * fall_x_mul,
+            0.0
+        );
     }
 }
 
@@ -56,7 +85,7 @@ unsafe fn game_specialairhi(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 4.0);
     if is_excute(fighter) {
-        damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_ALWAYS, 0);
+        //damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_ALWAYS, 0);
     }
     frame(lua_state, 9.0);
     if is_excute(fighter) {
@@ -95,6 +124,35 @@ unsafe fn game_specialairhi(fighter: &mut L2CAgentBase) {
     frame(lua_state, 46.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_MOVE_TRANS);
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_CHANGE_KINE);
+    }
+    frame(lua_state, 47.0);
+    if is_excute(fighter) {
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let air_speed_x_stable = WorkModule::get_param_float(boma, hash40("air_speed_x_stable"), 0);
+        let fall_x_mul = WorkModule::get_param_float(
+            boma,
+            hash40("param_special_hi"),
+            hash40("fall_x_mul")
+        );
+        sv_kinetic_energy!(
+            set_stable_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            air_speed_x_stable * fall_x_mul,
+            0.0
+        );
     }
 }
 

--- a/fighters/plizardon/src/lib.rs
+++ b/fighters/plizardon/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/plizardon/src/status.rs
+++ b/fighters/plizardon/src/status.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+mod special_s;
+
+pub fn install() {
+    special_s::install();
+
+}

--- a/fighters/plizardon/src/status.rs
+++ b/fighters/plizardon/src/status.rs
@@ -2,7 +2,37 @@ use super::*;
 
 mod special_s;
 
+// Prevents sideB from being used again if it has already been used once in the current airtime
+unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_AIR) && VarModule::is_flag(fighter.battle_object, vars::plizardon::instance::DISABLE_SPECIAL_S) {
+        false.into()
+    } else {
+        true.into()
+    }
+}
+
+// Re-enables the ability to use sideB when connecting to ground or cliff
+unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
+    || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD]) {
+        VarModule::off_flag(fighter.battle_object, vars::plizardon::instance::DISABLE_SPECIAL_S);
+    }
+    true.into()
+}
+
+#[smashline::fighter_init]
+fn plizardon_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        // set the callbacks on fighter init
+        if fighter.kind() == *FIGHTER_KIND_PLIZARDON {
+            fighter.global_table[globals::USE_SPECIAL_S_CALLBACK].assign(&L2CValue::Ptr(should_use_special_s_callback as *const () as _));
+            fighter.global_table[globals::STATUS_CHANGE_CALLBACK].assign(&L2CValue::Ptr(change_status_callback as *const () as _));   
+        }
+    }
+}
+
 pub fn install() {
+    smashline::install_agent_init_callbacks!(plizardon_init);
     special_s::install();
 
 }

--- a/fighters/plizardon/src/status/special_s.rs
+++ b/fighters/plizardon/src/status/special_s.rs
@@ -1,0 +1,18 @@
+use super::*;
+use globals::*;
+
+// FIGHTER_STATUS_KIND_SPECIAL_S //
+
+#[status_script(agent = "plizardon", status = FIGHTER_STATUS_KIND_SPECIAL_S, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+pub unsafe fn init_special_s(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_AIR) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL_NO_HIT);
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        init_special_s
+    );
+}

--- a/fighters/plizardon/src/status/special_s.rs
+++ b/fighters/plizardon/src/status/special_s.rs
@@ -5,9 +5,7 @@ use globals::*;
 
 #[status_script(agent = "plizardon", status = FIGHTER_STATUS_KIND_SPECIAL_S, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
 pub unsafe fn init_special_s(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_situation(*SITUATION_KIND_AIR) {
-        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL_NO_HIT);
-    }
+    VarModule::on_flag(fighter.battle_object, vars::plizardon::instance::DISABLE_SPECIAL_S);
     0.into()
 }
 

--- a/romfs/source/fighter/plizardon/param/vl.prcxml
+++ b/romfs/source/fighter/plizardon/param/vl.prcxml
@@ -2,13 +2,23 @@
 <struct>
   <list hash="cliff_hang_data">
     <struct index="0">
-      <float hash="p1_y">25.25</float>
+      <float hash="p1_y">22</float>
     </struct>
+  </list>
+  <list hash="param_special_s">
+    <struct index="0">
+      <float hash="speed_x_">3</float>
+      <float hash="brake_x_">0.04</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
   </list>
   <list hash="param_special_hi">
     <struct index="0">
-      <float hash="dir_mul">22</float>
+      <float hash="dir_mul">18</float>
       <float hash="air_pass_mul">0.935</float>
+      <int hash="landing_frame">28</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
- Ledgegrab box upper bound reduced 25.25 -> 22

Before:

![2023040218330900-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/47401664/229383047-56451ec7-01c9-4cc7-8913-4990978bb4cc.jpg)

After:

![2023040218231900-0E7DF678130F4F0FA2C88AE72B47AFDF](https://user-images.githubusercontent.com/47401664/229383050-d6b65996-bffa-4b1a-ac95-39d58d581590.jpg)

---

### SideB:
- Speed/distance significantly reduced
- Now once-per-airtime

Before:

https://user-images.githubusercontent.com/47401664/229383072-e8cfb3de-3694-4da9-b018-b192f8f5620b.mp4

After:

https://user-images.githubusercontent.com/47401664/229383081-33f96fe6-3e3e-47f2-ad13-fdfb43fe82e7.mp4

---

### UpB:
- Animation adjusted to travel straight vertically when stick is neutral, making the move more intuitive to use

Before:

https://user-images.githubusercontent.com/47401664/229383101-1b59a018-fd93-4785-b574-dfa3434b1514.mp4

After:

https://user-images.githubusercontent.com/47401664/229383112-031068dc-ed87-425b-a288-db1b10ca6300.mp4

- Able to drift much sooner after reaching peak
- Angleability range reduced 22 -> 18
- Armor removed on aerial variant
- Landing lag reduced 30 -> 28
