### PR TITLE
Ike recovery adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -468,6 +468,11 @@ pub mod vars {
     }
 
     pub mod ike {
+        pub mod instance {
+            // flags
+            pub const DISABLE_SPECIAL_S: i32 = 0x0100;
+
+        }
         pub mod status {
             // flags
             pub const IS_QUICK_DRAW_INSTAKILL: i32 = 0x1100;

--- a/fighters/ike/src/lib.rs
+++ b/fighters/ike/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -384,6 +384,15 @@ unsafe fn fair_wrist_bend(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
+unsafe fn quickdraw_attack_whiff_freefall(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_IKE_STATUS_KIND_SPECIAL_S_ATTACK)
+    && fighter.is_situation(*SITUATION_KIND_AIR)
+    && CancelModule::is_enable_cancel(fighter.module_accessor)
+    && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
+    }
+}
+
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     aether_drift(boma, status_kind, situation_kind, stick_x, facing);
@@ -393,6 +402,7 @@ pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut
     jab_lean(boma);
     grab_lean(boma);
     fair_wrist_bend(boma);
+    quickdraw_attack_whiff_freefall(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_IKE )]

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -390,6 +390,8 @@ unsafe fn quickdraw_attack_whiff_freefall(fighter: &mut L2CFighterCommon) {
     && CancelModule::is_enable_cancel(fighter.module_accessor)
     && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
+        let cancel_module = *(fighter.module_accessor as *mut BattleObjectModuleAccessor as *mut u64).add(0x128 / 8) as *const u64;
+        *(((cancel_module as u64) + 0x1c) as *mut bool) = false;  // CancelModule::is_enable_cancel = false
     }
 }
 

--- a/fighters/ike/src/status.rs
+++ b/fighters/ike/src/status.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+mod special_s;
+
+pub fn install() {
+    special_s::install();
+}

--- a/fighters/ike/src/status.rs
+++ b/fighters/ike/src/status.rs
@@ -2,6 +2,48 @@ use super::*;
 
 mod special_s;
 
+// Prevents sideB from being used again if it has already been used once in the current airtime
+unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_AIR) && VarModule::is_flag(fighter.battle_object, vars::ike::instance::DISABLE_SPECIAL_S) {
+        false.into()
+    } else {
+        true.into()
+    }
+}
+
+// Re-enables the ability to use sideB when connecting to ground or cliff or when hit
+unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
+    || fighter.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_REBIRTH,
+        *FIGHTER_STATUS_KIND_DEAD,
+        *FIGHTER_STATUS_KIND_DAMAGE,
+        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+        *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+        *FIGHTER_STATUS_KIND_DAMAGE_FALL])
+    {
+        VarModule::off_flag(fighter.battle_object, vars::ike::instance::DISABLE_SPECIAL_S);
+    }
+    true.into()
+}
+
+#[smashline::fighter_init]
+fn ike_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        // set the callbacks on fighter init
+        if fighter.kind() == *FIGHTER_KIND_IKE {
+            fighter.global_table[globals::USE_SPECIAL_S_CALLBACK].assign(&L2CValue::Ptr(should_use_special_s_callback as *const () as _));
+            fighter.global_table[globals::STATUS_CHANGE_CALLBACK].assign(&L2CValue::Ptr(change_status_callback as *const () as _));   
+        }
+    }
+}
+
 pub fn install() {
+    smashline::install_agent_init_callbacks!(ike_init);
     special_s::install();
 }

--- a/fighters/ike/src/status/special_s.rs
+++ b/fighters/ike/src/status/special_s.rs
@@ -5,10 +5,8 @@ use globals::*;
 
 #[status_script(agent = "ike", status = FIGHTER_STATUS_KIND_SPECIAL_S, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
 pub unsafe fn init_special_s(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_situation(*SITUATION_KIND_AIR) {
-        // Quick Draw once-per-airtime (refreshes on hit)
-        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL);
-    }
+    // Quick Draw once-per-airtime (refreshes on hit)
+    VarModule::on_flag(fighter.battle_object, vars::ike::instance::DISABLE_SPECIAL_S);
     original!(fighter)
 }
 

--- a/fighters/ike/src/status/special_s.rs
+++ b/fighters/ike/src/status/special_s.rs
@@ -1,0 +1,19 @@
+use super::*;
+use globals::*;
+
+// FIGHTER_STATUS_KIND_SPECIAL_S //
+
+#[status_script(agent = "ike", status = FIGHTER_STATUS_KIND_SPECIAL_S, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+pub unsafe fn init_special_s(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_AIR) {
+        // Quick Draw once-per-airtime (refreshes on hit)
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL);
+    }
+    original!(fighter)
+}
+
+pub fn install() {
+    install_status_scripts!(
+        init_special_s
+    );
+}

--- a/romfs/source/fighter/ike/param/vl.prcxml
+++ b/romfs/source/fighter/ike/param/vl.prcxml
@@ -10,10 +10,10 @@
     <struct index="0">
       <float hash="special_s_ground_dash_spd_min">3.8</float>
       <float hash="special_s_air_dash_spd_min">3.8</float>
-      <float hash="special_s_ground_dash_spd_mul">0.05</float>
+      <float hash="special_s_ground_dash_spd_mul">0.07</float>
       <float hash="special_s_air_dash_spd_mul">0.03</float>
       <float hash="special_s_ground_dash_brake_x">0.125</float>
-      <float hash="special_s_air_dash_brake_x">0.08</float>
+      <float hash="special_s_air_dash_brake_x">0.1</float>
       <int hash="special_s_dash_frame">18</int>
       <int hash="special_s_charge_dash_spd_up_max">30</int>
       <float hash="special_s_ground_end_spd_x_mul">0.4</float>


### PR DESCRIPTION
### SideB:

- Is now once-per-airtime (refreshes on hit)
- The attack variant will now send into freefall if whiffed in the air
- Dash aerial brake value increased 0.08 -> 0.1
- Dash grounded speed added per charge frame increased 0.05 -> 0.07