### PR TITLE
Steve recovery sweep

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -642,6 +642,7 @@ pub mod vars {
             pub const IS_CURRENT_ATTACK_LW3_SOUL_FIRE: i32 = 0x0100;
             pub const TUMBLE_START: i32 = 0x0101;
             pub const IS_IN_TUMBLE: i32 = 0x0102;
+            pub const DISABLE_SPECIAL_S: i32 = 0x0103;
         }
         pub mod status {
             // floats

--- a/fighters/pickel/src/acmd/aerials.rs
+++ b/fighters/pickel/src/acmd/aerials.rs
@@ -460,24 +460,19 @@ unsafe fn pickel_attack_air_lw_game(fighter: &mut L2CAgentBase) {
 unsafe fn pickel_attack_air_lw2_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter){
-        let stop_rise  = smash::phx::Vector3f { x: 1.0, y: 0.0, z: 1.0 };
-        KineticModule::mul_speed(boma, &stop_rise, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-    }
-    frame(lua_state, 7.0);
     if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 65, 75, 0, 75, 5.5, 0.0, -3.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 275, 70, 0, 10, 5.5, 0.0, -3.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        WorkModule::on_flag(boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_FLAG_REQUEST_REMOVE_HAVE_CRAFT_WEAPON);
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_LANDING_CLEAR_SPEED);
+        //WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_SPEED_OPERATION_CHK);
+        //WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_SPEED_OPERATION_CHK);
+        KineticModule::suspend_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
     }
-    wait(lua_state, 5.0);
+    frame(lua_state, 20.0);
     if is_excute(fighter) {
-        AttackModule::clear_all(boma);
+        KineticModule::resume_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
     }
         
 }
-
-
-
 pub fn install() {
     install_acmd_scripts!(
         //pickel_attack_air_n_game,

--- a/fighters/pickel/src/acmd/other.rs
+++ b/fighters/pickel/src/acmd/other.rs
@@ -213,32 +213,6 @@ unsafe fn pickel_fire_attack_lw3_game(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "pickel_fire", script = "effect_attacklw3" , category = ACMD_EFFECT , low_priority)]
-unsafe fn pickel_fire_attack_lw3_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
-    if is_excute(fighter) {
-        if VarModule::is_flag(owner_module_accessor.object(), vars::pickel::instance::IS_CURRENT_ATTACK_LW3_SOUL_FIRE){
-            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
-            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
-            LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.25, 1.0);
-        }
-        else {
-            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
-            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
-        }
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        EFFECT_DETACH_KIND(fighter, Hash40::new("pickel_fire_soot"), -1);
-    }
-    frame(lua_state, 38.0);
-    if is_excute(fighter) {
-        EFFECT_DETACH_KIND(fighter, Hash40::new("pickel_fire"), -1);
-    }
-}
-
 #[acmd_script( agent = "pickel", script = "game_escapeair" , category = ACMD_GAME , low_priority)]
 unsafe fn escape_air_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -270,6 +244,56 @@ unsafe fn escape_air_slide_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "pickel_fire", script = "effect_attacklw3" , category = ACMD_EFFECT , low_priority)]
