### PR TITLE
Palutena Teleport Hotfix

### DIFF
--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -18,7 +18,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
         return;
     }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI
-    && StatusModule::is_changing(boma) {
+    && boma.status_frame() == 1 {
         VarModule::off_flag(boma.object(), vars::palutena::instance::GROUNDED_TELEPORT);
         if situation_kind == *SITUATION_KIND_GROUND {
             VarModule::on_flag(boma.object(), vars::palutena::instance::GROUNDED_TELEPORT);
@@ -47,7 +47,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
 unsafe fn dj_upB_jump_refresh(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
         // If first 3 frames of dj
-        if fighter.status_frame() <= 2 {
+        if fighter.status_frame() <= 3 {
             VarModule::on_flag(fighter.battle_object, vars::palutena::instance::UP_SPECIAL_JUMP_REFRESH);
         }
         else {


### PR DESCRIPTION
Sweep formatting error broke grounded teleport. Now can jump out of grounded teleport again. In addition, the jump keep window on up b was listed as 3 frames but was only 2 frames in frame-by-frame. Changed to 3 to match what was written.