### PR TITLE
Reduce tech window, reduce tech lockout window

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -102,8 +102,8 @@
   <float hash="stand_stick_y">0.2</float>
   <float hash="stand_fb_stick_x">0.2</float>
   <float hash="pass_stick_y">-0.71</float>
-  <int hash="passive_trigger_frame">20</int>
-  <int hash="no_rapid_frame_value">40</int>
+  <int hash="passive_trigger_frame">15</int>
+  <int hash="no_rapid_frame_value">30</int>
   <float hash="invalid_passive_speed">999</float>
   <float hash="wall_jump_speed_dec">0.75</float>
   <float hash="wall_jump_x_speed_dec">0.7</float>


### PR DESCRIPTION
Tech window: 20 -> 15
Lockout window: 40 -> 30

The current values result in two problems. First, the large tech window results in "accidental" tech inputs being awarded to a player - for example, when cancelling plant's up b near the ledge, you will frequently get a free tech despite not attempting to time the input at all. Second, there are currently problems where you get "tech trapped" by the long lockout window. Mistiming a tech can result in being forced to miss the next tech, resulting in a long string of frustrating locked tech inputs. Values are a midpoint between melee and ultimate. For comparison's sake, ultimate has an 11 frame tech window and a 28 frame lockout window.

Relevant discord discussion begins here: https://discord.com/channels/659964948365049887/950977443345350678/1101038919421788231