+unsafe fn pickel_fire_attack_lw3_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
+    if is_excute(fighter) {
+        if VarModule::is_flag(owner_module_accessor.object(), vars::pickel::instance::IS_CURRENT_ATTACK_LW3_SOUL_FIRE){
+            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
+            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
+            LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.25, 1.0);
+        }
+        else {
+            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
+            EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
+        }
+    }
+    frame(lua_state, 30.0);
+    if is_excute(fighter) {
+        EFFECT_DETACH_KIND(fighter, Hash40::new("pickel_fire_soot"), -1);
+    }
+    frame(lua_state, 38.0);
+    if is_excute(fighter) {
+        EFFECT_DETACH_KIND(fighter, Hash40::new("pickel_fire"), -1);
+    }
+}
+
+#[acmd_script( agent = "pickel_trolley", script = "game_specialsdriveemptypartial", category = ACMD_GAME, low_priority )]
+unsafe fn pickel_trolley_drive_empty(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        WorkModule::on_flag(boma, *WEAPON_PICKEL_TROLLEY_INSTANCE_WORK_ID_FLAG_NO_ATTACK_HIT_MOTION);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 1.0, 0.0, 5.0, 6.0, Some(0.0), Some(0.0), Some(6.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 60, true, false, false, false, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        AttackModule::set_ignore_ground_shield(boma, 0, true);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 1.0, 0.0, 5.0, -6.0, Some(0.0), Some(0.0), Some(-6.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 60, true, false, false, false, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        AttackModule::set_ignore_ground_shield(boma, 1, true);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 1.0, 0.0, 0.0, 6.0, Some(0.0), Some(0.0), Some(-6.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 60, true, false, false, false, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        AttackModule::set_ignore_ground_shield(boma, 2, true);
+        ATTACK(fighter, 3, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 3.5, 0.0, 3.0, 3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 60, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_IIE, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 4, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 3.5, 0.0, 3.0, 3.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, f32::NAN, 0.0, 60, false, false, false, false, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        AttackModule::set_down_only(boma, 4, true);
+    }
+    wait(lua_state, 6.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 5, 0, Hash40::new("top"), 7.0, 60, 64, 0, 66, 1.5, 0.0, 3.0, 1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, f32::NAN, 0.0, 60, false, false, false, false, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        WorkModule::off_flag(boma, *WEAPON_PICKEL_TROLLEY_INSTANCE_WORK_ID_FLAG_NO_ATTACK_HIT_MOTION);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         escape_air_game,
@@ -277,13 +301,16 @@ pub fn install() {
         dash_game,
         dash_sound,
         turn_dash_game,
-        pickel_fire_attack_lw3_game,
-        pickel_fire_attack_lw3_effect,
         damageflyhi_sound,
         damageflylw_sound,
         damageflyn_sound,
         damageflyroll_sound,
         damageflytop_sound
+
+        pickel_fire_attack_lw3_game,
+        pickel_fire_attack_lw3_effect,
+        pickel_trolley_drive_empty
+
     );
 }
 

--- a/fighters/pickel/src/acmd/other.rs
+++ b/fighters/pickel/src/acmd/other.rs
@@ -305,7 +305,7 @@ pub fn install() {
         damageflylw_sound,
         damageflyn_sound,
         damageflyroll_sound,
-        damageflytop_sound
+        damageflytop_sound,
 
         pickel_fire_attack_lw3_game,
         pickel_fire_attack_lw3_effect,

--- a/fighters/pickel/src/acmd/specials.rs
+++ b/fighters/pickel/src/acmd/specials.rs
@@ -7,12 +7,13 @@ unsafe fn pickel_special_s_set_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_FLAG_REQUEST_REMOVE_HAVE_CRAFT_WEAPON);
-        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL_NO_HIT);
+        VarModule::on_flag(fighter.battle_object, vars::pickel::instance::DISABLE_SPECIAL_S);
     }
 }
+
 pub fn install() {
     install_acmd_scripts!(
-        pickel_special_s_set_game
+        pickel_special_s_set_game,
     );
 }
 

--- a/fighters/pickel/src/acmd/specials.rs
+++ b/fighters/pickel/src/acmd/specials.rs
@@ -1,19 +1,9 @@
 
 use super::*;
 
-#[acmd_script( agent = "pickel", script = "game_specialsset", category = ACMD_GAME, low_priority )]
-unsafe fn pickel_special_s_set_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        WorkModule::on_flag(boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_FLAG_REQUEST_REMOVE_HAVE_CRAFT_WEAPON);
-        VarModule::on_flag(fighter.battle_object, vars::pickel::instance::DISABLE_SPECIAL_S);
-    }
-}
-
 pub fn install() {
     install_acmd_scripts!(
-        pickel_special_s_set_game,
+
     );
 }
 

--- a/fighters/pickel/src/acmd/specials.rs
+++ b/fighters/pickel/src/acmd/specials.rs
@@ -1,9 +1,18 @@
 
 use super::*;
 
-
+#[acmd_script( agent = "pickel", script = "game_specialsset", category = ACMD_GAME, low_priority )]
+unsafe fn pickel_special_s_set_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_FLAG_REQUEST_REMOVE_HAVE_CRAFT_WEAPON);
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::SIDE_SPECIAL_CANCEL_NO_HIT);
+    }
+}
 pub fn install() {
     install_acmd_scripts!(
+        pickel_special_s_set_game
     );
 }
 

--- a/fighters/pickel/src/opff.rs
+++ b/fighters/pickel/src/opff.rs
@@ -101,6 +101,16 @@ unsafe fn logging_for_acmd(boma: &mut BattleObjectModuleAccessor, status_kind: i
         // println!("craft_shovel: {}", *FIGHTER_PICKEL_CRAFT_WEAPON_KIND_SHOVEL);
     }
 
+
+}
+unsafe fn minecart_armor_disable(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
+    if [
+    *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_RIDE,
+    *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_DRIVE].contains(&status_kind)
+    {
+        DamageModule::set_no_reaction_mode_status(boma, DamageNoReactionMode{_address: *DAMAGE_NO_REACTION_MODE_REACTION_VALUE as u8}, 0.0, -1.0, -1);
+    }
+
 }
 
 pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -109,6 +119,7 @@ pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i3
     buildwalk_crouch_disable(boma, status_kind);
     build_ecb_shift(boma, status_kind);
     //logging_for_acmd(boma, status_kind);
+    minecart_armor_disable(boma,status_kind)
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PICKEL )]

