### PR TITLE
Improve FGC Command Input Game-Feel

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -21,6 +21,7 @@ pub mod set_fighter_status_data;
 pub mod attack;
 pub mod collision;
 pub mod camera;
+pub mod shotos;
 
 #[repr(C)]
 pub struct TempModule {
@@ -671,6 +672,7 @@ pub fn install() {
     attack::install();
     collision::install();
     camera::install();
+    shotos::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/common/src/function_hooks/shotos.rs
+++ b/fighters/common/src/function_hooks/shotos.rs
@@ -1,0 +1,11 @@
+use super::*;
+use globals::*;
+
+pub fn install() {
+  skyline::install_hook!(disable_negative_edge);
+}
+
+#[skyline::hook(offset = 0x6b9588, inline)]
+unsafe fn disable_negative_edge(ctx: &mut skyline::hooks::InlineCtx) {
+  *ctx.registers[22].w.as_mut() = 0x0;
+}

--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -114,12 +114,14 @@ unsafe fn hadoken_fadc_sfs_cancels(fighter: &mut L2CFighterCommon, boma: &mut Ba
 
 
     if boma.kind() == *FIGHTER_KIND_RYU
+    && boma.is_cat_flag(Cat1::SpecialAny)
     && boma.is_cat_flag(Cat4::SpecialNCommand | Cat4::SpecialN2Command | Cat4::SpecialHiCommand)
     && super_fs_cancel(boma) {
         return;
     }
 
     if boma.kind() == *FIGHTER_KIND_KEN
+    && boma.is_cat_flag(Cat1::SpecialAny)
     && boma.is_cat_flag(Cat4::SpecialSCommand | Cat4::SpecialHiCommand)
     && super_fs_cancel(boma) {
         return;
@@ -239,7 +241,7 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
     if boma.kind() == *FIGHTER_KIND_RYU {
         WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
 
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             boma.change_status_req(*FIGHTER_RYU_STATUS_KIND_SPECIAL_N2_COMMAND, false);
             return;
         }
@@ -263,15 +265,15 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
 
     let new_status = if boma.is_cat_flag(Cat1::SpecialN) {
         *FIGHTER_STATUS_KIND_SPECIAL_N
-    } else if boma.is_cat_flag(Cat4::SpecialNCommand) {
+    } else if boma.is_cat_flag(Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
         *FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND
     } else if boma.is_cat_flag(Cat1::SpecialS) {
         *FIGHTER_STATUS_KIND_SPECIAL_S
-    } else if boma.is_cat_flag(Cat4::SpecialSCommand) {
+    } else if boma.is_cat_flag(Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
         *FIGHTER_RYU_STATUS_KIND_SPECIAL_S_COMMAND
     } else if boma.is_cat_flag(Cat1::SpecialHi) {
         *FIGHTER_STATUS_KIND_SPECIAL_HI
-    } else if boma.is_cat_flag(Cat4::SpecialHiCommand) {
+    } else if boma.is_cat_flag(Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
         *FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND
     } else if boma.is_cat_flag(Cat1::SpecialLw) {
         *FIGHTER_STATUS_KIND_SPECIAL_LW
@@ -312,6 +314,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
     }
 
     if boma.kind() == *FIGHTER_KIND_RYU
+    && boma.is_cat_flag(Cat1::SpecialAny)
     && boma.is_cat_flag(Cat4::SpecialNCommand | Cat4::SpecialN2Command | Cat4::SpecialHiCommand)
     {
         super_fs_cancel(boma);
@@ -319,6 +322,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
     }
 
     if boma.kind() == *FIGHTER_KIND_KEN
+    && boma.is_cat_flag(Cat1::SpecialAny)
     && boma.is_cat_flag(Cat4::SpecialSCommand | Cat4::SpecialHiCommand)
     {
         super_fs_cancel(boma);

--- a/fighters/dolly/src/opff.rs
+++ b/fighters/dolly/src/opff.rs
@@ -34,19 +34,19 @@ unsafe fn power_wave_dash_cancel_super_cancels(fighter: &mut L2CFighterCommon, b
                 WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);
 
                 // Buster Wolf
-                if boma.is_cat_flag(Cat4::SuperSpecialCommand){
+                if boma.is_cat_flag(Cat4::SuperSpecialCommand) && boma.is_cat_flag(Cat1::SpecialAny){
                     StatusModule::change_status_request_from_script(boma, *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL, false);
                 }
 
                 // Power Geyser
-                if boma.is_cat_flag(Cat4::SuperSpecial2Command){
+                if boma.is_cat_flag(Cat4::SuperSpecial2Command) && boma.is_cat_flag(Cat1::SpecialAny){
                     StatusModule::change_status_request_from_script(boma, *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2, false);
                 }
             }
         }
 
         // Triple Geyser
-        if boma.is_cat_flag( Cat4::SpecialN2Command) {
+        if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             if MeterModule::drain(boma.object(), 10) {
                 WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_FINAL);
                 WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_IS_DISCRETION_FINAL_USED);
@@ -78,7 +78,7 @@ unsafe fn special_super_cancels_triple_geyser(fighter: &mut L2CFighterCommon, bo
         *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND,
         *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_ATTACK].contains(&status_kind) {
         // Triple Geyser
-        if boma.is_cat_flag( Cat4::SpecialN2Command) {
+        if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             if MeterModule::drain(boma.object(), 10) {
                 WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_FINAL);
                 WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_FINAL);
@@ -93,7 +93,7 @@ unsafe fn special_super_cancels_triple_geyser(fighter: &mut L2CFighterCommon, bo
         *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2,
         *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2_BLOW].contains(&status_kind)
         && motion_kind == 0x13434c5490 as u64 {
-        if boma.is_cat_flag( Cat4::SpecialN2Command) {
+        if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             if MeterModule::drain(boma.object(), 6) {
                 WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_FINAL);
                 WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_FINAL);
@@ -166,7 +166,7 @@ unsafe fn super_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
     if status_kind == *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL {
             
         // Power Geyser -> Buster Wolf
-        if boma.is_cat_flag(Cat4::SuperSpecial2Command) {
+        if boma.is_cat_flag(Cat4::SuperSpecial2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             if !StopModule::is_stop(boma){
                 if MeterModule::drain(boma.object(), 2) {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);
@@ -181,7 +181,7 @@ unsafe fn super_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
         *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2_BLOW].contains(&status_kind)
         || motion_kind == 0x13434c5490 as u64 {
         // Buster Wolf -> Power Geyser
-        if boma.is_cat_flag(Cat4::SuperSpecialCommand){
+        if boma.is_cat_flag(Cat4::SuperSpecialCommand) && boma.is_cat_flag(Cat1::SpecialAny){
             if !StopModule::is_stop(boma){
                 if MeterModule::drain(boma.object(), 2) {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL);
@@ -267,11 +267,11 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
             if WorkModule::is_flag(boma, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_ENABLE_SUPER_SPECIAL) {
                 WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL);
                 WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);
-                if boma.is_cat_flag(Cat4::SuperSpecialCommand) {
+                if boma.is_cat_flag(Cat4::SuperSpecialCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL;
                 }
-                else if boma.is_cat_flag(Cat4::SuperSpecial2Command){
+                else if boma.is_cat_flag(Cat4::SuperSpecial2Command) && boma.is_cat_flag(Cat1::SpecialAny){
                     is_input_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2;
                 }
@@ -293,7 +293,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B;
                 }
-                if boma.is_cat_flag( Cat4::SpecialSCommand) {
+                if boma.is_cat_flag( Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B_COMMAND;
                 }
@@ -302,7 +302,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI;
                 }
-                if boma.is_cat_flag( Cat4::SpecialHi2Command) {
+                if boma.is_cat_flag( Cat4::SpecialHi2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_HI_COMMAND;
                 }
@@ -311,7 +311,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_STATUS_KIND_SPECIAL_LW;
                 }
-                if boma.is_cat_flag( Cat4::SpecialHiCommand) {
+                if boma.is_cat_flag( Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND;
                 }
@@ -336,7 +336,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_STATUS_KIND_SPECIAL_S;
                 }
-                if boma.is_cat_flag( Cat4::SpecialNCommand) {
+                if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_S_COMMAND;
                 }
@@ -345,7 +345,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B;
                 }
-                if boma.is_cat_flag( Cat4::SpecialSCommand) {
+                if boma.is_cat_flag( Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B_COMMAND;
                 }
@@ -354,7 +354,7 @@ unsafe fn special_cancels(boma: &mut BattleObjectModuleAccessor) {
                     is_input_special_special_cancel = true;
                     new_status = *FIGHTER_STATUS_KIND_SPECIAL_LW;
                 }
-                if boma.is_cat_flag( Cat4::SpecialHiCommand) {
+                if boma.is_cat_flag( Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                     is_input_cancel = true;
                     new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND;
                 }
@@ -402,7 +402,7 @@ unsafe fn jab_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_ATTACK_HI4_START;
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
@@ -422,7 +422,7 @@ unsafe fn jab_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_ATTACK_HI4_START;
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
@@ -459,7 +459,7 @@ unsafe fn tilt_cancels(boma: &mut BattleObjectModuleAccessor) {
             }
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
@@ -484,7 +484,7 @@ unsafe fn tilt_cancels(boma: &mut BattleObjectModuleAccessor) {
             }
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
@@ -505,7 +505,7 @@ unsafe fn tilt_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_ATTACK_HI4_START;
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);
@@ -543,11 +543,11 @@ unsafe fn dash_attack_cancels(boma: &mut BattleObjectModuleAccessor) {
     if WorkModule::is_flag(boma, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_ENABLE_SUPER_SPECIAL) {
         WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL);
         WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2);
-        if boma.is_cat_flag(Cat4::SuperSpecialCommand) {
+        if boma.is_cat_flag(Cat4::SuperSpecialCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL;
         }
-        else if boma.is_cat_flag(Cat4::SuperSpecial2Command) {
+        else if boma.is_cat_flag(Cat4::SuperSpecial2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2;
         }
@@ -560,12 +560,12 @@ unsafe fn dash_attack_cancels(boma: &mut BattleObjectModuleAccessor) {
             is_input_cancel = true;
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI
         }
-        else if boma.is_cat_flag(Cat4::SpecialHi2Command) {
+        else if boma.is_cat_flag(Cat4::SpecialHi2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_HI_COMMAND;
         }
         // Power Dunk
-        else if boma.is_cat_flag(Cat4::SpecialHiCommand) {
+        else if boma.is_cat_flag(Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND;
         }
@@ -598,7 +598,7 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_N;
         }
         // Burn Knuckle
-        else if boma.is_cat_flag(Cat4::SpecialNCommand) {
+        else if boma.is_cat_flag(Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_S_COMMAND;
         }
@@ -607,7 +607,7 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_S;
         }
         // Crack Shoot
-        else if boma.is_cat_flag(Cat4::SpecialSCommand) {
+        else if boma.is_cat_flag(Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;   
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B_COMMAND;
         }
@@ -620,12 +620,12 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
             is_input_cancel = true;
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI
         }
-        else if boma.is_cat_flag(Cat4::SpecialHi2Command) {
+        else if boma.is_cat_flag(Cat4::SpecialHi2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_HI_COMMAND;
         }
         // Power Dunk
-        else if boma.is_cat_flag(Cat4::SpecialHiCommand) {
+        else if boma.is_cat_flag(Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             new_status = *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND;
         }
@@ -634,7 +634,7 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_LW
         }
         // Power Charge
-        if boma.is_cat_flag(Cat4::SpecialN2Command) {
+        if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             ControlModule::clear_command(boma, false);
             WorkModule::off_flag(boma, *FIGHTER_DOLLY_STATUS_ATTACK_WORK_FLAG_HIT_CANCEL);

--- a/fighters/dolly/src/status.rs
+++ b/fighters/dolly/src/status.rs
@@ -29,6 +29,107 @@ pub fn install() {
         //wait_main,
         landing_main
     );
+    smashline::install_agent_init_callbacks!(dolly_init);
+}
+
+#[smashline::fighter_init]
+fn dolly_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        if smash::app::utility::get_kind(&mut *fighter.module_accessor) != *FIGHTER_KIND_DOLLY {
+            return;
+        }
+        fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(dolly_check_special_command as *const () as _));
+    }
+}
+
+
+pub unsafe extern "C" fn dolly_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if dolly_check_super_special_command(fighter).get_bool() {
+        return true.into();
+    }
+    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI_COMMAND)
+    && dolly_check_special_hi_command(fighter).get_bool() {
+        return true.into();
+    }
+    let cat1 =  fighter.global_table[CMD_CAT1].get_i32();
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_LW_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_LW_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_COMMAND.into(), true.into());
+            return true.into();
+        }
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_S_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_S_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B_COMMAND.into(), true.into());
+            return true.into();
+        }
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_S_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SPECIAL_S_COMMAND.into(), true.into());
+            return true.into();
+        }
+    }
+    false.into()
+}
+
+unsafe extern "C" fn dolly_check_super_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let cat1 =  fighter.global_table[CMD_CAT1].get_i32();
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+        WorkModule::set_int(fighter.module_accessor, cat4, *FIGHTER_DOLLY_INSTANCE_WORK_ID_INT_CAT4_SPECIAL_COMMAND);
+        if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND
+        && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DOLLY_INSTANCE_WORK_ID_FLAG_ENABLE_SUPER_SPECIAL) {
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2) {
+                fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2.into(), true.into());
+                return true.into();
+            }
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL) {
+                fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL.into(), true.into());
+                return true.into();
+            }
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL2_R_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL2) {
+                let opplr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLOAT_OPPONENT_LR_1ON1);
+                if opplr != 0.0 {
+                    PostureModule::reverse_lr(fighter.module_accessor);
+                }
+                fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL2.into(), true.into());
+                return true.into();
+            }
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SUPER_SPECIAL_R_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SUPER_SPECIAL) {
+                let opplr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLOAT_OPPONENT_LR_1ON1);
+                if opplr != 0.0 {
+                    PostureModule::reverse_lr(fighter.module_accessor);
+                }
+                fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SUPER_SPECIAL.into(), true.into());
+                return true.into();
+            }
+        }
+    }
+    
+    false.into()
+}
+
+unsafe extern "C" fn dolly_check_special_hi_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let cat1 =  fighter.global_table[CMD_CAT1].get_i32();
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI2_COMMAND != 0
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_HI_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_DOLLY_STATUS_KIND_SPECIAL_HI_COMMAND.into(), true.into());
+            return true.into();
+        }
+    }
+
+    false.into()
 }
 
 // FIGHTER_STATUS_KIND_TURN_DASH //

