### PR TITLE
UpB landing fixes

### DIFF
--- a/fighters/common/src/opff/shotos.rs
+++ b/fighters/common/src/opff/shotos.rs
@@ -145,6 +145,13 @@ unsafe fn training_mode_full_meter(fighter: &mut L2CFighterCommon, boma: &mut Ba
     }
 }
 
+unsafe fn up_special_early_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_JUMP) 
+    && fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status_req(*FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_LANDING, false);
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "Rust" fn shotos_common(fighter: &mut L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
@@ -153,21 +160,12 @@ pub unsafe extern "Rust" fn shotos_common(fighter: &mut L2CFighterCommon) {
 }
 
 pub unsafe fn shotos_moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    MeterModule::update(fighter.battle_object, false);
-    if boma.kind() != *FIGHTER_KIND_DOLLY {
-        utils::ui::UiManager::set_ex_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
-        utils::ui::UiManager::set_ex_meter_info(
-            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
-            MeterModule::meter(fighter.object()),
-            ParamModule::get_float(fighter.object(), ParamType::Common, "meter_max_damage"),
-            MeterModule::meter_per_level(fighter.object())
-        );
-    }
     //dtilt_utilt_repeat_increment(boma, id, motion_kind); // UNUSED
     tatsumaki_ex_land_cancel_hover(boma, status_kind, situation_kind);
 	//ex_shoryuken(boma, status_kind, situation_kind, motion_kind);
     hadoken_fadc_sfs_cancels(fighter, boma, id, status_kind, cat, frame);
     training_mode_full_meter(fighter, boma, status_kind);
+    up_special_early_landing(fighter);
 
     // Magic Series
     //magic_series(fighter, boma, id, cat, status_kind, situation_kind, motion_kind, stick_x, stick_y, facing, frame);

--- a/fighters/ken/src/opff.rs
+++ b/fighters/ken/src/opff.rs
@@ -21,7 +21,14 @@ extern "Rust" {
 #[fighter_frame( agent = FIGHTER_KIND_KEN )]
 pub fn ken_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
-        shotos_common(fighter);
+        MeterModule::update(fighter.battle_object, false);
+        utils::ui::UiManager::set_ex_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_ex_meter_info(
+            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
+            MeterModule::meter(fighter.object()),
+            ParamModule::get_float(fighter.object(), ParamType::Common, "meter_max_damage"),
+            MeterModule::meter_per_level(fighter.object())
+        );
     }
 }
 
@@ -29,6 +36,7 @@ pub fn ken_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 pub fn ken_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
+        shotos_common(fighter);
 		ken_frame(fighter);
     }
 }

--- a/fighters/littlemac/src/opff.rs
+++ b/fighters/littlemac/src/opff.rs
@@ -76,10 +76,21 @@ unsafe fn nspecial_cancels(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma:
     }
 }
 
+// Fixes weird vanilla behavior where touching ground during upB puts you into special fall for 1f before landing
+unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_HI_JUMP)
+    && fighter.is_situation(*SITUATION_KIND_GROUND)
+    && MotionModule::frame(fighter.module_accessor) >= 28.0 {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        KineticModule::clear_speed_energy_id(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     normal_side_special(boma, status_kind);
     tech_roll_help(boma, motion_kind, facing, frame);
     nspecial_cancels(fighter, boma, status_kind, situation_kind, cat[0], frame);
+    up_special_proper_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LITTLEMAC )]

--- a/fighters/marth/src/opff.rs
+++ b/fighters/marth/src/opff.rs
@@ -16,8 +16,19 @@ pub unsafe fn dancing_blade_vertical_momentum(boma: &mut BattleObjectModuleAcces
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+// Fixes weird vanilla behavior where touching ground during upB puts you into special fall for 1f before landing
+unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI)
+    && fighter.is_situation(*SITUATION_KIND_GROUND)
+    && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_MARTH_STATUS_SPECIAL_HI_FLAG_TRANS_MOVE);
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     dancing_blade_vertical_momentum(boma);
+    up_special_proper_landing(fighter);
 }
 
 
@@ -37,6 +48,6 @@ pub fn marth_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn marth_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/roy/src/opff.rs
+++ b/fighters/roy/src/opff.rs
@@ -16,8 +16,19 @@ pub unsafe fn double_edge_dance_vertical_momentum(boma: &mut BattleObjectModuleA
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+// Fixes weird vanilla behavior where touching ground during upB puts you into special fall for 1f before landing
+unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI)
+    && fighter.is_situation(*SITUATION_KIND_GROUND)
+    && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_ROY_STATUS_SPECIAL_HI_FLAG_FREE_FALL) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_ROY_STATUS_SPECIAL_HI_FLAG_FREE_FALL);
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     double_edge_dance_vertical_momentum(boma);
+    up_special_proper_landing(fighter);
 }
 
 
@@ -37,6 +48,6 @@ pub fn roy_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn roy_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }

--- a/fighters/ryu/src/opff.rs
+++ b/fighters/ryu/src/opff.rs
@@ -20,7 +20,14 @@ extern "Rust" {
 #[fighter_frame( agent = FIGHTER_KIND_RYU )]
 pub fn ryu_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
-        shotos_common(fighter);
+        MeterModule::update(fighter.battle_object, false);
+        utils::ui::UiManager::set_ex_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_ex_meter_info(
+            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
+            MeterModule::meter(fighter.object()),
+            ParamModule::get_float(fighter.object(), ParamType::Common, "meter_max_damage"),
+            MeterModule::meter_per_level(fighter.object())
+        );
     }
 }
 
@@ -28,6 +35,7 @@ pub fn ryu_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 pub fn ryu_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
+        shotos_common(fighter);
 		ryu_frame(fighter);
     }
 }

--- a/fighters/shulk/src/opff.rs
+++ b/fighters/shulk/src/opff.rs
@@ -21,9 +21,25 @@ unsafe fn air_slash_cancels(boma: &mut BattleObjectModuleAccessor, id: usize, st
     }
 }
 
-pub unsafe fn moveset(boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+// Fixes weird vanilla behavior where touching ground during upB puts you into special fall for 1f before landing
+unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI)
+    && fighter.is_situation(*SITUATION_KIND_GROUND)
+    && WorkModule::is_flag(fighter.module_accessor, *FIGHTER_SHULK_STATUS_SPECIAL_HI_FLAG_IS_FALL) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_SHULK_STATUS_SPECIAL_HI_FLAG_IS_FALL);
+    }
+    else if fighter.is_status(*FIGHTER_SHULK_STATUS_KIND_SPECIAL_HI_ADD)
+    && fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        KineticModule::clear_speed_energy_id(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    }
+}
+
+pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     // Magic Series
     air_slash_cancels(boma, id, status_kind, cat[0], frame);
+    up_special_proper_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_SHULK )]
@@ -36,6 +52,6 @@ pub fn shulk_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 
 pub unsafe fn shulk_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if let Some(info) = FrameInfo::update_and_get(fighter) {
-        moveset(&mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
+        moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }


### PR DESCRIPTION
Fixes vanilla behavior where the following characters were locked out of landing until reaching the end of upB's animation:
- Ryu
- Ken

Fixes vanilla behavior where the following characters would enter special fall for a single frame before landing out of upB:
- Marth
- Lucina
- Roy
- Shulk
- Little Mac