--- a/fighters/pickel/src/status.rs
+++ b/fighters/pickel/src/status.rs
@@ -48,7 +48,14 @@ pub unsafe extern "C" fn attack_air_lw_main_status_loop(fighter: &mut L2CFighter
 
 #[status_script(agent = "pickel", status = FIGHTER_STATUS_KIND_SPECIAL_S, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
 pub unsafe fn special_s_pre(fighter: &mut L2CFighterCommon) -> L2CValue{
-    VarModule::on_flag(fighter.battle_object, vars::pickel::instance::DISABLE_SPECIAL_S);
+
+    let hasIron = WorkModule::get_int(fighter.module_accessor,*FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_IRON) > 0;
+    let forgeArticle = ArticleModule::is_exist(fighter.module_accessor,*FIGHTER_PICKEL_GENERATE_ARTICLE_TROLLEY);
+    let canCart = hasIron && !forgeArticle;
+
+    if canCart {
+        VarModule::on_flag(fighter.battle_object, vars::pickel::instance::DISABLE_SPECIAL_S);
+    }
     return original!(fighter);
 }
 
@@ -64,6 +71,7 @@ unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommo
 // Re-enables the ability to use sideB when connecting to ground or cliff
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
     let still_SideSpecial = fighter.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_SPECIAL_S,
         *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_JUMP,
         *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_RIDE,
         *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_DRIVE

--- a/fighters/pickel/src/status.rs
+++ b/fighters/pickel/src/status.rs
@@ -9,7 +9,39 @@ pub fn install() {
         //waza_jumpsquat,
         pre_jump,
         //jump
+
+        attack_air_lw_start_main,
+
     );
+}
+
+#[status_script(agent = "pickel", status = FIGHTER_PICKEL_STATUS_KIND_ATTACK_AIR_LW_START, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn attack_air_lw_start_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let hasIron = WorkModule::get_int(fighter.module_accessor,*FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_IRON) > 0;
+    let forgeArticle = ArticleModule::is_exist(fighter.module_accessor,*FIGHTER_PICKEL_GENERATE_ARTICLE_FORGE);
+    let canForge = hasIron && !forgeArticle;
+
+    if (canForge)
+    {
+        return original!(fighter);
+    }
+    else{
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_air_lw_fail"), 0.0, 1.0, false, 0.0, false, false);
+        fighter.sub_attack_air_common(false.into());
+        return fighter.main_shift(attack_air_lw_main_status_loop);
+    }
+}
+pub unsafe extern "C" fn attack_air_lw_main_status_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !fighter.status_AttackAir_Main_common().get_bool() {
+        fighter.sub_air_check_superleaf_fall_slowly();
+        if !fighter.global_table[IS_STOPPING].get_bool() {
+            fighter.sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec_fix_pos();
+        }
+        0.into()
+    }
+    else {
+        1.into()
+    }
 }
 
 // FIGHTER_STATUS_KIND_JUMP_SQUAT //

--- a/fighters/pickel/src/status.rs
+++ b/fighters/pickel/src/status.rs
@@ -77,11 +77,21 @@ unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L
         *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_DRIVE
         ]
     );
+    
+    let damage_statuses = &[*FIGHTER_STATUS_KIND_DAMAGE,
+                            *FIGHTER_STATUS_KIND_DAMAGE_AIR,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+                            *FIGHTER_STATUS_KIND_DAMAGE_FALL];
 
     if (!fighter.is_situation(*SITUATION_KIND_AIR) && !still_SideSpecial) 
     || fighter.is_situation(*SITUATION_KIND_CLIFF)
     || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD])
-    || VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_IN_HITSTUN) {
+    || fighter.is_status_one_of(damage_statuses) {
         VarModule::off_flag(fighter.battle_object, vars::pickel::instance::DISABLE_SPECIAL_S);
     }
 

--- a/romfs/source/fighter/pickel/param/vl.prcxml
+++ b/romfs/source/fighter/pickel/param/vl.prcxml
@@ -40,6 +40,36 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <list hash="param_special_s">
+    <struct index="0">
+      <float hash="reaction_threshold_to_damage">0</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
+  <list hash="param_trolley">
+    <struct index="0">
+      <float hash="reaction_threshold_to_damage_s">0</float>
+      <float hash="reaction_threshold_to_damage_l">0</float>
+      <float hash="reaction_threshold_to_damage_motion_s">0</float>
+      <float hash="reaction_threshold_to_damage_motion_l">0</float>
+    </struct>
+    <struct index="1">
+      <float hash="reaction_threshold_to_damage_s">0</float>
+      <float hash="reaction_threshold_to_damage_l">0</float>
+      <float hash="reaction_threshold_to_damage_motion_s">0</float>
+      <float hash="reaction_threshold_to_damage_motion_l">0</float>
+    </struct>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
+  <list hash="param_special_hi">
+    <hash40 index="0">dummy</hash40>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
   <struct hash="param_pickelobject">
     <float hash="hp_grade_1">6</float>
     <float hash="hp_wood">10</float>


### PR DESCRIPTION
Down Air:

```diff
- Can no longer stall by using the failed variant (no iron/anvil in play)
- Hitbox removed on failed variant
```

Side Special:

```diff
- Can only be used once per airtime (can be used again if hit midair) upon successful cart crafting
- Minecart can no longer grab opponents
- Armor removed from Steve during this move (Minecart still has the ability to tank one hit)
```