### PR TITLE
Lucario recovery adjustment

### DIFF
--- a/fighters/lucario/src/acmd/specials.rs
+++ b/fighters/lucario/src/acmd/specials.rs
@@ -184,10 +184,7 @@ unsafe fn lucario_special_air_s_throw_expression(fighter: &mut L2CAgentBase) {
 unsafe fn lucario_special_hi_l_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.500);
-    }
+    FT_DESIRED_RATE(fighter, 30.0, 25.0);
     frame(lua_state, 21.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_LUCARIO_MACH_STATUS_WORK_ID_FLAG_RUSH_DIR);
@@ -199,10 +196,7 @@ unsafe fn lucario_special_hi_l_game(fighter: &mut L2CAgentBase) {
 unsafe fn lucario_special_hi_r_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.400);
-    }
+    FT_DESIRED_RATE(fighter, 30.0, 25.0);
     frame(lua_state, 21.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_LUCARIO_MACH_STATUS_WORK_ID_FLAG_RUSH_DIR);
@@ -214,10 +208,7 @@ unsafe fn lucario_special_hi_r_game(fighter: &mut L2CAgentBase) {
 unsafe fn lucario_special_air_hi_l_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.400);
-    }
+    FT_DESIRED_RATE(fighter, 30.0, 25.0);
     frame(lua_state, 13.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_LUCARIO_MACH_STATUS_WORK_ID_FLAG_GRAVITY_ONOFF);
@@ -233,10 +224,7 @@ unsafe fn lucario_special_air_hi_l_game(fighter: &mut L2CAgentBase) {
 unsafe fn lucario_special_air_hi_r_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.500);
-    }
+    FT_DESIRED_RATE(fighter, 30.0, 25.0);
     frame(lua_state, 13.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_LUCARIO_MACH_STATUS_WORK_ID_FLAG_GRAVITY_ONOFF);

--- a/fighters/lucario/src/status.rs
+++ b/fighters/lucario/src/status.rs
@@ -15,7 +15,8 @@ pub fn install() {
         special_s_throw_main,
         pre_walk,
         pre_dash,
-        pre_run
+        pre_run,
+        special_hi_bound_end
     );
 }
 
@@ -225,4 +226,12 @@ pub unsafe fn pre_dash(fighter: &mut L2CFighterCommon) -> L2CValue {
 #[status_script(agent = "lucario", status = FIGHTER_STATUS_KIND_RUN, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
 pub unsafe fn pre_run(fighter: &mut L2CFighterCommon) -> L2CValue {
     fighter.status_pre_Run()
+}
+
+// FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND
+
+#[status_script(agent = "lucario", status = FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+pub unsafe fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);
+    0.into()
 }

--- a/romfs/source/fighter/lucario/param/vl.prcxml
+++ b/romfs/source/fighter/lucario/param/vl.prcxml
@@ -28,6 +28,7 @@
       <float hash="rush_speed">4</float>
       <float hash="0x189cd804c5">0.8</float>
       <float hash="angle_speed">2</float>
+      <float hash="end_accel_y">0.3</float>
       <int hash="landing_frame">30</int>
     </struct>
     <hash40 index="1">dummy</hash40>


### PR DESCRIPTION
### UpB:
- Startup increased 15f -> 25f (matches P+)
- UpB end gravity value increased 0.18 -> 0.3
  - Allows easier sweetspotting with upB cancels
- Ground bounce now always land cancels