### PR TITLE
Add analog-based light shields

### DIFF
--- a/fighters/common/src/general_statuses/shield/fighter_status_guard/mod.rs
+++ b/fighters/common/src/general_statuses/shield/fighter_status_guard/mod.rs
@@ -28,12 +28,12 @@ pub unsafe fn calc_shield_scale(
     let shield_radius =
         WorkModule::get_param_float(fighter.module_accessor, hash40("shield_radius"), 0);
 
-    // let analog = InputModule::get_analog_for_guard(fighter.battle_object);
-    // let scale = if analog > 0.0 && analog < 1.0 {
-    //     (shield_level * (2.0 - analog) / shield_max) * (1.0 - shield_scale_min) + shield_scale_min
-    // } else {
-    let scale = (shield_level / shield_max) * (1.0 - shield_scale_min) + shield_scale_min;
-    // };
+    let analog = InputModule::get_analog_for_guard(fighter.battle_object);
+    let scale = if analog > 0.0 && analog < 1.0 {
+        (shield_level * (2.0 - analog) / shield_max) * (1.0 - shield_scale_min) + shield_scale_min
+    } else {
+        (shield_level / shield_max) * (1.0 - shield_scale_min) + shield_scale_min
+    };
 
     L2CValue::F32(scale * shield_radius)
 }

--- a/fighters/common/src/general_statuses/shield/guard_damage/init.rs
+++ b/fighters/common/src/general_statuses/shield/guard_damage/init.rs
@@ -20,12 +20,12 @@ unsafe fn sub_ftStatusUniqProcessGuardDamage_initStatus_Inner(fighter: &mut L2CF
         hash40("shield_setoff_mul"),
     );
 
-    // let analog = InputModule::get_analog_for_guard(fighter.battle_object);
-    // let param_setoff_mul = if analog > 0.0 && analog < 1.0 {
-    //     ((1.0 - analog) * 0.65 + param_setoff_mul / 1.5) * 1.5
-    // } else {
-    //     param_setoff_mul
-    // };
+    let analog = InputModule::get_analog_for_guard(fighter.battle_object);
+    let param_setoff_mul = if analog > 0.0 && analog < 1.0 {
+        ((1.0 - analog) * 0.65 + param_setoff_mul / 1.5) * 1.5
+    } else {
+        param_setoff_mul
+    };
 
     let mut shield_power = shield_power * setoff_mul * param_setoff_mul;
     let object_id = WorkModule::get_int(
@@ -240,12 +240,12 @@ unsafe fn sub_ftStatusUniqProcessGuardDamage_initStatus_Inner(fighter: &mut L2CF
         hash40("shield_setoff_speed_mul"),
     );
 
-    // let analog = InputModule::get_analog_for_guard(fighter.battle_object);
-    // let setoff_speed_mul = if analog > 0.0 && analog < 1.0 {
-    //     0.195 * (1.0 - analog) + setoff_speed_mul
-    // } else {
-    //     setoff_speed_mul
-    // };
+    let analog = InputModule::get_analog_for_guard(fighter.battle_object);
+    let setoff_speed_mul = if analog > 0.0 && analog < 1.0 {
+        0.195 * (1.0 - analog) + setoff_speed_mul
+    } else {
+        setoff_speed_mul
+    };
 
     let mut setoff_speed = shield_power * setoff_speed_mul;
 

--- a/fighters/common/src/general_statuses/shield/misc.rs
+++ b/fighters/common/src/general_statuses/shield/misc.rs
@@ -64,13 +64,13 @@ pub unsafe fn sub_guard_on_uniq(fighter: &mut L2CFighterCommon, arg: L2CValue) -
                 hash40("common"),
                 hash40("shield_dec1"),
             );
-            // let analog = InputModule::get_analog_for_guard(fighter.battle_object);
-            // let dec = if analog > 0.0 && analog < 1.0 {
-            //     let variable = 1.9 * analog;
-            //     (variable + 0.1) * shield_dec1 / 2.0
-            // } else {
-            let dec = shield_dec1;
-            // };
+            let analog = InputModule::get_analog_for_guard(fighter.battle_object);
+            let dec = if analog > 0.0 && analog < 1.0 {
+                let variable = 1.9 * analog;
+                (variable + 0.1) * shield_dec1 / 2.0
+            } else {
+                shield_dec1
+            };
 
             let shield_frame =
                 WorkModule::get_param_float(fighter.module_accessor, hash40("shield_frame"), 0);
