### PR TITLE
Pits recovery adjustments

### DIFF
--- a/fighters/pit/src/acmd/specials.rs
+++ b/fighters/pit/src/acmd/specials.rs
@@ -29,10 +29,80 @@ unsafe fn pit_special_n_fire_hi_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "pit", script = "game_specialsstart", category = ACMD_GAME, low_priority )]
+unsafe fn game_specialsstart(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_MOVE_FRONT);
+        //damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_ALWAYS, 0);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 12.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+    }
+    frame(lua_state, 27.0);
+    if is_excute(fighter) {
+        //damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_NORMAL, 0);
+    }
+    frame(lua_state, 31.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_GRAVITY_ONOFF);
+    }
+    frame(lua_state, 36.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_MTRANS_AIR_UNABLE);
+        AttackModule::clear_all(boma);
+        WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
+        WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+    }
+}
+
+#[acmd_script( agent = "pit", script = "game_specialairsstart", category = ACMD_GAME, low_priority )]
+unsafe fn game_specialairsstart(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        boma.select_cliff_hangdata_from_name("special_s");
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_MOVE_FRONT);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        //damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_ALWAYS, 0);
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 14.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
+    }
+    frame(lua_state, 27.0);
+    if is_excute(fighter) {
+        //damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_NORMAL, 0);
+    }
+    frame(lua_state, 31.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_GRAVITY_ONOFF);
+    }
+    frame(lua_state, 36.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
+        shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
+        AttackModule::clear_all(boma);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         pit_special_n_fire_s_game,
         pit_special_n_fire_hi_game,
+        game_specialsstart,
+        game_specialairsstart
     );
 }
 

--- a/fighters/pit/src/lib.rs
+++ b/fighters/pit/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/pit/src/status/mod.rs
+++ b/fighters/pit/src/status/mod.rs
@@ -1,0 +1,8 @@
+use super::*;
+use smashline::*;
+
+mod special_hi;
+
+pub fn install() {
+    special_hi::install();
+}

--- a/fighters/pit/src/status/special_hi.rs
+++ b/fighters/pit/src/status/special_hi.rs
@@ -1,0 +1,85 @@
+use super::*;
+use globals::*;
+
+
+// FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END
+
+#[status_script(agent = "pit", status = FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn special_hi_rush_end_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_MOTION_FALL,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_FLOAT,
+        0
+    );
+
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        0,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    
+    0.into()
+}
+
+#[status_script(agent = "pit", status = FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_hi_end"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+    let x_max_mul = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_FALL_X_MAX_MUL);
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        air_speed_x_stable * x_max_mul,
+        0.0
+    );
+
+    fighter.select_cliff_hangdata_from_name("special_hi");
+    
+    fighter.main_shift(special_hi_rush_end_main_loop)
+}
+
+unsafe extern "C" fn special_hi_rush_end_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        return 0.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, false);
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        special_hi_rush_end_pre,
+        special_hi_rush_end_main
+    );
+}

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -62,6 +62,7 @@ unsafe fn pitb_special_air_s_start_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
+        boma.select_cliff_hangdata_from_name("special_s");
         WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_MOVE_FRONT);
     }
     frame(lua_state, 19.0);

--- a/fighters/pitb/src/lib.rs
+++ b/fighters/pitb/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -34,13 +34,13 @@ unsafe fn guardian_orbitar_jc(boma: &mut BattleObjectModuleAccessor, status_kind
 
 
 extern "Rust" {
-    fn pits_common(boma: &mut BattleObjectModuleAccessor, status_kind: i32);
+    fn pits_common(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32);
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_ff_lc(boma, status_kind, situation_kind, cat[1], stick_y);
     guardian_orbitar_jc(boma, status_kind, situation_kind, cat[0], stick_x, facing, frame);
-    pits_common(boma, status_kind);
+    pits_common(fighter, boma, status_kind);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PITB )]
@@ -54,6 +54,6 @@ pub fn pitb_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn pitb_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/pitb/src/status/mod.rs
+++ b/fighters/pitb/src/status/mod.rs
@@ -1,0 +1,8 @@
+use super::*;
+use smashline::*;
+
+mod special_hi;
+
+pub fn install() {
+    special_hi::install();
+}

--- a/fighters/pitb/src/status/special_hi.rs
+++ b/fighters/pitb/src/status/special_hi.rs
@@ -1,0 +1,85 @@
+use super::*;
+use globals::*;
+
+
+// FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END
+
+#[status_script(agent = "pitb", status = FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn special_hi_rush_end_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_MOTION_FALL,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_PIT_SPECIAL_HI_RUSH_END_FLOAT,
+        0
+    );
+
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        0,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    
+    0.into()
+}
+
+#[status_script(agent = "pitb", status = FIGHTER_PIT_STATUS_KIND_SPECIAL_HI_RUSH_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_hi_end"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+    let x_max_mul = WorkModule::get_float(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLOAT_FALL_X_MAX_MUL);
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        air_speed_x_stable * x_max_mul,
+        0.0
+    );
+
+    fighter.select_cliff_hangdata_from_name("special_hi");
+    
+    fighter.main_shift(special_hi_rush_end_main_loop)
+}
+
+unsafe extern "C" fn special_hi_rush_end_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        return 0.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, false);
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        special_hi_rush_end_pre,
+        special_hi_rush_end_main
+    );
+}

