### PR TITLE
Remove parries from the game

### DIFF
--- a/fighters/common/src/general_statuses/shield/guard_damage/exec.rs
+++ b/fighters/common/src/general_statuses/shield/guard_damage/exec.rs
@@ -13,6 +13,7 @@ unsafe fn sub_ftStatusUniqProcessGuardDamage_execStatus_common(fighter: &mut L2C
         let scale = fighter_status_guard::calc_shield_scale(fighter, shield_level.into()).get_f32();
         ModelModule::set_joint_scale(fighter.module_accessor, Hash40::new("throw"), &Vector3f{ x: scale, y: scale, z: scale });
     }
+    // who shit my pants
 }
 
 #[common_status_script(status = FIGHTER_STATUS_KIND_GUARD_DAMAGE, condition = LUA_SCRIPT_STATUS_FUNC_EXEC_STATUS,


### PR DESCRIPTION
After much consideration and internal discussion, we have come to the conclusion that parries were not fitting into our overall vision for the game. We felt that the mechanic slowed down the pace of gameplay and didn't provide the level of excitement and engagement that we were striving for.

We understand that parries were a popular feature among many of our players, and we want to assure you that we did not make this decision lightly. However, we firmly believe that this change will ultimately result in a better and more enjoyable experience for everyone.

We want to thank you for your continued support and understanding as we strive to make the best possible game for our community. If you have any questions or concerns, please do not hesitate to reach out to us.