--- a/fighters/ken/src/opff.rs
+++ b/fighters/ken/src/opff.rs
@@ -159,7 +159,7 @@ unsafe fn special_fadc_super_cancels(boma: &mut BattleObjectModuleAccessor) {
                     }
                 }
             }
-            if boma.is_cat_flag(Cat4::SpecialSCommand | Cat4::SpecialHiCommand){
+            if boma.is_cat_flag(Cat4::SpecialSCommand | Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                 if !StopModule::is_stop(boma){
                     if MeterModule::drain(boma.object(), 10) {
                         WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_FINAL);
@@ -322,34 +322,34 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
 
     if !boma.is_status(*FIGHTER_STATUS_KIND_ATTACK_S4){
         // Special cancels
-        if boma.is_cat_flag(Cat1::SpecialN) {
+        if boma.is_cat_flag(Cat1::SpecialHi) {
             is_input_cancel = true;
             is_jump_cancel = false;
-            new_status = *FIGHTER_STATUS_KIND_SPECIAL_N;
-        } else if boma.is_cat_flag(Cat4::SpecialNCommand) {
+            new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI;
+        } else if boma.is_cat_flag(Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
-            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND;
-        } else if boma.is_cat_flag(Cat4::SpecialN2Command) {
+            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND;
+        } else if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N2_COMMAND;
+        } else if boma.is_cat_flag(Cat1::SpecialN) {
+            is_input_cancel = true;
+            is_jump_cancel = false;
+            new_status = *FIGHTER_STATUS_KIND_SPECIAL_N;
+        } else if boma.is_cat_flag(Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+            is_input_cancel = true;
+            is_jump_cancel = false;
+            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND;
         } else if boma.is_cat_flag(Cat1::SpecialS) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_S;
-        } else if boma.is_cat_flag(Cat4::SpecialSCommand) {
+        } else if boma.is_cat_flag(Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_S_COMMAND;
-        } else if boma.is_cat_flag(Cat1::SpecialHi) {
-            is_input_cancel = true;
-            is_jump_cancel = false;
-            new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI;
-        } else if boma.is_cat_flag(Cat4::SpecialHiCommand) {
-            is_input_cancel = true;
-            is_jump_cancel = false;
-            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND;
         } else if boma.is_cat_flag(Cat1::SpecialLw) {
             is_input_cancel = true;
             is_jump_cancel = false;

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -116,17 +116,17 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_RYU {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
-                    if boma.is_cat_flag( Cat4::SpecialNCommand) {
-                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
-                    }
-                    if boma.is_cat_flag( Cat4::SpecialN2Command) {
+                    if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, false);
+                    }
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
                     }
                 }
                 // Ken
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_KEN {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
-                    if boma.is_cat_flag( Cat4::AttackCommand1) {
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND, false);
                     }
                 }
@@ -179,17 +179,17 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_RYU {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
-                    if boma.is_cat_flag( Cat4::SpecialNCommand) {
-                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
-                    }
-                    if boma.is_cat_flag( Cat4::SpecialN2Command) {
+                    if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, false);
+                    }
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
                     }
                 }
                 // Ken
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_KEN {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
-                    if boma.is_cat_flag( Cat4::AttackCommand1) {
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND, false);
                     }
                 }
