### PR TITLE
Little Mac - grounded Jolt Haymaker bugfix

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -129,7 +129,9 @@ unsafe fn skip_early_main_status(boma: *mut BattleObjectModuleAccessor, status_k
         || ((*boma).kind() == *FIGHTER_KIND_MIIGUNNER
             && [*FIGHTER_STATUS_KIND_SPECIAL_HI].contains(&status_kind))
         || ((*boma).kind() == *FIGHTER_KIND_GEKKOUGA
-            && [*FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind)) )
+            && [*FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind))
+        || ((*boma).kind() == *FIGHTER_KIND_LITTLEMAC
+            && [*FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP].contains(&status_kind)) )
     {
         return true;
     }

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -129,9 +129,7 @@ unsafe fn skip_early_main_status(boma: *mut BattleObjectModuleAccessor, status_k
         || ((*boma).kind() == *FIGHTER_KIND_MIIGUNNER
             && [*FIGHTER_STATUS_KIND_SPECIAL_HI].contains(&status_kind))
         || ((*boma).kind() == *FIGHTER_KIND_GEKKOUGA
-            && [*FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind))
-        || ((*boma).kind() == *FIGHTER_KIND_LITTLEMAC
-            && [*FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP].contains(&status_kind)) )
+            && [*FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind)) )
     {
         return true;
     }

--- a/fighters/littlemac/src/status.rs
+++ b/fighters/littlemac/src/status.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 mod special_n_cancel;
+mod special_s;
  
 pub fn install() {
     special_n_cancel::install();
+    special_s::install();
 }
 
 pub fn add_statuses() {

--- a/fighters/littlemac/src/status/special_s.rs
+++ b/fighters/littlemac/src/status/special_s.rs
@@ -1,0 +1,15 @@
+use super::*;
+use globals::*;
+
+
+#[status_script(agent = "littlemac", status = FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn special_s_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    ControlModule::reset_trigger(fighter.module_accessor);
+    original!(fighter)
+}
+
+pub fn install() {
+    install_status_scripts!(
+        special_s_jump_main
+    );
+}


### PR DESCRIPTION
Fixes an issue where grounded Jolt Haymaker would immediately transition into the swing unless Special was only pressed for a single frame