### PR TITLE
Camera parameter standardization + camera adjustments

### DIFF
--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -27,13 +27,176 @@ unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::Inline
     asm!("fmov s1, w8", in("w8") target_interpolation_rate)
 }
 
+// The following hooks handle Unrestricted Camera
+#[skyline::hook(offset = 0x262286c, inline)]
+unsafe fn parse_stprm_pause_camera_min_fov(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_min_fov: f32 = 4e-44;
+    asm!("fmov s2, w8", in("w8") pause_camera_min_fov)
+}
+#[skyline::hook(offset = 0x2622a04, inline)]
+unsafe fn parse_stprm_pause_camera_max_fov(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_max_fov: f32 = 180.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_max_fov)
+}
+#[skyline::hook(offset = 0x2622acc, inline)]
+unsafe fn parse_stprm_pause_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_min_distance: f32 = 0.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_min_distance)
+}
+#[skyline::hook(offset = 0x2622c54, inline)]
+unsafe fn parse_stprm_pause_camera_max_distance(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_max_distance: f32 = 536870900.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_max_distance)
+}
+#[skyline::hook(offset = 0x2622d18, inline)]
+unsafe fn parse_stprm_pause_camera_limit_pos_top(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_pos_top: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_top)
+}
+#[skyline::hook(offset = 0x2622ddc, inline)]
+unsafe fn parse_stprm_pause_camera_limit_pos_bottom(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_pos_bottom: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_bottom)
+}
+#[skyline::hook(offset = 0x2622ea0, inline)]
+unsafe fn parse_stprm_pause_camera_limit_pos_left(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_pos_left: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_left)
+}
+#[skyline::hook(offset = 0x2622f64, inline)]
+unsafe fn parse_stprm_pause_camera_limit_pos_right(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_pos_right: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_right)
+}
+#[skyline::hook(offset = 0x2623028, inline)]
+unsafe fn parse_stprm_pause_camera_limit_angle_up(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_angle_up: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_up)
+}
+#[skyline::hook(offset = 0x26230f0, inline)]
+unsafe fn parse_stprm_pause_camera_limit_angle_down(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_angle_down: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_down)
+}
+#[skyline::hook(offset = 0x2623280, inline)]
+unsafe fn parse_stprm_pause_camera_limit_angle_left(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_angle_left: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_left)
+}
+#[skyline::hook(offset = 0x26231b8, inline)]
+unsafe fn parse_stprm_pause_camera_limit_angle_right(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_limit_angle_right: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_right)
+}
+#[skyline::hook(offset = 0x2623348, inline)]
+unsafe fn parse_stprm_pause_camera_gyro_limit_angle_up(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_gyro_limit_angle_up: f32 = 0.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_up)
+}
+#[skyline::hook(offset = 0x2623410, inline)]
+unsafe fn parse_stprm_pause_camera_gyro_limit_angle_down(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_gyro_limit_angle_down: f32 = 0.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_down)
+}
+#[skyline::hook(offset = 0x2623598, inline)]
+unsafe fn parse_stprm_pause_camera_gyro_limit_angle_left(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_gyro_limit_angle_left: f32 = 0.0;
+    asm!("fmov s0, w8", in("w8") pause_camera_gyro_limit_angle_left)
+}
+#[skyline::hook(offset = 0x26234d8, inline)]
+unsafe fn parse_stprm_pause_camera_gyro_limit_angle_right(ctx: &mut skyline::hooks::InlineCtx) {
+    let pause_camera_gyro_limit_angle_right: f32 = 0.0;
+    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_right)
+}
+#[skyline::hook(offset = 0x2621b24, inline)]
+unsafe fn parse_stprm_vr_camera_position_x_min(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_x_min: f32 = f32::NAN;
+    asm!("fmov s0, w8", in("w8") vr_camera_position_x_min)
+}
+#[skyline::hook(offset = 0x26158f8, inline)]
+unsafe fn parse_stprm_vr_camera_position_x_max(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_x_max: f32 = f32::NAN;
+    asm!("fmov s1, w8", in("w8") vr_camera_position_x_max)
+}
+#[skyline::hook(offset = 0x2621bd8, inline)]
+unsafe fn parse_stprm_vr_camera_position_y_min(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_y_min: f32 = f32::NAN;
+    asm!("fmov s1, w8", in("w8") vr_camera_position_y_min)
+}
+#[skyline::hook(offset = 0x26159b8, inline)]
+unsafe fn parse_stprm_vr_camera_position_y_max(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_y_max: f32 = f32::NAN;
+    asm!("fmov s2, w8", in("w8") vr_camera_position_y_max)
+}
+#[skyline::hook(offset = 0x2621c8c, inline)]
+unsafe fn parse_stprm_vr_camera_position_z_min(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_z_min: f32 = f32::NEG_INFINITY;
+    asm!("fmov s2, w8", in("w8") vr_camera_position_z_min)
+}
+#[skyline::hook(offset = 0x2615a78, inline)]
+unsafe fn parse_stprm_vr_camera_position_z_max(ctx: &mut skyline::hooks::InlineCtx) {
+    let vr_camera_position_z_max: f32 = f32::INFINITY;
+    asm!("fmov s3, w8", in("w8") vr_camera_position_z_max)
+}
+
+
+
 pub fn install() {
     unsafe {
+        // Stubs original target_interpolation_rate pull
         skyline::patching::Patch::in_text(0x2620fec).nop();
+
+        // Stubs original param pulls related to Unrestricted Camera
+        skyline::patching::Patch::in_text(0x262286c).nop();
+        skyline::patching::Patch::in_text(0x2622a04).nop();
+        skyline::patching::Patch::in_text(0x2622acc).nop();
+        skyline::patching::Patch::in_text(0x2622c54).nop();
+        skyline::patching::Patch::in_text(0x2622d18).nop();
+        skyline::patching::Patch::in_text(0x2622ddc).nop();
+        skyline::patching::Patch::in_text(0x2622ea0).nop();
+        skyline::patching::Patch::in_text(0x2622f64).nop();
+        skyline::patching::Patch::in_text(0x2623028).nop();
+        skyline::patching::Patch::in_text(0x26230f0).nop();
+        skyline::patching::Patch::in_text(0x2623280).nop();
+        skyline::patching::Patch::in_text(0x26231b8).nop();
+        skyline::patching::Patch::in_text(0x2623348).nop();
+        skyline::patching::Patch::in_text(0x2623410).nop();
+        skyline::patching::Patch::in_text(0x2623598).nop();
+        skyline::patching::Patch::in_text(0x26234d8).nop();
+        skyline::patching::Patch::in_text(0x2621b24).nop();
+        skyline::patching::Patch::in_text(0x26158f8).nop();
+        skyline::patching::Patch::in_text(0x2621bd8).nop();
+        skyline::patching::Patch::in_text(0x26159b8).nop();
+        skyline::patching::Patch::in_text(0x2621c8c).nop();
+        skyline::patching::Patch::in_text(0x2615a78).nop();
+        
     }
     skyline::install_hooks!(
         normal_camera,
         parse_stprm_normal_camera_min_distance,
-        parse_stprm_target_interpolation_rate
+        parse_stprm_target_interpolation_rate,
+
+        parse_stprm_pause_camera_min_fov,
+        parse_stprm_pause_camera_max_fov,
+        parse_stprm_pause_camera_min_distance,
+        parse_stprm_pause_camera_max_distance,
+        parse_stprm_pause_camera_limit_pos_top,
+        parse_stprm_pause_camera_limit_pos_bottom,
+        parse_stprm_pause_camera_limit_pos_left,
+        parse_stprm_pause_camera_limit_pos_right,
+        parse_stprm_pause_camera_limit_angle_up,
+        parse_stprm_pause_camera_limit_angle_down,
+        parse_stprm_pause_camera_limit_angle_left,
+        parse_stprm_pause_camera_limit_angle_right,
+        parse_stprm_pause_camera_gyro_limit_angle_up,
+        parse_stprm_pause_camera_gyro_limit_angle_down,
+        parse_stprm_pause_camera_gyro_limit_angle_left,
+        parse_stprm_pause_camera_gyro_limit_angle_right,
+        parse_stprm_vr_camera_position_x_min,
+        parse_stprm_vr_camera_position_x_max,
+        parse_stprm_vr_camera_position_y_min,
+        parse_stprm_vr_camera_position_y_max,
+        parse_stprm_vr_camera_position_z_min,
+        parse_stprm_vr_camera_position_z_max
     );
 }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -9,8 +9,53 @@ unsafe fn normal_camera(ptr: u64, float: f32) {
     call_original!(ptr, float);
 }
 