@@ -232,17 +232,17 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_RYU {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
-                    if boma.is_cat_flag( Cat4::SpecialNCommand) {
-                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
-                    }
-                    if boma.is_cat_flag( Cat4::SpecialN2Command) {
+                    if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, false);
+                    }
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
                     }
                 }
                 // Ken
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_KEN {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
-                    if boma.is_cat_flag( Cat4::AttackCommand1) {
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND, false);
                     }
                 }
@@ -278,17 +278,17 @@ unsafe fn magic_series(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_RYU {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND);
-                    if boma.is_cat_flag( Cat4::SpecialNCommand) {
-                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
-                    }
-                    if boma.is_cat_flag( Cat4::SpecialN2Command) {
+                    if boma.is_cat_flag( Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND, false);
+                    }
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+                        StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND, false);
                     }
                 }
                 // Ken
                 if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_KEN {
                     WorkModule::enable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND);
-                    if boma.is_cat_flag( Cat4::AttackCommand1) {
+                    if boma.is_cat_flag( Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
                         StatusModule::change_status_request_from_script(boma, *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND, false);
                     }
                 }

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -7,6 +7,59 @@ pub fn install() {
         pre_jump,
         throw_kirby_map_correction
     );
+    smashline::install_agent_init_callbacks!(kirby_init);
+}
+
+#[smashline::fighter_init]
+fn kirby_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        if smash::app::utility::get_kind(&mut *fighter.module_accessor) != *FIGHTER_KIND_KIRBY {
+            return;
+        }
+        fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(kirby_check_special_command as *const () as _));
+    }
+}
+
+/// determines the command inputs
+/// NOTE: order is important! early order has higher priority
+pub unsafe extern "C" fn kirby_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let cat1 =  fighter.global_table[CMD_CAT1].get_i32();
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+
+    // Ryu
+    if WorkModule::get_int(fighter.module_accessor, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_RYU {
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+            // shaku
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N2_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND)
+            && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_N_CALLBACK].clone()).get_bool() {
+                fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND.into(), true.into());
+                return true.into();
+            }
+    
+            // hado
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+            && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_N_CALLBACK].clone()).get_bool() {
+                fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND.into(), true.into());
+                return true.into();
+            }
+        }
+    }
+    // Ken
+    if WorkModule::get_int(fighter.module_accessor, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_KEN {
+        if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+            // hado
+            if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+            && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+            && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_N_CALLBACK].clone()).get_bool() {
+                fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND.into(), true.into());
+                return true.into();
+            }
+        }
+    }
+
+    false.into()
 }
 
 // FIGHTER_STATUS_KIND_JUMP //

