### PR TITLE
Massive UI Overhaul

### DIFF
--- a/romfs/source/ui/script/menu/main/main_menu_layer_other.lua
+++ b/romfs/source/ui/script/menu/main/main_menu_layer_other.lua
@@ -1,0 +1,184 @@
+local value = {}
+
+button:add_id("OTHER", "STANDARD", 1)
+button:add_id("OTHER", "TRAINING", 2)
+button:add_id("OTHER", "KUMITE", 3)
+button:add_id("OTHER", "CHARAMAKE", 4)
+button:add_id("OTHER", "AMIIBO", 5)
+button:add_id("OTHER", "CHALLENGER", 6)
+button:add_id("OTHER", "STAGEMAKE", 7)
+button:add_id("OTHER", "VR", 8)
+button:add_id("OTHER", "HOMERUN", 9)
+
+function value:initialize()
+    self.layout_root = LayoutRootList.main_menu
+    self.layout_view = self.layout_root:get_root_view()
+    self.virtual_input = self.layout_root:get_virtual_input()
+    self.in_anim = "appear_other_top"
+    self.out_anim = "disappear_other_top"
+    self.header = {}
+    self.header.layout_view = self.layout_view:get_parts("set_header_other")
+    self.selector = LayoutButtonSelector.new()
+    self.selector_parts = "set_menu_other"
+    self.selector_name = "selector_0"
+    self.selector_config = LayoutButtonSelectorConfig.new()
+    self.selector_config.bring_front_on_select = true
+    self.selector_config.directional_degree = 60
+    self.selector_config.use_cursor_looping = false
+    self.selector_config.is_unique_se = true
+    self.selector_config.decide_se_label_code = "se_system_fixed_s"
+    self.selector_config.cancel_se_label_code = "se_system_cancel"
+    self.selector_config.cursor_se_label_code = "se_system_cursor_l"
+    self.selector_initial_id = button.OTHER_TRAINING
+    self.button_table = {}
+    self.button_table[button.OTHER_STANDARD] = {
+        parts = "set_parts_btn_00",
+        sequence = SEQUENCE_OTHER_STANDARD
+    }
+    self.button_table[button.OTHER_TRAINING] = {
+        parts = "set_parts_btn_01",
+        sequence = SEQUENCE_OTHER_TRAINING
+    }
+    self.button_table[button.OTHER_KUMITE] = {
+        parts = "set_parts_btn_02",
+        state = STATE_KUMITE_IN
+    }
+    self.button_table[button.OTHER_CHARAMAKE] = {
+        parts = "set_parts_btn_03",
+        sequence = SEQUENCE_OTHER_CHARA_MAKE
+    }
+    self.button_table[button.OTHER_AMIIBO] = {
+        parts = "set_parts_btn_04",
+        sequence = SEQUENCE_OTHER_AMIIBO
+    }
+    self.button_table[button.OTHER_CHALLENGER] = {
+        parts = "set_parts_btn_05",
+        sequence = SEQUENCE_OTHER_CHALLENGER
+    }
+    self.button_table[button.OTHER_STAGEMAKE] = {
+        parts = "set_parts_btn_06",
+        sequence = SEQUENCE_OTHER_STAGE_MAKE
+    }
+    self.button_table[button.OTHER_VR] = {
+        parts = "set_parts_btn_07",
+        sequence = SEQUENCE_OTHER_VR
+    }
+    self.button_table[button.OTHER_HOMERUN] = {
+        parts = "set_parts_btn_08",
+        state = STATE_HOMERUN_IN
+    }
+
+    self.footer_table = {}
+    self.footer_table[button.OTHER_STANDARD] = {
+        label = "mnu_oth_top_help_standard"
+    }
+    self.footer_table[button.OTHER_TRAINING] = {
+        label = "mnu_oth_top_help_training"
+    }
+    self.footer_table[button.OTHER_KUMITE] = {
+        label = "mnu_oth_top_help_sparring"
+    }
+    self.footer_table[button.OTHER_CHARAMAKE] = {
+        label = "mnu_oth_top_help_make_miifighter"
+    }
+    self.footer_table[button.OTHER_AMIIBO] = {
+        label = "mnu_oth_top_help_amiibo"
+    }
+    self.footer_table[button.OTHER_CHALLENGER] = {
+        label = "mnu_oth_top_help_challengers"
+    }
+    self.footer_table[button.OTHER_STAGEMAKE] = {
+        label = "mnu_oth_top_help_build_stage"
+    }
+    self.footer_table[button.OTHER_VR] = {
+        label = "mnu_oth_top_help_vr"
+    }
+    self.footer_table[button.OTHER_HOMERUN] = {
+        label = "mnu_oth_top_help_homerun"
+    }
+
+    self.preview_table = {}
+    self.preview_table.layout_view = self.layout_view:get_parts("set_menu_preview_other")
+    self.preview_table[button.OTHER_STANDARD] = {
+        tag = "select_standard"
+    }
+    self.preview_table[button.OTHER_TRAINING] = {
+        tag = "select_training"
+    }
+    self.preview_table[button.OTHER_KUMITE] = {
+        tag = "select_sparring"
+    }
+    self.preview_table[button.OTHER_CHARAMAKE] = {
+        tag = "select_make_miifighter"
+    }
+    self.preview_table[button.OTHER_AMIIBO] = {
+        tag = "select_amiibo"
+    }
+    self.preview_table[button.OTHER_CHALLENGER] = {
+        tag = "select_challengers"
+    }
+    self.preview_table[button.OTHER_STAGEMAKE] = {
+        tag = "select_edit_stage"
+    }
+    self.preview_table[button.OTHER_VR] = {
+        tag = "select_vr"
+    }
+    self.preview_table[button.OTHER_HOMERUN] = {
+        tag = "select_homerun"
+    }
+
+    self.howto_table = {}
+    self.howto_table[button.OTHER_STANDARD] = {
+        id = "UI_HOWTOPLAY_STANDARD_TOP"
+    }
+    self.howto_table[button.OTHER_KUMITE] = {
+        id = "UI_HOWTOPLAY_KUMITE_TOP"
+    }
+    self.howto_table[button.OTHER_CHARAMAKE] = {
+        id = "UI_HOWTOPLAY_MIIFIGHTER_TOP"
+    }
+    self.howto_table[button.OTHER_AMIIBO] = {
+        id = "UI_HOWTOPLAY_AMIIBO_TOP"
+    }
+    self.howto_table[button.OTHER_CHALLENGER] = {
+        id = "UI_HOWTOPLAY_CHALLENGER_TOP"
+    }
+    self.howto_table[button.OTHER_STAGEMAKE] = {
+        id = "UI_HOWTOPLAY_STAGE_BUILDER_TOP"
+    }
+    self.howto_table[button.OTHER_VR] = {
+        id = "UI_HOWTOPLAY_VR_MELEE_TOP"
+    }
+    self.howto_table[button.OTHER_HOMERUN] = {
+        id = "UI_HOWTOPLAY_HOMERUN_TOP"
+    }
+end
+
+function value:setup_selector()
+    local is_challenger = prg_func.get_challenger_state() == CHALLENGER_OPEN
+    local selector = self.layout_view:get_parts(self.selector_parts)
+    local challenger_parts = selector:get_parts(self.button_table[button.OTHER_CHALLENGER].parts)
+    local challenger_btn = self.selector:get_button(button.OTHER_CHALLENGER)
+    common.play_animation(challenger_parts, is_challenger and "show" or "hide")
+    challenger_btn:set_selectable(is_challenger)
+    challenger_btn:set_decidable(is_challenger)
+    local view_anim = prg_func.is_locale_japan() and "view_jp" or "view_other"
+    local charamake_parts = selector:get_parts(self.button_table[button.OTHER_CHARAMAKE].parts)
+    common.play_animation(charamake_parts, view_anim)
+    local stagemake_parts = selector:get_parts(self.button_table[button.OTHER_STAGEMAKE].parts)
+    common.play_animation(stagemake_parts, view_anim)
+end
+
+function value:update_state_in()
+    common.update_state_in(self)
+end
+
+function value:update_state_main()
+    common.update_state_main(self)
+end
+
+function value:update_state_out()
+    common.update_state_out(self)
+end
+
+return value