+// Standardizes normal_camera_min_distance for all stages
+#[skyline::hook(offset = 0x26209b8, inline)]
+unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
+    let normal_camera_min_distance: f32 = 125.0;
+    asm!("fmov s0, w8", in("w8") normal_camera_min_distance)
+}
+
+// Standardizes normal_camera_max_distance for all stages
+#[skyline::hook(offset = 0x2620a7c, inline)]
+unsafe fn parse_stprm_normal_camera_max_distance(ctx: &mut skyline::hooks::InlineCtx) {
+    let normal_camera_max_distance: f32 = 1000.0;
+    asm!("fmov s0, w8", in("w8") normal_camera_max_distance)
+}
+
+// Standardizes normal_camera_vertical_angle and normal_camera_look_down_vertical_angle for all stages
+#[skyline::hook(offset = 0x2620e50, inline)]
+unsafe fn parse_stprm_normal_camera_angles(ctx: &mut skyline::hooks::InlineCtx) {
+    let hash = *ctx.registers[18].x.as_ref();
+    let mut angle: f32 = 0.0;
+    if hash == hash40("normal_camera_vertical_angle") {
+        angle = -5.5;
+    }
+    else if hash == hash40("normal_camera_look_down_vertical_angle") {
+        angle = -25.0;
+    }
+    asm!("fmov s0, w8", in("w8") angle)
+}
+
+// Standardizes target_interpolation_rate for all stages
+#[skyline::hook(offset = 0x2620fec, inline)]
+unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::InlineCtx) {
+    let target_interpolation_rate: f32 = 1.0;
+    asm!("fmov s1, w8", in("w8") target_interpolation_rate)
+}
+
 pub fn install() {
+    unsafe {
+        skyline::patching::Patch::in_text(0x26209b8).nop();
+        skyline::patching::Patch::in_text(0x2620a7c).nop();
+        skyline::patching::Patch::in_text(0x2620e50).nop();
+        skyline::patching::Patch::in_text(0x2620fec).nop();
+    }
     skyline::install_hooks!(
-        normal_camera
+        normal_camera,
+        parse_stprm_normal_camera_min_distance,
+        parse_stprm_normal_camera_max_distance,
+        parse_stprm_normal_camera_angles,
+        parse_stprm_target_interpolation_rate
     );
 }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -23,7 +23,7 @@ unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::Inlin
 // Standardizes target_interpolation_rate for all stages
 #[skyline::hook(offset = 0x2620fec, inline)]
 unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::InlineCtx) {
-    let target_interpolation_rate: f32 = 1.0;
+    let target_interpolation_rate: f32 = 0.9;
     asm!("fmov s1, w8", in("w8") target_interpolation_rate)
 }
 

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -9,234 +9,81 @@ unsafe fn normal_camera(ptr: u64, float: f32) {
     call_original!(ptr, float);
 }
 