--- a/fighters/ryu/src/opff.rs
+++ b/fighters/ryu/src/opff.rs
@@ -110,7 +110,7 @@ unsafe fn special_fadc_super_cancels(boma: &mut BattleObjectModuleAccessor) {
                     }
                 }
             }
-            if boma.is_cat_flag(Cat4::SpecialNCommand | Cat4::SpecialHiCommand){
+            if boma.is_cat_flag(Cat4::SpecialNCommand | Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny){
                 if !StopModule::is_stop(boma){
                     if MeterModule::drain(boma.object(), 10) {
                         WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_FINAL);
@@ -291,34 +291,35 @@ unsafe fn smash_cancels(boma: &mut BattleObjectModuleAccessor) {
             new_status = *FIGHTER_STATUS_KIND_JUMP_SQUAT;
         }
         // Special cancels
-        if boma.is_cat_flag(Cat1::SpecialN) {
+        // Special cancels
+        if boma.is_cat_flag(Cat1::SpecialHi) {
             is_input_cancel = true;
             is_jump_cancel = false;
-            new_status = *FIGHTER_STATUS_KIND_SPECIAL_N;
-        } else if boma.is_cat_flag(Cat4::SpecialNCommand) {
+            new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI;
+        } else if boma.is_cat_flag(Cat4::SpecialHiCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
-            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND;
-        } else if boma.is_cat_flag(Cat4::SpecialN2Command) {
+            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND;
+        } else if boma.is_cat_flag(Cat4::SpecialN2Command) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N2_COMMAND;
+        } else if boma.is_cat_flag(Cat1::SpecialN) {
+            is_input_cancel = true;
+            is_jump_cancel = false;
+            new_status = *FIGHTER_STATUS_KIND_SPECIAL_N;
+        } else if boma.is_cat_flag(Cat4::SpecialNCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
+            is_input_cancel = true;
+            is_jump_cancel = false;
+            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND;
         } else if boma.is_cat_flag(Cat1::SpecialS) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_STATUS_KIND_SPECIAL_S;
-        } else if boma.is_cat_flag(Cat4::SpecialSCommand) {
+        } else if boma.is_cat_flag(Cat4::SpecialSCommand) && boma.is_cat_flag(Cat1::SpecialAny) {
             is_input_cancel = true;
             is_jump_cancel = false;
             new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_S_COMMAND;
-        } else if boma.is_cat_flag(Cat1::SpecialHi) {
-            is_input_cancel = true;
-            is_jump_cancel = false;
-            new_status = *FIGHTER_STATUS_KIND_SPECIAL_HI;
-        } else if boma.is_cat_flag(Cat4::SpecialHiCommand) {
-            is_input_cancel = true;
-            is_jump_cancel = false;
-            new_status = *FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND;
         } else if boma.is_cat_flag(Cat1::SpecialLw) {
             is_input_cancel = true;
             is_jump_cancel = false;

--- a/fighters/ryu/src/status.rs
+++ b/fighters/ryu/src/status.rs
@@ -46,6 +46,65 @@ pub fn install() {
         //wait_main,
         landing_main
     );
+    smashline::install_agent_init_callbacks!(ryu_init);
+}
+
+#[smashline::fighter_init]
+fn ryu_init(fighter: &mut L2CFighterCommon) {
+    unsafe {
+        if smash::app::utility::get_kind(&mut *fighter.module_accessor) != *FIGHTER_KIND_RYU {
+            return;
+        }
+        fighter.global_table[CHECK_SPECIAL_COMMAND].assign(&L2CValue::Ptr(ryu_check_special_command as *const () as _));
+    }
+}
+
+/// determines the command inputs
+/// I have divided these inputs into command normals (A) and command specials (B)
+/// NOTE: order is important! early order has higher priority
+pub unsafe extern "C" fn ryu_check_special_command(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let cat1 =  fighter.global_table[CMD_CAT1].get_i32();
+    let cat4 = fighter.global_table[CMD_CAT4].get_i32();
+
+    if cat1 & *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY != 0 {
+        // COMMAND SPECIALS
+
+        // shoryu
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_HI_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_HI_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_HI_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_COMMAND.into(), true.into());
+            return true.into();
+        }
+
+        // shaku
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N2_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N2_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_N_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_N2_COMMAND.into(), true.into());
+            return true.into();
+        }
+
+        // hado
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_N_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_N_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_N_CALLBACK].clone()).get_bool() {
+            fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_N_COMMAND.into(), true.into());
+            return true.into();
+        }
+
+        // tatsu
+        if cat4 & *FIGHTER_PAD_CMD_CAT4_FLAG_SPECIAL_S_COMMAND != 0
+        && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SPECIAL_S_COMMAND)
+        && fighter.sub_transition_term_id_cont_disguise(fighter.global_table[USE_SPECIAL_S_CALLBACK].clone()).get_bool()
+        && FighterSpecializer_Ryu::check_special_air_s_command(fighter.module_accessor) {
+            fighter.change_status(FIGHTER_RYU_STATUS_KIND_SPECIAL_S_COMMAND.into(), true.into());
+            return true.into();
+        }
+
+    }
+
+    false.into()
 }
 
 // FIGHTER_STATUS_KIND_TURN_DASH //


### PR DESCRIPTION
## Notes

Ken's, Ryu's, and Terry's command input specials often activate in unwanted scenarios:

- A-button command specials activate based on normal air movement into A-button aerials, forcing FGC players to always use C-stick
- Negative edge activates unintended specials often during cancel-able moves, and makes simple special cancels obtuse
- The order of priority of Ken/Ryu's specials causes Hadouken to often take priority over other inputs, such as Shaku and Shoryu

## Global

- Remove Negative Edge

## B-only command specials (Ken/Ryu/Terry):

- NSpecial (Kirby's copy ability too)
- SSpecial
- USpecial
- DSpecial (Terry)
- Final Smashes

## A-only command normals (Ken):

- Crescent Kick (632)
- Roundhouse Kick (41236)

## New order of priority (Ken/Ryu)

1. Final Smash
2. Shoryuken
3. Shakunetsu
4. Hadouken
5. Tatsumaki