### PR TITLE
Paisy followup recovery adjustments

### DIFF
--- a/fighters/daisy/src/opff.rs
+++ b/fighters/daisy/src/opff.rs
@@ -25,8 +25,16 @@ unsafe fn wall_bounce(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+unsafe fn up_special_freefall_land_cancel(fighter: &mut L2CFighterCommon) {
+    if fighter.is_prev_status(*FIGHTER_STATUS_KIND_FALL_SPECIAL)
+    && fighter.is_status(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING, false);
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     wall_bounce(boma, status_kind);
+    up_special_freefall_land_cancel(fighter);
 }
 #[utils::macros::opff(FIGHTER_KIND_DAISY )]
 pub unsafe fn daisy_frame_wrapper(fighter: &mut L2CFighterCommon) {
@@ -35,6 +43,6 @@ pub unsafe fn daisy_frame_wrapper(fighter: &mut L2CFighterCommon) {
 }
 pub unsafe fn daisy_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/peach/src/opff.rs
+++ b/fighters/peach/src/opff.rs
@@ -35,9 +35,17 @@ unsafe fn wall_bounce(boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+unsafe fn up_special_freefall_land_cancel(fighter: &mut L2CFighterCommon) {
+    if fighter.is_prev_status(*FIGHTER_STATUS_KIND_FALL_SPECIAL)
+    && fighter.is_status(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING, false);
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     float_cancel(boma, status_kind);
     wall_bounce(boma, status_kind);
+    up_special_freefall_land_cancel(fighter);
 }
 
 #[::utils::macros::opff(FIGHTER_KIND_PEACH )]
@@ -50,6 +58,6 @@ pub fn peach_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn peach_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -2934,7 +2934,7 @@
       <float hash="landing_attack_air_frame_hi">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
       <int hash="landing_heavy_frame">4</int>
-      <int hash="jump_count_max">3</int>
+      <int hash="jump_count_max">2</int>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>

--- a/romfs/source/fighter/daisy/param/vl.prcxml
+++ b/romfs/source/fighter/daisy/param/vl.prcxml
@@ -45,6 +45,7 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="special_hi_start_dir_mul">30</float>
+      <float hash="special_hi_start_trans_speed_mul">0.8</float>
       <float hash="special_hi_fall_accel_x_mul">0.8</float>
       <float hash="special_hi_fall_accel_y_mul">-0.01</float>
       <int hash="special_hi_parasol_limit_time">120</int>

--- a/romfs/source/fighter/peach/param/vl.prcxml
+++ b/romfs/source/fighter/peach/param/vl.prcxml
@@ -42,7 +42,7 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
-      <float hash="special_hi_start_trans_speed_mul">0.925</float>
+      <float hash="special_hi_start_trans_speed_mul">0.8</float>
       <int hash="special_hi_landing_mot_frame">30</int>
     </struct>
     <hash40 index="1">dummy</hash40>


### PR DESCRIPTION
### UpB:
- Height multiplier reduced 0.925 -> 0.8 (matches P+ height)
- Freefall (when Parasol is put away) now land cancels
  - Still undergo 30f landing lag if Parasol is out