### PR TITLE
Pac-Man recovery followup adjustments

### DIFF
--- a/fighters/common/src/function_hooks/ledges.rs
+++ b/fighters/common/src/function_hooks/ledges.rs
@@ -658,12 +658,7 @@ unsafe fn check_cliff_entry_specializer(boma: &mut BattleObjectModuleAccessor) -
             }
         }
         if motion_kind == hash40("special_s_move") || motion_kind == hash40("special_s_dash") {
-            if frame < 10.0 {
-                return 1;
-            }
-            else{
-                return -1;
-            }
+            return 1;
         }
     }
 

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -38,10 +38,19 @@ unsafe fn side_special_freefall(fighter: &mut L2CFighterCommon) {
     }
 }
 
+// Allows you to land out of upB before reaching end of animation (weird vanilla behavior)
+unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_HI_END)
+    && fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind);
     bonus_fruit_toss_ac(boma, status_kind, situation_kind, cat[0], frame);
     side_special_freefall(fighter);
+    up_special_proper_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_PACMAN )]


### PR DESCRIPTION
### UpB:
- Removed weird vanilla behavior that disallowed you from landing until reaching end of animation (when Pac-Man completes the flip at the peak)

### SideB:
- Removed ability to grab ledge while rising