### PR TITLE
Waveland snap improvements

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -223,6 +223,7 @@ pub mod vars {
             pub const LAST_ATTACK_HIT_LOCATION_X: i32 = 0x0016;
             pub const LAST_ATTACK_HIT_LOCATION_Y: i32 = 0x0017;
             pub const LAST_ATTACK_HIT_LOCATION_Z: i32 = 0x0018;
+            pub const ECB_CENTER_Y_OFFSET: i32 = 0x0019;
         }
         pub mod status {
             // flags

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -864,8 +864,13 @@ impl BomaExt for BattleObjectModuleAccessor {
         let mut ground_pos_stage = Vector2f::zero();
         GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, hip_pos_y), &snap_detect_bottom, &Vector2f::zero(), &mut ground_pos_any, true);
         GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, hip_pos_y), &snap_detect_bottom, &Vector2f::zero(), &mut ground_pos_stage, false);
-        let can_snap = ground_pos_any != Vector2f::zero() && (ground_pos_stage == Vector2f::zero()
-            || WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0);
+        let can_snap = !( 
+            ground_pos_any == Vector2f::zero()
+            || (ground_pos_stage != Vector2f::zero()
+                && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) > 0.0)
+            || (self.is_prev_status(*FIGHTER_STATUS_KIND_PASS)
+                && ground_pos_stage == Vector2f::zero())
+        );
         if can_snap { // pretty sure it returns a pointer, at least it defo returns a non-0 value if success
             crate::VarModule::on_flag(self.object(), crate::consts::vars::common::status::DISABLE_ECB_SHIFT);
             PostureModule::set_pos(self, &Vector3f::new(pos.x, ground_pos_any.y + 0.1, pos.z));

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -849,33 +849,33 @@ impl BomaExt for BattleObjectModuleAccessor {
         // The distance from your Hip bone to your Top bone is your waveland snap threshold
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
         let pos = *PostureModule::pos(self);
-        let mut hip_offset = Vector3f::zero();
+        let mut upper_bound_offset = Vector3f::zero();
         let upper_bound_bone = if self.kind() == *FIGHTER_KIND_KOOPAJR && self.is_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
             "clownhip"
         } else {
             "hip"
         };
-        ModelModule::joint_global_offset_from_top(self, Hash40::new(upper_bound_bone), &mut hip_offset);
-        let hip_pos_y = pos.y + hip_offset.y;
+        ModelModule::joint_global_offset_from_top(self, Hash40::new(upper_bound_bone), &mut upper_bound_offset);
+        if self.is_prev_status(*FIGHTER_STATUS_KIND_PASS) {
+            upper_bound_offset.y = crate::VarModule::get_float(self.object(), crate::consts::vars::common::instance::ECB_BOTTOM_Y_OFFSET);
+        }
+        let upper_bound_y = pos.y + upper_bound_offset.y;
         let snap_leniency = if WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0 {
                 // For a downwards/horizontal airdodge, waveland snap threshold = the distance from your Hip bone to your Top bone
-                hip_offset.y
+                upper_bound_offset.y
             } else {
                 // For an upwards airdodge, waveland snap threshold = 5 units below Hip bone, if the distance from your Hip Bone to your Top bone is < 5
-                (hip_offset.y).max(crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"))
+                (upper_bound_offset.y).max(crate::ParamModule::get_float(self.object(), crate::ParamType::Common, "waveland_distance_threshold"))
             };
-        let snap_detect_bottom = Vector2f::new(ecb_bottom.x, hip_pos_y - snap_leniency);
+        let lower_bound = Vector2f::new(ecb_bottom.x, upper_bound_y - snap_leniency);
         let mut ground_pos_any = Vector2f::zero();
         let mut ground_pos_stage = Vector2f::zero();
-        GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, hip_pos_y), &snap_detect_bottom, &Vector2f::zero(), &mut ground_pos_any, true);
-        GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, hip_pos_y), &snap_detect_bottom, &Vector2f::zero(), &mut ground_pos_stage, false);
+        GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, upper_bound_y), &lower_bound, &Vector2f::zero(), &mut ground_pos_any, true);
+        GroundModule::line_segment_check(self, &Vector2f::new(ecb_bottom.x, upper_bound_y), &lower_bound, &Vector2f::zero(), &mut ground_pos_stage, false);
         let can_snap = !( 
             ground_pos_any == Vector2f::zero()
             || (ground_pos_stage != Vector2f::zero()
                 && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) > 0.0)
