### PR TITLE
Bowser recovery followup adjustments

### DIFF
--- a/romfs/source/fighter/koopa/param/vl.prcxml
+++ b/romfs/source/fighter/koopa/param/vl.prcxml
@@ -22,11 +22,12 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
-      <float hash="special_hi_ar_ax">0.1</float>
-      <float hash="special_hi_ar_vx_max">1.2</float>
-      <float hash="special_hi_ar_vy0">2.1</float>
-      <float hash="special_hi_jump_restart_start_frame">-1</float>
-      <float hash="special_hi_jump_restart_end_frame">-1</float>
+      <float hash="special_hi_ar_ax">0.07</float>
+      <float hash="special_hi_ar_vx_max">0.8</float>
+      <float hash="special_hi_ar_vy0">1.8</float>
+      <float hash="special_hi_jump_speed_y">0.9</float>
+      <float hash="special_hi_jump_restart_start_frame">1</float>
+      <float hash="special_hi_jump_restart_end_frame">50</float>
       <float hash="special_hi_jump_restart_prohibition_frame">5</float>
       <int hash="special_hi_landing_f">28</int>
     </struct>


### PR DESCRIPTION
### UpB:
- Mash reinstated
  - Max height same as last PR
- Max horizontal air accel reduced 0.1 -> 0.07
- Max horizontal air speed reduced 1.2 -> 0.8
- Initial vertical air speed reduced 2.1 -> 1.8
- Added vertical speed on mash input reduced 1.0 -> 0.9