### PR TITLE
Luigi followup recovery adjustments

### DIFF
--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -202,10 +202,12 @@ unsafe fn sound_specialairn(fighter: &mut L2CAgentBase) {
 unsafe fn game_specialairsstart(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    //frame(lua_state, 1.0);
-    //if is_excute(fighter) {
-        //KineticModule::mul_speed(boma, &Vector3f{x: 1.0, y: 0.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-    //}
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        if KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) < 0.0 {
+            KineticModule::mul_speed(boma, &Vector3f{x: 1.0, y: 0.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        }
+    }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_LUIGI_STATUS_SPECIAL_S_FLAG_REVERSE_LR);

--- a/fighters/luigi/src/opff.rs
+++ b/fighters/luigi/src/opff.rs
@@ -11,9 +11,18 @@ use globals::*;
 //    }
 //}
 
+unsafe fn special_hi_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_DROP) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            fighter.change_status_req(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_LANDING_FALL, false);
+        }
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     //luigi_missle_ledgegrab(fighter);
     special_s_charge_init(fighter, status_kind);
+    special_hi_proper_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LUIGI )]


### PR DESCRIPTION
### SideB:
- Resets vertical speed in the air like before, *only* if you were descending (works like downB now)

### UpB:
- Is able to land much earlier into the animation now; Luigi no longer has to turn completely upside down before landing