### PR TITLE
Mario Throw Changes

### DIFF
--- a/fighters/mario/src/acmd/throws.rs
+++ b/fighters/mario/src/acmd/throws.rs
@@ -73,12 +73,42 @@ unsafe fn mario_pivotgrab(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "mario", script = "game_throwb", category = ACMD_GAME, low_priority )]
+unsafe fn game_throwb(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 11.0, 45, 76, 0, 75, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+    }
+    frame(lua_state, 13.0);
+    if is_excute(fighter) {
+        ATTACK_IGNORE_THROW(fighter, 0, 0, Hash40::new("hip"), 8.0, 50, 70, 0, 100, 4.0, -1.0, 6.0, 0.0, Some(-3.2), Some(13.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_THROW);
+    }
+    frame(lua_state, 40.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        REVERSE_LR(fighter);
+    }
+    frame(lua_state, 43.0);
+    if is_excute(fighter) {
+        CHECK_FINISH_CAMERA(fighter, 14, 7);
+    }
+    frame(lua_state, 44.0);
+    if is_excute(fighter) {
+        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
+        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
+        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+    }
+}
+
 #[acmd_script( agent = "mario", script = "game_throwhi", category = ACMD_GAME, low_priority )]
 unsafe fn game_throwhi(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 90, 92, 0, 70, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 90, 90, 0, 70, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 17.0);
@@ -99,7 +129,7 @@ unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 74, 105, 0, 50, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 90, 90, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 17.0);
@@ -118,6 +148,7 @@ pub fn install() {
         mario_grab,
         mario_dashgrab,
         mario_pivotgrab,
+        game_throwb,
         game_throwhi,
         game_throwlw,
     );


### PR DESCRIPTION
Changes: 
-Back Throw-

- [+] KGB is increased from 66 -> 76
- [+] BKB is increased from 70 -> 75
- On the ledge of battlefield with inkling, it kills at 150 with perfect di compared to 171.

-Up Throw- 

- [+] KGB decreased from 92 -> 90
- [+] Damage decreased from 7 -> 6
- These are very small changes so that up throw can still be used a bit more at low percents.

-Down throw-

- [+] Angle has been changed from 74 -> 90
- [+] KGB decreased from 105 -> 90
- [-] BKB increased from 50 -> 60
- [-] Damage changed from 6 -> 7

At its core, these changes are here to buff both back throw and down throw (up throw is negligible but I don't want it to be useless). Back throw can now kill slightly earlier than it can originally but doesn't overshadows doc's back throw (which kills at like 125 or 130). Down throw's angle changed to be like melee (or pm) mario's down throw without the chain grabs.

Note: I want this to be merged after the recovery changes, mario's up b is already broken, I don't want his grabs to further enhance it.