--- a/romfs/source/ui/script/menu/main/main_menu_layer_top.lua
+++ b/romfs/source/ui/script/menu/main/main_menu_layer_top.lua
@@ -1,0 +1,114 @@
+local value = {}
+
+button:add_id(nil, "MELEE", 1)
+button:add_id(nil, "SPIRITS", 2)
+button:add_id(nil, "OTHER", 3)
+button:add_id(nil, "ONLINE", 4)
+button:add_id(nil, "COLLECTION", 5)
+button:add_id(nil, "ESHOP", 6)
+
+function value:initialize()
+    self.layout_root = LayoutRootList.main_menu
+    self.layout_view = self.layout_root:get_root_view()
+    self.virtual_input = self.layout_root:get_virtual_input()
+    self.in_anim = "in"
+    self.out_anim = "out"
+
+    self.selector = LayoutButtonSelector.new()
+    self.selector_name = "selector_00"
+    
+    self.selector_config = LayoutButtonSelectorConfig.new()
+    self.selector_config.directional_degree = 60
+    self.selector_config.use_cursor_looping = false
+    self.selector_config.is_unique_se = true
+    self.selector_config.decide_se_label_code = "se_system_fixed_s"
+    self.selector_config.cancel_se_label_code = "se_system_cancel"
+    self.selector_config.cursor_se_label_code = "se_system_cursor_l"
+    self.selector_initial_id = button.MELEE
+
+    self.button_table = {}
+    self.button_table[button.MELEE] = {
+        parts = "set_parts_btn_melee",
+        state = STATE_MELEE_IN
+    }
+    self.button_table[button.SPIRITS] = {
+        parts = "set_parts_btn_spirits",
+        state = STATE_SPIRITS_IN
+    }
+    self.button_table[button.OTHER] = {
+        parts = "set_parts_btn_other",
+        state = STATE_OTHER_IN
+    }
+    self.button_table[button.ONLINE] = {
+        parts = "set_parts_btn_online",
+        sequence = SEQUENCE_ONLINE_MELEE_ROOM
+    }
+    self.button_table[button.COLLECTION] = {
+        parts = "set_parts_btn_colle",
+        state = STATE_COLLECTION_IN
+    }
+    self.button_table[button.ESHOP] = {
+        parts = "set_parts_btn_eshop",
+        func_decide = self.callback_eshop_decide
+    }
+
+    self.footer_table = {}
+    self.footer_table[button.MELEE] = {
+        label = "mnu_top_help_melee"
+    }
+    self.footer_table[button.SPIRITS] = {
+        label = "mnu_top_help_spirits"
+    }
+    self.footer_table[button.OTHER] = {
+        label = "mnu_top_help_other"
+    }
+    self.footer_table[button.ONLINE] = {
+        label = "mnu_top_help_online"
+    }
+    self.footer_table[button.COLLECTION] = {
+        label = "mnu_top_help_collection"
+    }
+    self.footer_table[button.ESHOP] = {
+        label = "mnu_top_help_eshop"
+    }
+
+    self.preview_table = {}
+    self.preview_table.layout_view = self.layout_view:get_parts("set_parts_center")
+    self.preview_table[button.MELEE] = {
+        tag = "select_melee"
+    }
+    self.preview_table[button.SPIRITS] = {
+        tag = "select_spirits"
+    }
+    self.preview_table[button.OTHER] = {
+        tag = "select_other"
+    }
+    self.preview_table[button.ONLINE] = {
+        tag = "select_online"
+    }
+    self.preview_table[button.COLLECTION] = {
+        tag = "select_collection"
+    }
+    self.preview_table[button.ESHOP] = {
+        tag = "select_eshop"
+    }
+end
+
+function value:callback_eshop_decide()
+    common.wait(1)
+    common.show_eshop()
+end
+
+function value:update_state_in()
+    common.update_state_in(self)
+end
+
+function value:update_state_main()
+    common.update_state_main(self)
+end
+
+function value:update_state_out()
+    common.update_state_out(self)
+end
+
+return value


