### PR TITLE
Wario recovery adjustments

### DIFF
--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -107,6 +107,12 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
         && VarModule::is_flag(boma.object(), vars::common::instance::UP_SPECIAL_CANCEL) {
             next_status = *FIGHTER_STATUS_KIND_FALL;
         }
+        if boma.kind() == *FIGHTER_KIND_WARIO
+        && StatusModule::status_kind(boma) == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_DRIVE
+        && next_status == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_ESCAPE_START
+        && boma.get_num_used_jumps() >= boma.get_jump_count_max() {
+            return 0;
+        }
     }
     original!()(boma, next_status, clear_buffer)
 }

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -108,10 +108,11 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
             next_status = *FIGHTER_STATUS_KIND_FALL;
         }
         if boma.kind() == *FIGHTER_KIND_WARIO
-        && StatusModule::status_kind(boma) == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_DRIVE
-        && next_status == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_ESCAPE_START
+        && StatusModule::status_kind(boma) == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_ESCAPE_START
+        && next_status == *FIGHTER_WARIO_STATUS_KIND_SPECIAL_S_ESCAPE
         && boma.get_num_used_jumps() >= boma.get_jump_count_max() {
-            return 0;
+            next_status = *FIGHTER_STATUS_KIND_FALL;
+            clear_buffer = true;
         }
     }
     original!()(boma, next_status, clear_buffer)

--- a/fighters/wario/src/lib.rs
+++ b/fighters/wario/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/wario/src/status.rs
+++ b/fighters/wario/src/status.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+mod special_s;
+
+pub fn install() {
+    special_s::install();
+}

--- a/fighters/wario/src/status/special_s.rs
+++ b/fighters/wario/src/status/special_s.rs
@@ -3,8 +3,8 @@ use globals::*;
 
 // WEAPON_WARIO_WARIOBIKE_STATUS_KIND_SPECIAL_S_ESCAPE_START
 
-#[status_script(agent = "wario_wariobike", status = WEAPON_WARIO_WARIOBIKE_STATUS_KIND_SPECIAL_S_ESCAPE_START, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
-pub unsafe fn special_s_escape_start_init(weapon: &mut L2CWeaponCommon) -> L2CValue {
+#[status_script(agent = "wario_wariobike", status = WEAPON_WARIO_WARIOBIKE_STATUS_KIND_SPECIAL_S_ESCAPE_START, condition = LUA_SCRIPT_STATUS_FUNC_EXIT_STATUS)]
+pub unsafe fn special_s_escape_start_exit(weapon: &mut L2CWeaponCommon) -> L2CValue {
     let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
     let wario = utils::util::get_battle_object_from_id(owner_id);
     let wario_boma = &mut *(*wario).module_accessor;
@@ -18,6 +18,6 @@ pub unsafe fn special_s_escape_start_init(weapon: &mut L2CWeaponCommon) -> L2CVa
 
 pub fn install() {
     install_status_scripts!(
-        special_s_escape_start_init
+        special_s_escape_start_exit
     );
 }

--- a/fighters/wario/src/status/special_s.rs
+++ b/fighters/wario/src/status/special_s.rs
@@ -1,0 +1,23 @@
+use super::*;
+use globals::*;
+
+// WEAPON_WARIO_WARIOBIKE_STATUS_KIND_SPECIAL_S_ESCAPE_START
+
+#[status_script(agent = "wario_wariobike", status = WEAPON_WARIO_WARIOBIKE_STATUS_KIND_SPECIAL_S_ESCAPE_START, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+pub unsafe fn special_s_escape_start_init(weapon: &mut L2CWeaponCommon) -> L2CValue {
+    let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
+    let wario = utils::util::get_battle_object_from_id(owner_id);
+    let wario_boma = &mut *(*wario).module_accessor;
+    if weapon.global_table[SITUATION_KIND] == SITUATION_KIND_AIR
+    && wario_boma.get_num_used_jumps() < wario_boma.get_jump_count_max() {
+        WorkModule::inc_int(wario_boma, *FIGHTER_INSTANCE_WORK_ID_INT_JUMP_COUNT);
+    }
+    0.into()
+}
+
+
+pub fn install() {
+    install_status_scripts!(
+        special_s_escape_start_init
+    );
+}

--- a/romfs/source/fighter/wario/param/vl.prcxml
+++ b/romfs/source/fighter/wario/param/vl.prcxml
@@ -16,7 +16,7 @@
   </list>
   <list hash="param_wariobike">
     <struct index="0">
-      <float hash="start_speed_x_air">1.2</float>
+      <float hash="start_speed_x_air">1.5</float>
       <float hash="brake_x_air">0.025</float>
       <float hash="speed_x_min_air">0.8</float>
     </struct>
@@ -26,6 +26,7 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
+    <float hash="adjust_angle">30</float>
       <float hash="jump_y_spd_mul">1</float>
     </struct>
     <hash40 index="1">dummy</hash40>


### PR DESCRIPTION
### SideB:

- Jumping off of bike in the air now consumes double jump
- If double jump is used, you will not jump when getting off the bike
- Bike initial aerial horizontal speed increased to compensate, 1.2 -> 1.5

### UpB:
- Angleability range reduced 40 -> 30