### PR TITLE
Rising platwarp removal logic rework

### DIFF
--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -36,6 +36,21 @@ unsafe fn ground_module_ecb_point_calc_hook(ground_module: u64, param_1: *mut *m
         // This check passes after 9 frames of airtime, if not in a grabbed/thrown state
         *param_3 = 0.0;
     }
+
+    // Prevents rising platwarps during aerials and tumble
+    if !StopModule::is_stop(boma) {
+        if (*boma).is_status_one_of(&[*FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_DAMAGE_FLY])
+        && KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) > 0.0
+        {
+            // Forces character to ignore platforms, overrides ability to land
+            GroundModule::set_passable_check(boma, true);
+        }
+        else if (*boma).is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR)
+        && KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) <= 0.0
+        {
+            GroundModule::set_passable_check(boma, false);
+        }
+    }
 }
 
 

--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -115,23 +115,10 @@ unsafe fn plat_cancels(fighter: &mut L2CFighterCommon) {
     }
 }
 
-// Prevents rising platwarps during aerials and tumble
-unsafe fn prevent_rising_platwarps(fighter: &mut L2CFighterCommon) {
-    if !StopModule::is_stop(fighter.module_accessor)
-    && fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_DAMAGE_FLY])
-    && KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) > 0.0
-    {
-        // Forces character to stay in air, overrides ability to land
-        // for single frame
-        fighter.set_situation(L2CValue::I32(*SITUATION_KIND_AIR));
-    }
-}
-
 pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     extra_traction(fighter, boma);
     grab_jump_refresh(boma);
     plat_cancels(fighter);
-    prevent_rising_platwarps(fighter);
 
     //WorkModule::unable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_DAMAGE_FLY_REFLECT_D); //Melee style spike knockdown (courtesey of zabimaru), leaving it commented here just to have it saved somewhere
 }


### PR DESCRIPTION
The implementation in nightly does not work as intended, as characters can still be warped above a platform while rising with an aerial; they simply won't be interrupted with landing.

The new implementation ignores platform collision entirely while rising.