### PR TITLE
Sonic - upB bugfixes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -165,6 +165,8 @@ pub mod vars {
 
             pub const IS_IGNORED_STATUS_FRAME_0: i32 = 0x0058;
 
+            pub const FLUSH_EFFECT_ACMD: i32 = 0x0059;
+
             // ints
 
             pub const LAST_ATTACK_RECEIVER_ENTRY_ID: i32 = 0x0000;

--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -28,7 +28,7 @@ unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash:
         }
 
         // Allows a frame-perfect edge canceled waveland to still generate landing smoke GFX
-        if VarModule::is_flag(boma.object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY)
+        if VarModule::is_flag(boma.object(), vars::common::instance::FLUSH_EFFECT_ACMD)
         && MotionModule::motion_kind(boma) == hash40("landing_heavy") {
             MotionAnimcmdModule::flush(boma, false);
         }
@@ -40,7 +40,7 @@ unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash:
 unsafe fn change_motion_inherit_frame_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: f32, arg6: bool, arg7: bool) -> u64 {
     change_motion_pos_shift_check(boma);
     if boma.is_fighter()
-    && (VarModule::is_flag(boma.object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY)
+    && (VarModule::is_flag(boma.object(), vars::common::instance::FLUSH_EFFECT_ACMD)
         || StatusModule::is_changing(boma))
     {
         MotionAnimcmdModule::flush(boma, false);
@@ -52,7 +52,7 @@ unsafe fn change_motion_inherit_frame_hook(boma: &mut BattleObjectModuleAccessor
 unsafe fn change_motion_inherit_frame_keep_rate_hook(boma: &mut BattleObjectModuleAccessor, motion_hash: smash::phx::Hash40, arg3: f32, arg4: f32, arg5: f32) -> u64 {
     change_motion_pos_shift_check(boma);
     if boma.is_fighter()
-    && (VarModule::is_flag(boma.object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY)
+    && (VarModule::is_flag(boma.object(), vars::common::instance::FLUSH_EFFECT_ACMD)
         || StatusModule::is_changing(boma))
     {
         MotionAnimcmdModule::flush(boma, false);

--- a/fighters/common/src/function_hooks/ledges.rs
+++ b/fighters/common/src/function_hooks/ledges.rs
@@ -507,6 +507,9 @@ unsafe fn check_cliff_entry_specializer(boma: &mut BattleObjectModuleAccessor) -
     }
 
     if fighter_kind == *FIGHTER_KIND_SONIC {
+        if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI {
+            return 0;
+        }
         if status_kind == *FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP {
             if frame < 23.0 {
                 return 0;

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -593,7 +593,10 @@ unsafe fn after_collision(object: *mut BattleObject) {
                     if VarModule::has_var_module((*boma).object()) { VarModule::on_flag((*boma).object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY); }
                     let status_module__run_lua_status: extern "C" fn(*const TempModule) = std::mem::transmute(*(((module_accessor.status_module.vtable as u64) + 0x68) as *const u64));
                     status_module__run_lua_status(module_accessor.status_module);
-                    if VarModule::has_var_module((*boma).object()) { VarModule::off_flag((*boma).object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY); }
+                    if VarModule::has_var_module((*boma).object()) {
+                        VarModule::off_flag((*boma).object(), vars::common::instance::CHECK_CHANGE_MOTION_ONLY);
+                        VarModule::off_flag((*boma).object(), vars::common::instance::FLUSH_EFFECT_ACMD);
+                    }
                 }
             }
         }

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -373,13 +373,14 @@ unsafe fn sub_transition_group_check_ground(fighter: &mut L2CFighterCommon, to_s
 pub unsafe fn sys_line_status_system_control_hook(fighter: &mut L2CFighterBase) -> L2CValue {
     if VarModule::has_var_module(fighter.battle_object)
     && VarModule::is_flag(fighter.battle_object, vars::common::instance::CHECK_CHANGE_MOTION_ONLY)
-    && fighter.global_table[CURRENT_FRAME].get_i32() != 0
     {
         // When we are calling MAIN status for the sole purpose of changing motion kind upon contact with a surface,
         // there is no need to increment the CURRENT_FRAME counter,
         // or run sub statuses (which are often used to increment various counters used during a status)
         // So we are only updating situation kind, then returning
         // MAIN status will then be called after returning
+        VarModule::off_flag(fighter.battle_object, vars::common::instance::CHECK_CHANGE_MOTION_ONLY);
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::FLUSH_EFFECT_ACMD);
         let situation_kind = StatusModule::situation_kind(fighter.module_accessor);
         fighter.global_table[SITUATION_KIND].assign(&L2CValue::I32(situation_kind));
         fighter.global_table[0xD].assign(&L2CValue::Bool(false));

--- a/fighters/sonic/src/opff.rs
+++ b/fighters/sonic/src/opff.rs
@@ -10,10 +10,20 @@ if status_kind == *FIGHTER_SONIC_STATUS_KIND_SPECIAL_S_TURN && boma.is_input_jum
   }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+// Allows Sonic to land during upB before he completes the spin at the top
+unsafe fn up_special_early_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP) {
+        if GroundModule::is_touch(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32) {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        }
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     sonic_spindash_jump_waveland(boma, status_kind, situation_kind, cat[0]);
     //sonic_moveset(boma, situation_kind, status_kind, motion_kind, frame, cat[0], id);
     //sonic_lightspeed_dash(boma, status_kind, motion_kind, situation_kind, cat[0], id);
+    up_special_early_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_SONIC )]
@@ -26,7 +36,7 @@ pub fn sonic_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn sonic_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }
 


### PR DESCRIPTION
- Fixes an issue where Sonic's upB would go farther if initiated at a certain point against the underside of a stage.
- Fixes an issue where Sonic could grab ledge out of the initial frames of upB.
- Allows Sonic to land out of upB before he completes the spin at the peak of the jump.