--- a/romfs/config.json
+++ b/romfs/config.json
@@ -39,6 +39,12 @@
 		],
 		"fighter/pacman/cmn": [
 			"fighter/pacman/param/hdr.prc"
+		],
+		"fighter/pit/cmn": [
+			"fighter/pit/param/hdr.prc"
+		],
+		"fighter/pitb/cmn": [
+			"fighter/pitb/param/hdr.prc"
 		]
 	}
 }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -3042,7 +3042,7 @@
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">11</float>
       <float hash="landing_attack_air_frame_lw">10</float>
-      <bool hash="wall_jump_type">true</bool>
+      <bool hash="wall_jump_type">false</bool>
       <float hash="tread_jump_speed_y_mul">0.9</float>
       <float hash="tread_mini_jump_speed_y_mul">0.9</float>
       <int hash="attack_hi4_hold_keep_frame">1</int>

--- a/romfs/source/fighter/pit/param/hdr.xml
+++ b/romfs/source/fighter/pit/param/hdr.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <struct hash="cliff_hang_data">
+        <struct hash="special_hi">
+            <float hash="p1_x">16</float>
+            <float hash="p1_y">20</float>
+            <float hash="p2_x">-9.6</float>
+            <float hash="p2_y">11</float>
+        </struct>
+        <struct hash="special_s">
+            <float hash="p1_x">16</float>
+            <float hash="p1_y">20</float>
+            <float hash="p2_x">-9.6</float>
+            <float hash="p2_y">11</float>
+        </struct>
+    </struct>
+</struct>

--- a/romfs/source/fighter/pit/param/vl.prcxml
+++ b/romfs/source/fighter/pit/param/vl.prcxml
@@ -32,11 +32,19 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <list hash="param_special_s">
+    <struct index="0">
+      <float hash="0x1548c529ef">4</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="rush_speed">3</float>
       <int hash="rush_brake_frame">1</int>
-      <int hash="landing_frame">24</int>
+      <int hash="landing_frame">28</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/pit/param/vl.prcxml
+++ b/romfs/source/fighter/pit/param/vl.prcxml
@@ -2,7 +2,7 @@
 <struct>
   <list hash="cliff_hang_data">
     <struct index="0">
-      <float hash="p1_y">22</float>
+      <float hash="p1_y">25</float>
     </struct>
   </list>
   <list hash="fly_speed_y">
@@ -36,6 +36,7 @@
     <struct index="0">
       <float hash="rush_speed">3</float>
       <int hash="rush_brake_frame">1</int>
+      <int hash="landing_frame">24</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/pitb/param/hdr.xml
+++ b/romfs/source/fighter/pitb/param/hdr.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <struct hash="cliff_hang_data">
+        <struct hash="special_hi">
+            <float hash="p1_x">16</float>
+            <float hash="p1_y">20</float>
+            <float hash="p2_x">-9.6</float>
+            <float hash="p2_y">11</float>
+        </struct>
+        <struct hash="special_s">
+            <float hash="p1_x">16</float>
+            <float hash="p1_y">20</float>
+            <float hash="p2_x">-9.6</float>
+            <float hash="p2_y">11</float>
+        </struct>
+    </struct>
+</struct>

--- a/romfs/source/fighter/pitb/param/vl.prcxml
+++ b/romfs/source/fighter/pitb/param/vl.prcxml
@@ -30,6 +30,14 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <list hash="param_special_s">
+    <struct index="0">
+      <float hash="0x1548c529ef">4</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="rush_speed">2.5</float>

--- a/romfs/source/fighter/pitb/param/vl.prcxml
+++ b/romfs/source/fighter/pitb/param/vl.prcxml
@@ -2,7 +2,7 @@
 <struct>
   <list hash="cliff_hang_data">
     <struct index="0">
-      <float hash="p1_y">22</float>
+      <float hash="p1_y">25</float>
     </struct>
   </list>
   <list hash="fly_speed_y">
@@ -36,6 +36,7 @@
       <int hash="rush_brake_frame">1</int>
       <float hash="rush_end_speed_rate_x">0.05</float>
       <float hash="rush_end_speed_rate_y">0.025</float>
+      <float hash="rush_angle">90</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -10,3 +10,5 @@ chrom: fighter/chrom/param/hdr.prc
 captain: fighter/captain/param/hdr.prc
 pacman: fighter/pacman/param/hdr.prc
 kamui: fighter/kamui/param/hdr.prc
+pit: fighter/pit/param/hdr.prc
+pitb: fighter/pitb/param/hdr.prc

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -12,3 +12,5 @@ fighter/chrom/param/hdr.xml
 fighter/captain/param/hdr.xml
 fighter/pacman/param/hdr.xml
 fighter/kamui/param/hdr.xml
+fighter/pit/param/hdr.xml
+fighter/pitb/param/hdr.xml


### PR DESCRIPTION
# Pit:
- Normal ledgegrab box reverted to vanilla

### SideB:
- Now freefalls on whiff
- Can no longer be jump canceled in the air
- Armor removed
- Custom ledgegrab box implemented, lower than before
- Now land cancels on hit

### UpB:
- Intangibility on startup removed
- Momentum on cancel adjusted for more natural feel/easier aiming
- Able to drift much sooner after reaching peak/after canceling
- Landing lag reduced 28 -> 24
- Custom ledgegrab box implemented, lower than before

---

# Dark Pit:
- Normal ledgegrab box reverted to vanilla

### SideB:
- Now freefalls on whiff
- Custom ledgegrab box implemented, lower than before
- Now land cancels on hit

### UpB:
- Intangibility on startup removed
- Angleability reduced 160 -> 90 (45° in either direction)
- Momentum on cancel adjusted for more natural feel/easier aiming
- Able to drift much sooner after reaching peak/after canceling
- Custom ledgegrab box implemented, lower than before