-// Standardizes normal_camera_min_distance for all stages
-#[skyline::hook(offset = 0x26209bc, inline)]
-unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
-    let normal_camera_min_distance: f32;
-    asm!("fmov w20, s0", out("w20") normal_camera_min_distance);
-    if normal_camera_min_distance < 120.0 {
-        let normal_camera_min_distance: f32 = 120.0;
-        asm!("fmov s0, w8", in("w8") normal_camera_min_distance);
-    }
+#[repr(C)]
+pub struct NormalCameraParams {
+    pub normal_camera_min_distance: f32,
+    pub normal_camera_max_distance: f32,
+    pub normal_camera_min_distance_2: f32,
+    pub swing_rate_x: f32,
+    pub swing_rate_y: f32,
+    pub unk: [f32; 7],
+    pub normal_camera_vertical_angle: f32,
+    pub normal_camera_fov: f32,
+    pub target_interpolation_rate: f32,
+    // others...
 }
 
-// Standardizes swing_rate_x for all stages
-#[skyline::hook(offset = 0x2620c04, inline)]
-unsafe fn parse_stprm_swing_rate_x(ctx: &mut skyline::hooks::InlineCtx) {
-    let swing_rate_x: f32 = 0.0;
-    asm!("fmov s0, w8", in("w8") swing_rate_x)
-}
-
-// Standardizes swing_rate_y for all stages
-#[skyline::hook(offset = 0x2620cc8, inline)]
-unsafe fn parse_stprm_swing_rate_y(ctx: &mut skyline::hooks::InlineCtx) {
-    let swing_rate_y: f32 = 0.0;
-    asm!("fmov s0, w8", in("w8") swing_rate_y)
-}
-
-// Standardizes normal_camera_vertical_angle and normal_camera_look_down_vertical_angle for all stages
-#[skyline::hook(offset = 0x2620e54, inline)]
-unsafe fn parse_stprm_normal_camera_angles(ctx: &mut skyline::hooks::InlineCtx) {
-    let hash = *ctx.registers[18].x.as_ref();
-    let mut angle: f32 = 0.0;
-    asm!("fmov w20, s0", out("w20") angle);
-    if hash == hash40("normal_camera_vertical_angle") {
-        if angle < -5.0 {
-            angle = -5.0;
-        }
-    }
-    else if hash == hash40("normal_camera_look_down_vertical_angle") {
-        if angle < -25.0 {
-            angle = -25.0;
-        }
-    }
-    asm!("fmov s0, w8", in("w8") angle)
-}
-
-// Standardizes target_interpolation_rate for all stages
-#[skyline::hook(offset = 0x2620fec, inline)]
-unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::InlineCtx) {
-    let target_interpolation_rate: f32 = 0.9;
-    asm!("fmov s1, w8", in("w8") target_interpolation_rate)
-}
-
-// The following hooks handle Unrestricted Camera
-#[skyline::hook(offset = 0x262286c, inline)]
-unsafe fn parse_stprm_pause_camera_min_fov(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_min_fov: f32 = 4e-44;
-    asm!("fmov s2, w8", in("w8") pause_camera_min_fov)
-}
-#[skyline::hook(offset = 0x2622a04, inline)]
-unsafe fn parse_stprm_pause_camera_max_fov(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_max_fov: f32 = 180.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_max_fov)
-}
-#[skyline::hook(offset = 0x2622acc, inline)]
-unsafe fn parse_stprm_pause_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_min_distance: f32 = 0.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_min_distance)
-}
-#[skyline::hook(offset = 0x2622c54, inline)]
-unsafe fn parse_stprm_pause_camera_max_distance(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_max_distance: f32 = 536870900.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_max_distance)
-}
-#[skyline::hook(offset = 0x2622d18, inline)]
-unsafe fn parse_stprm_pause_camera_limit_pos_top(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_pos_top: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_top)
-}
-#[skyline::hook(offset = 0x2622ddc, inline)]
-unsafe fn parse_stprm_pause_camera_limit_pos_bottom(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_pos_bottom: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_bottom)
-}
-#[skyline::hook(offset = 0x2622ea0, inline)]
-unsafe fn parse_stprm_pause_camera_limit_pos_left(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_pos_left: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_left)
-}
-#[skyline::hook(offset = 0x2622f64, inline)]
-unsafe fn parse_stprm_pause_camera_limit_pos_right(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_pos_right: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_pos_right)
-}
-#[skyline::hook(offset = 0x2623028, inline)]
-unsafe fn parse_stprm_pause_camera_limit_angle_up(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_angle_up: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_up)
-}
-#[skyline::hook(offset = 0x26230f0, inline)]
-unsafe fn parse_stprm_pause_camera_limit_angle_down(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_angle_down: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_down)
-}
-#[skyline::hook(offset = 0x2623280, inline)]
-unsafe fn parse_stprm_pause_camera_limit_angle_left(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_angle_left: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_left)
-}
-#[skyline::hook(offset = 0x26231b8, inline)]
-unsafe fn parse_stprm_pause_camera_limit_angle_right(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_limit_angle_right: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") pause_camera_limit_angle_right)
-}
-#[skyline::hook(offset = 0x2623348, inline)]
-unsafe fn parse_stprm_pause_camera_gyro_limit_angle_up(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_gyro_limit_angle_up: f32 = 0.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_up)
-}
-#[skyline::hook(offset = 0x2623410, inline)]
-unsafe fn parse_stprm_pause_camera_gyro_limit_angle_down(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_gyro_limit_angle_down: f32 = 0.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_down)
-}
-#[skyline::hook(offset = 0x2623598, inline)]
-unsafe fn parse_stprm_pause_camera_gyro_limit_angle_left(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_gyro_limit_angle_left: f32 = 0.0;
-    asm!("fmov s0, w8", in("w8") pause_camera_gyro_limit_angle_left)
-}
-#[skyline::hook(offset = 0x26234d8, inline)]
-unsafe fn parse_stprm_pause_camera_gyro_limit_angle_right(ctx: &mut skyline::hooks::InlineCtx) {
-    let pause_camera_gyro_limit_angle_right: f32 = 0.0;
-    asm!("fmov s2, w8", in("w8") pause_camera_gyro_limit_angle_right)
-}
-#[skyline::hook(offset = 0x2621b24, inline)]
-unsafe fn parse_stprm_vr_camera_position_x_min(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_x_min: f32 = f32::NAN;
-    asm!("fmov s0, w8", in("w8") vr_camera_position_x_min)
-}
-#[skyline::hook(offset = 0x26158f8, inline)]
-unsafe fn parse_stprm_vr_camera_position_x_max(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_x_max: f32 = f32::NAN;
-    asm!("fmov s1, w8", in("w8") vr_camera_position_x_max)
-}
-#[skyline::hook(offset = 0x2621bd8, inline)]
-unsafe fn parse_stprm_vr_camera_position_y_min(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_y_min: f32 = f32::NAN;
-    asm!("fmov s1, w8", in("w8") vr_camera_position_y_min)
-}
-#[skyline::hook(offset = 0x26159b8, inline)]
-unsafe fn parse_stprm_vr_camera_position_y_max(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_y_max: f32 = f32::NAN;
-    asm!("fmov s2, w8", in("w8") vr_camera_position_y_max)
-}
-#[skyline::hook(offset = 0x2621c8c, inline)]
-unsafe fn parse_stprm_vr_camera_position_z_min(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_z_min: f32 = f32::NEG_INFINITY;
-    asm!("fmov s2, w8", in("w8") vr_camera_position_z_min)
-}
-#[skyline::hook(offset = 0x2615a78, inline)]
-unsafe fn parse_stprm_vr_camera_position_z_max(ctx: &mut skyline::hooks::InlineCtx) {
-    let vr_camera_position_z_max: f32 = f32::INFINITY;
-    asm!("fmov s3, w8", in("w8") vr_camera_position_z_max)
+#[skyline::hook(offset = 0x26207f0)]
+pub fn parse_stprm_active_camera_params(param_obj: u64, params: &mut NormalCameraParams) {
+    call_original!(param_obj, params);
+    params.normal_camera_min_distance = params.normal_camera_min_distance.max(120.0);
+    params.normal_camera_min_distance_2 = params.normal_camera_min_distance_2.max(120.0);
+    params.swing_rate_x = 0.0;
+    params.swing_rate_y = 0.0;
+    params.normal_camera_vertical_angle = params.normal_camera_vertical_angle.max(-5.0_f32.to_radians());
+    params.target_interpolation_rate = 0.9;
 }
 
 
+#[repr(C)]
+pub struct PauseCameraParams {
+    pub pause_camera_min_fov: f32,
+    pub pause_camera_fov: f32,
+    pub pause_camera_max_fov: f32,
+    pub pause_camera_min_distance: f32,
+    pub pause_camera_initial_distance: f32,
+    pub pause_camera_max_distance: f32,
+    pub pause_camera_limit_pos_top: f32,
+    pub pause_camera_limit_pos_bottom: f32,
+    pub pause_camera_limit_pos_right: f32,
+    pub pause_camera_limit_pos_left: f32,
+    pub pause_camera_limit_angle_up: f32,
+    pub pause_camera_limit_angle_down: f32,
+    pub pause_camera_limit_angle_right: f32,
+    pub pause_camera_limit_angle_left: f32,
+    pub pause_camera_gyro_limit_angle_up: f32,
+    pub pause_camera_gyro_limit_angle_down: f32,
+    pub pause_camera_gyro_limit_angle_right: f32,
+    pub pause_camera_gyro_limit_angle_left: f32,
+    // others...
+}
+
+// The following function hook handles Unrestricted Camera
+#[skyline::hook(offset = 0x26226b0)]
+pub fn parse_stprm_pause_camera_params(param_obj: u64, params: &mut PauseCameraParams) {
+    call_original!(param_obj, params);
+    params.pause_camera_min_fov = 4e-44_f32.to_radians();
+    params.pause_camera_max_fov = 180.0_f32.to_radians();
+    params.pause_camera_min_distance = 0.0;
+    params.pause_camera_max_distance = 536870900.0;
+    params.pause_camera_limit_pos_top = f32::NAN;
+    params.pause_camera_limit_pos_bottom = f32::NAN;
+    params.pause_camera_limit_pos_right = f32::NAN;
+    params.pause_camera_limit_pos_left = f32::NAN;
+    params.pause_camera_limit_angle_up = f32::NAN;
+    params.pause_camera_limit_angle_down = f32::NAN;
+    params.pause_camera_limit_angle_right = f32::NAN;
+    params.pause_camera_limit_angle_left = f32::NAN;
+    params.pause_camera_gyro_limit_angle_up = 0.0;
+    params.pause_camera_gyro_limit_angle_down = 0.0;
+    params.pause_camera_gyro_limit_angle_right = 0.0;
+    params.pause_camera_gyro_limit_angle_left = 0.0;
+}
 
 pub fn install() {
-    unsafe {
-        // Stubs original swing_rate_x pull
-        skyline::patching::Patch::in_text(0x2620c04).nop();
-        // Stubs original swing_rate_y pull
-        skyline::patching::Patch::in_text(0x2620cc8).nop();
-        // Stubs original target_interpolation_rate pull
-        skyline::patching::Patch::in_text(0x2620fec).nop();
-
-        // Stubs original param pulls related to Unrestricted Camera
-        skyline::patching::Patch::in_text(0x262286c).nop();
-        skyline::patching::Patch::in_text(0x2622a04).nop();
-        skyline::patching::Patch::in_text(0x2622acc).nop();
-        skyline::patching::Patch::in_text(0x2622c54).nop();
-        skyline::patching::Patch::in_text(0x2622d18).nop();
-        skyline::patching::Patch::in_text(0x2622ddc).nop();
-        skyline::patching::Patch::in_text(0x2622ea0).nop();
-        skyline::patching::Patch::in_text(0x2622f64).nop();
-        skyline::patching::Patch::in_text(0x2623028).nop();
-        skyline::patching::Patch::in_text(0x26230f0).nop();
-        skyline::patching::Patch::in_text(0x2623280).nop();
-        skyline::patching::Patch::in_text(0x26231b8).nop();
-        skyline::patching::Patch::in_text(0x2623348).nop();
-        skyline::patching::Patch::in_text(0x2623410).nop();
-        skyline::patching::Patch::in_text(0x2623598).nop();
-        skyline::patching::Patch::in_text(0x26234d8).nop();
-        skyline::patching::Patch::in_text(0x2621b24).nop();
-        skyline::patching::Patch::in_text(0x26158f8).nop();
-        skyline::patching::Patch::in_text(0x2621bd8).nop();
-        skyline::patching::Patch::in_text(0x26159b8).nop();
-        skyline::patching::Patch::in_text(0x2621c8c).nop();
-        skyline::patching::Patch::in_text(0x2615a78).nop();
-        
-    }
     skyline::install_hooks!(
         normal_camera,
-        parse_stprm_normal_camera_min_distance,
-        parse_stprm_swing_rate_x,
-        parse_stprm_swing_rate_y,
-        parse_stprm_normal_camera_angles,
-        parse_stprm_target_interpolation_rate,
-
-        parse_stprm_pause_camera_min_fov,
-        parse_stprm_pause_camera_max_fov,
-        parse_stprm_pause_camera_min_distance,
-        parse_stprm_pause_camera_max_distance,
-        parse_stprm_pause_camera_limit_pos_top,
-        parse_stprm_pause_camera_limit_pos_bottom,
-        parse_stprm_pause_camera_limit_pos_left,
-        parse_stprm_pause_camera_limit_pos_right,
-        parse_stprm_pause_camera_limit_angle_up,
-        parse_stprm_pause_camera_limit_angle_down,
-        parse_stprm_pause_camera_limit_angle_left,
-        parse_stprm_pause_camera_limit_angle_right,
-        parse_stprm_pause_camera_gyro_limit_angle_up,
-        parse_stprm_pause_camera_gyro_limit_angle_down,
-        parse_stprm_pause_camera_gyro_limit_angle_left,
-        parse_stprm_pause_camera_gyro_limit_angle_right,
-        parse_stprm_vr_camera_position_x_min,
-        parse_stprm_vr_camera_position_x_max,
-        parse_stprm_vr_camera_position_y_min,
-        parse_stprm_vr_camera_position_y_max,
-        parse_stprm_vr_camera_position_z_min,
-        parse_stprm_vr_camera_position_z_max
+        parse_stprm_active_camera_params,
+        parse_stprm_pause_camera_params
     );
 }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -14,10 +14,17 @@ unsafe fn normal_camera(ptr: u64, float: f32) {
 unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
     let normal_camera_min_distance: f32;
     asm!("fmov w20, s0", out("w20") normal_camera_min_distance);
-    if normal_camera_min_distance < 125.0 {
-        let normal_camera_min_distance: f32 = 125.0;
+    if normal_camera_min_distance < 120.0 {
+        let normal_camera_min_distance: f32 = 120.0;
         asm!("fmov s0, w8", in("w8") normal_camera_min_distance);
     }
+}
+
+// Standardizes swing_rate_x for all stages
+#[skyline::hook(offset = 0x2620c04, inline)]
+unsafe fn parse_stprm_swing_rate_x(ctx: &mut skyline::hooks::InlineCtx) {
+    let swing_rate_x: f32 = 0.0;
+    asm!("fmov s0, w8", in("w8") swing_rate_x)
 }
 
 // Standardizes swing_rate_y for all stages
@@ -169,6 +176,8 @@ unsafe fn parse_stprm_vr_camera_position_z_max(ctx: &mut skyline::hooks::InlineC
 
 pub fn install() {
     unsafe {
+        // Stubs original swing_rate_x pull
+        skyline::patching::Patch::in_text(0x2620c04).nop();
         // Stubs original swing_rate_y pull
         skyline::patching::Patch::in_text(0x2620cc8).nop();
         // Stubs original target_interpolation_rate pull
@@ -202,6 +211,7 @@ pub fn install() {
     skyline::install_hooks!(
         normal_camera,
         parse_stprm_normal_camera_min_distance,
+        parse_stprm_swing_rate_x,
         parse_stprm_swing_rate_y,
         parse_stprm_normal_camera_angles,
         parse_stprm_target_interpolation_rate,

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -29,7 +29,6 @@ unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::Inline
 
 pub fn install() {
     unsafe {
-        skyline::patching::Patch::in_text(0x2620e50).nop();
         skyline::patching::Patch::in_text(0x2620fec).nop();
     }
     skyline::install_hooks!(

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -20,20 +20,6 @@ unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::Inlin
     }
 }
 
-// Standardizes normal_camera_vertical_angle and normal_camera_look_down_vertical_angle for all stages
-#[skyline::hook(offset = 0x2620e50, inline)]
-unsafe fn parse_stprm_normal_camera_angles(ctx: &mut skyline::hooks::InlineCtx) {
-    let hash = *ctx.registers[18].x.as_ref();
-    let mut angle: f32 = 0.0;
-    if hash == hash40("normal_camera_vertical_angle") {
-        angle = -5.5;
-    }
-    else if hash == hash40("normal_camera_look_down_vertical_angle") {
-        angle = -25.0;
-    }
-    asm!("fmov s0, w8", in("w8") angle)
-}
-
 // Standardizes target_interpolation_rate for all stages
 #[skyline::hook(offset = 0x2620fec, inline)]
 unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::InlineCtx) {
@@ -49,7 +35,6 @@ pub fn install() {
     skyline::install_hooks!(
         normal_camera,
         parse_stprm_normal_camera_min_distance,
-        parse_stprm_normal_camera_angles,
         parse_stprm_target_interpolation_rate
     );
 }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -23,7 +23,7 @@ unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::Inlin
 // Standardizes swing_rate_y for all stages
 #[skyline::hook(offset = 0x2620cc8, inline)]
 unsafe fn parse_stprm_swing_rate_y(ctx: &mut skyline::hooks::InlineCtx) {
-    let swing_rate_y: f32 = 0.1;
+    let swing_rate_y: f32 = 0.0;
     asm!("fmov s0, w8", in("w8") swing_rate_y)
 }
 
@@ -34,12 +34,12 @@ unsafe fn parse_stprm_normal_camera_angles(ctx: &mut skyline::hooks::InlineCtx) 
     let mut angle: f32 = 0.0;
     asm!("fmov w20, s0", out("w20") angle);
     if hash == hash40("normal_camera_vertical_angle") {
-        if angle == -5.0 {
-            angle = -5.5;
+        if angle < -5.0 {
+            angle = -5.0;
         }
     }
     else if hash == hash40("normal_camera_look_down_vertical_angle") {
-        if angle == -22.0 {
+        if angle < -25.0 {
             angle = -25.0;
         }
     }

--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -10,17 +10,14 @@ unsafe fn normal_camera(ptr: u64, float: f32) {
 }
 
 // Standardizes normal_camera_min_distance for all stages
-#[skyline::hook(offset = 0x26209b8, inline)]
+#[skyline::hook(offset = 0x26209bc, inline)]
 unsafe fn parse_stprm_normal_camera_min_distance(ctx: &mut skyline::hooks::InlineCtx) {
-    let normal_camera_min_distance: f32 = 125.0;
-    asm!("fmov s0, w8", in("w8") normal_camera_min_distance)
-}
-
-// Standardizes normal_camera_max_distance for all stages
-#[skyline::hook(offset = 0x2620a7c, inline)]
-unsafe fn parse_stprm_normal_camera_max_distance(ctx: &mut skyline::hooks::InlineCtx) {
-    let normal_camera_max_distance: f32 = 1000.0;
-    asm!("fmov s0, w8", in("w8") normal_camera_max_distance)
+    let normal_camera_min_distance: f32;
+    asm!("fmov w20, s0", out("w20") normal_camera_min_distance);
+    if normal_camera_min_distance < 125.0 {
+        let normal_camera_min_distance: f32 = 125.0;
+        asm!("fmov s0, w8", in("w8") normal_camera_min_distance);
+    }
 }
 
 // Standardizes normal_camera_vertical_angle and normal_camera_look_down_vertical_angle for all stages
@@ -46,15 +43,12 @@ unsafe fn parse_stprm_target_interpolation_rate(ctx: &mut skyline::hooks::Inline
 
 pub fn install() {
     unsafe {
-        skyline::patching::Patch::in_text(0x26209b8).nop();
-        skyline::patching::Patch::in_text(0x2620a7c).nop();
         skyline::patching::Patch::in_text(0x2620e50).nop();
         skyline::patching::Patch::in_text(0x2620fec).nop();
     }
     skyline::install_hooks!(
         normal_camera,
         parse_stprm_normal_camera_min_distance,
-        parse_stprm_normal_camera_max_distance,
         parse_stprm_normal_camera_angles,
         parse_stprm_target_interpolation_rate
     );


### PR DESCRIPTION
This programmatically standardizes some of the camera's parameters to be the same *across all stages*, without needing to individually edit each stage's .stprm file.

The following parameters have been standardized:
- Minimum camera zoom
- Target interpolation rate (character tracking speed)
- Camera horizontal rotation rate
- Camera vertical rotation rate
- Unrestricted Camera parameters

Along with this, some changes have been made to the normal battle camera:
- Minimum camera zoom value has been increased from 100 -> 120, meaning the camera will be less zoomed in when characters are close together
- Target interpolation rate has been decreased from 1.0 -> 0.9
- Horizontal rotation rate has been decreased from 0.1 -> 0.0
- Vertical rotation rate has been decreased from 0.1 -> 0.0

*These 4 changes should alleviate some issues regarding camera disorientation.*

Minimum zoom before:

![image](https://user-images.githubusercontent.com/47401664/231798951-fd27cc5b-7e59-4307-9a9c-760d2a0212fd.png)

Minimum zoom after:

![image](https://user-images.githubusercontent.com/47401664/231799006-ea53178e-de9d-4e1d-940f-05f9d08007d0.png)


The new minimum zoom value should more closely match Melee/PM in how much space characters take up on screen, as you can see below:

![minzoomcompare](https://user-images.githubusercontent.com/47401664/231799543-53c99bbe-45bb-4891-9fbc-bb64efc20074.png)

To be merged with HDR-Development/hdr-private#332