-            || (self.is_prev_status(*FIGHTER_STATUS_KIND_PASS)
-                && ground_pos_stage == Vector2f::zero()
-                && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0)
         );
         if can_snap { // pretty sure it returns a pointer, at least it defo returns a non-0 value if success
             crate::VarModule::on_flag(self.object(), crate::consts::vars::common::status::DISABLE_ECB_SHIFT);

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -850,7 +850,12 @@ impl BomaExt for BattleObjectModuleAccessor {
         let ecb_bottom = *GroundModule::get_rhombus(self, true).add(1);
         let pos = *PostureModule::pos(self);
         let mut hip_offset = Vector3f::zero();
-        ModelModule::joint_global_offset_from_top(self, Hash40::new("hip"), &mut hip_offset);
+        let upper_bound_bone = if self.kind() == *FIGHTER_KIND_KOOPAJR && self.is_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+            "clownhip"
+        } else {
+            "hip"
+        };
+        ModelModule::joint_global_offset_from_top(self, Hash40::new(upper_bound_bone), &mut hip_offset);
         let hip_pos_y = pos.y + hip_offset.y;
         let snap_leniency = if WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0 {
                 // For a downwards/horizontal airdodge, waveland snap threshold = the distance from your Hip bone to your Top bone
@@ -869,7 +874,8 @@ impl BomaExt for BattleObjectModuleAccessor {
             || (ground_pos_stage != Vector2f::zero()
                 && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) > 0.0)
             || (self.is_prev_status(*FIGHTER_STATUS_KIND_PASS)
-                && ground_pos_stage == Vector2f::zero())
+                && ground_pos_stage == Vector2f::zero()
+                && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0)
         );
         if can_snap { // pretty sure it returns a pointer, at least it defo returns a non-0 value if success
             crate::VarModule::on_flag(self.object(), crate::consts::vars::common::status::DISABLE_ECB_SHIFT);

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -847,7 +847,7 @@ impl BomaExt for BattleObjectModuleAccessor {
     
         // The distance from your ECB center to your base position is your waveland snap threshold
         let pos = *PostureModule::pos(self);
-        let upper_bound_offset_y = if StatusModule::is_changing(self) {
+        let upper_bound_offset_y = if StatusModule::is_changing(self) && !self.is_prev_status(*FIGHTER_STATUS_KIND_PASS) {
             crate::VarModule::get_float(self.object(), crate::consts::vars::common::instance::ECB_CENTER_Y_OFFSET)
         } else {
             crate::VarModule::get_float(self.object(), crate::consts::vars::common::instance::ECB_BOTTOM_Y_OFFSET)

--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -21,6 +21,8 @@ unsafe fn ground_module_ecb_point_calc_hook(ground_module: u64, param_1: *mut *m
     if (*boma).is_fighter() {
         VarModule::off_flag((*boma).object(), vars::common::instance::IS_GETTING_POSITION_FOR_ECB);
         VarModule::set_float((*boma).object(), vars::common::instance::ECB_BOTTOM_Y_OFFSET, *param_3);
+        let ecb_center_y_offset = ((*param_5 - *param_3) / 2.0) + *param_3;
+        VarModule::set_float((*boma).object(), vars::common::instance::ECB_CENTER_Y_OFFSET, ecb_center_y_offset);
     }
     if !(*boma).is_fighter()
     || VarModule::is_flag((*boma).object(), vars::common::status::DISABLE_ECB_SHIFT)

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -462,20 +462,20 @@ unsafe fn setup_escape_air_slide_common(fighter: &mut L2CFighterCommon, stick_x:
     WorkModule::set_int(fighter.module_accessor, escape_air_slide_back_end_frame + escape_air_add_xlu_start_frame, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_INT_SLIDE_BACK_END_FRAME);
     WorkModule::set_float(fighter.module_accessor, escape_air_slide_stiff_frame, *FIGHTER_STATUS_ESCAPE_AIR_STIFF_FRAME);
     
-    EffectModule::req_on_joint(
-        fighter.module_accessor,
-        Hash40::new("sys_smash_flash_s"),
-        Hash40::new("hip"),
-        &Vector3f{x: 0.0, y: 4.0, z: 8.0},
-        &Vector3f::zero(),
-        1.1,
-        &Vector3f{x: 18.0, y: 12.0, z: 0.0},
-        &Vector3f::zero(),
-        false,
-        0,
-        0,
-        0
-    );
+    // EffectModule::req_on_joint(
+    //     fighter.module_accessor,
+    //     Hash40::new("sys_smash_flash_s"),
+    //     Hash40::new("hip"),
+    //     &Vector3f{x: 0.0, y: 4.0, z: 8.0},
+    //     &Vector3f::zero(),
+    //     1.1,
+    //     &Vector3f{x: 18.0, y: 12.0, z: 0.0},
+    //     &Vector3f::zero(),
+    //     false,
+    //     0,
+    //     0,
+    //     0
+    // );
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_exec_escape_air_slide)]

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -337,7 +337,9 @@ unsafe extern "C" fn sub_escape_air_common_strans_main(fighter: &mut L2CFighterC
     let stick_x = fighter.global_table[STICK_X].get_f32();
     let passive_fb_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("passive_fb_cont_value"));
     // lazy eval gaurantees that we don't call handle_waveland if we are on the ground
-    if situation_kind == *SITUATION_KIND_GROUND || fighter.handle_waveland(false) {
+    // or if you have begun falling (after frame 30)
+    if situation_kind == *SITUATION_KIND_GROUND
+    || (!WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_KINE_FALL) && fighter.handle_waveland(false)) {
         if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_FLAG_PREV_STATUS_PASSIVE_GROUND) 
         && WorkModule::get_float(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) <= 0.0 {
             if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_PASSIVE_FB)


### PR DESCRIPTION
## Current behavior:
Currently, you are able to waveland when a surface intersects the distance from your **ECB's bottom point** to your **base position** on airdodge initiation, as seen below:

![oldwavelandsnap](https://user-images.githubusercontent.com/47401664/236071811-77839bff-30fd-4d35-810a-ae62ff8d5ca9.png)

That being said, ECB shifts vary wildly across the cast. Some characters' ECBs do not offset much from their base position, and therefore have a more difficult time wavelanding than others. This is most noticeable with stubbier characters, who barely get any leeway with waveland snapping.

## New behavior:
This changes the waveland snap threshold to be the distance from your **ECB center** to your **base position** on airdodge initiation, as seen below:

![newwavelandsnap](https://user-images.githubusercontent.com/47401664/236071834-aa8b2908-9ddf-45e0-9731-9d34faee790e.png)

I believe this makes for a more consistent visual metric of "wavelandable" area across the cast.

With this change, characters should *generally* be able to snap onto a platform if initiating an airdodge approximately halfway into the platform, much like Rivals.

This also removes the "twinkle" graphical effect on directional airdodge/wavedash/waveland, which should lessen visual clutter during movement.