@@ -408,12 +408,12 @@ pub unsafe fn status_guard_main_common(fighter: &mut L2CFighterCommon) -> L2CVal
         vars::common::instance::SHIELD_EFFECT_HANDLE,
     ) as u32;
 
-    // let analog = InputModule::get_analog_for_guard(fighter.object());
-    // if analog > 0.0 && analog < 1.0 {
-    //     EffectModule::set_alpha(fighter.module_accessor, handle as _, analog);
-    // } else {
-    //     EffectModule::set_alpha(fighter.module_accessor, handle as _, 1.0);
-    // }
+    let analog = InputModule::get_analog_for_guard(fighter.object());
+    if analog > 0.0 && analog < 1.0 {
+        EffectModule::set_alpha(fighter.module_accessor, handle as _, analog);
+    } else {
+        EffectModule::set_alpha(fighter.module_accessor, handle as _, 1.0);
+    }
 
     if shield < 0.0 {
         fighter.change_status(FIGHTER_STATUS_KIND_SHIELD_BREAK_FLY.into(), false.into());

--- a/fighters/common/src/misc.rs
+++ b/fighters/common/src/misc.rs
@@ -80,12 +80,12 @@ unsafe fn shield_pushback_analog(ctx: &skyline::hooks::InlineCtx) {
 
 pub fn install() {
     smashline::install_agent_resets!(fighter_reset);
-    // skyline::patching::Patch::in_text(0x6417f4).nop();
-    // skyline::patching::Patch::in_text(0x6285d0).nop();
+    skyline::patching::Patch::in_text(0x6417f4).nop();
+    skyline::patching::Patch::in_text(0x6285d0).nop();
     skyline::install_hooks!(
         steve_parry_stuff_fix,
-        // shield_damage_analog,
-        // shield_pushback_analog
+        shield_damage_analog,
+        shield_pushback_analog
     );
     //skyline::install_hooks!(
     //    set_hit_team_hook,


### PR DESCRIPTION
Assets: 
[parry-layout-assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11187705/parry-layout-assets.zip)

# General Summary
This pull requests brings back light shielding, a mechanic not seen in any Smash iteration (or platform fighter, to my knowledge) since Melee. Formulas for shield damage, shield pushback, attacker rebound, and shield stun have all been inspired by Melee but adapted to HDR.

Please understand that I am aware this is a controversial change, I make this PR because this has been my one singular passionate goal for Ultimate modding since February, 2021. I have been through iteration hell trying to get this working, and more importantly, **getting it working online**.

If this PR never gets merged that's alright with me, I will be content with having implemented. I just wanted to showcase it, and garner feedback and see how people feel. It would make me very happy if it got merged, but I do not expect it.

# Detailed Changes

## Trigger Thresholds
Due to some code mixups, this change actually also applies to the parry pull request (#1535).

In previous versions of HDR, Gamecube controller triggers get registered as digital button presses starting at 0.33 (this is not exactly 1/3 of the way down, this is after the Switch's HID driver's deadzones).

Now, analog values start getting registered between 0.1 and end at 0.8. Anything below 0.1 gets mapped to 0.0, and anything above 0.8 gets mapped to 1.0. Values between 0.1 and 0.8 get linearly interpolated between 0 and 1.0

This makes Gamecube triggers register earlier than what might be expected, and there might need to be additional logic performed on these to detect releases so that gamefeel continues to feel good. Thank you for patience!

## Shield Scaling
The maximum light shield has a radius of 2x the full hard shield of a character. Since this value is literally impossible to reach (would require an analog value of 0.0), the maximum radius is a little lower than that.

## Formulas
Where `A` is the analog value of the shield, and `setoff_mul` is a per-move value:

| Formula | Regular Shield | Light Shield |
|-|-|-|
| Shield Damage | `attack_power * 1.4` | `attack_power * (1.4 + 0.2 * (1.0 - A))` ||
| Shield Stun | `attack_power * setoff_mul * 0.55` | `attack_power * setoff_mul * ((1.0 - A) * 0.65 + 0.55 / 1.5) * 1.5` |
| Shield Pushback | `attack_power * 0.051` | `attack_power * (0.195 * (1.0 - A) + 0.051)` |
| Attacker Recoil | `attack_power * 0.04` | `attack_power * 0.04 * A * 0.1` |

Some of these formulas may be implemented incorrectly, it was very difficult to locate where to implement them, so I may change these over time.

Videos:
https://streamable.com/19671f
https://streamable.com/9lq0ou