### PR DESCRIPTION
I will be writing this here for everyone to see what's getting changed.

Well here's the changelog, get ready...

**New Title Screen**

![Screenshot 2023-04-23 18-47-54](https://user-images.githubusercontent.com/78892309/233881457-180ea330-8068-430a-85c6-b3744c1ff501.png)
![Screenshot 2023-04-23 18-45-41](https://user-images.githubusercontent.com/78892309/233881462-927e9435-6699-4c38-bd88-ce1330290308.png)


**New Main Menu**

![Screenshot 2023-04-23 18-21-37](https://user-images.githubusercontent.com/78892309/233879483-ed5d2deb-f520-4154-8df6-5188a5985269.png)

**Smash**

- Smash subsection has been overhauled

![Screenshot 2023-04-23 18-23-26](https://user-images.githubusercontent.com/78892309/233879512-d899362d-1468-42b6-af84-c80335a07b7b.png)

![Screenshot 2023-04-23 18-24-31](https://user-images.githubusercontent.com/78892309/233879536-81f4ebb0-aeaa-4494-b679-c94d27938957.png)


**Training**

- Games & More has been renamed to "Training" 

![Screenshot 2023-04-23 18-23-30](https://user-images.githubusercontent.com/78892309/233879541-e9dfda9a-c3ca-4c3c-b919-8f6442eebce3.png)


**Arenas**

- Online has been renamed to "Arenas"
- Entering the Arenas section will now immediately send you to Battle Arenas
- Public Arenas section has been removed

![Screenshot 2023-04-23 12-53-59](https://user-images.githubusercontent.com/78892309/233879790-50cfea8d-e93f-4d84-a8cd-ca9cef0a9163.png)

**Vault**

![Screenshot 2023-04-23 18-23-34](https://user-images.githubusercontent.com/78892309/233879973-83ae5d91-8178-42a9-bbb9-10032187c972.png)
![Screenshot 2023-04-23 18-24-43](https://user-images.githubusercontent.com/78892309/233879981-8ae1a3ab-d14f-410f-afb9-3258f8625114.png)

**Spirits**

![Screenshot 2023-04-23 18-23-37](https://user-images.githubusercontent.com/78892309/233880018-8becee4a-8277-4e39-94ed-6ea6dd5aecda.png)


**Battle HUD Overhaul**

![Screenshot 2023-04-23 18-33-38](https://user-images.githubusercontent.com/78892309/233880371-b3fc5c7b-4486-460e-83c7-266b9750c9a2.png)

- The nametag has been redesigned
![image](https://user-images.githubusercontent.com/78892309/233880215-23c5483f-b7d9-4619-86eb-7a9e7b98261b.png)

- "GO!" size has been decreased
- Timer color has been inverted
- New animation for 1v1 stock score

