### PR TITLE
Ganon Down B Edge Cancel + C Falcon Misc. Effect Cleanup

### DIFF
--- a/fighters/captain/src/acmd/specials.rs
+++ b/fighters/captain/src/acmd/specials.rs
@@ -266,6 +266,22 @@ unsafe fn captain_special_air_lw_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "captain", script = "effect_specialairlw" , category = ACMD_EFFECT , low_priority)]
+unsafe fn captain_special_air_lw_effect (fighter: &mut L2CAgentBase) {
+	let lua_state = fighter.lua_state_agent;
+	let boma = fighter.boma();
+	frame(lua_state, 2.0);
+	if is_excute(fighter) {
+		EFFECT_FOLLOW(fighter, Hash40::new("captain_fk_hold"), Hash40::new("bust"), 0, 0, 0, 0, 0, 0, 0.7, true);
+		EffectModule::enable_sync_init_pos_last(fighter.module_accessor);
+	}
+	frame(lua_state, 12.0);
+	if is_excute(fighter) {
+		EFFECT_FOLLOW(fighter, Hash40::new("captain_fk_air"), Hash40::new("toel"), 1, 1, 0, 0, 0, 140, 0.45, true);
+		EffectModule::enable_sync_init_pos_last(fighter.module_accessor);
+	}
+}
+
 #[acmd_script( agent = "captain", script = "game_specialairlwend" , category = ACMD_GAME , low_priority)]
 unsafe fn captain_special_air_lw_end_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -332,6 +348,7 @@ pub fn install() {
         captain_special_s_end_game,
         captain_special_air_s_end_game,
         captain_special_air_lw_game,
+        captain_special_air_lw_effect,
         captain_special_air_lw_end_game,
         game_specialhithrow
     );

--- a/fighters/ganon/src/acmd/specials.rs
+++ b/fighters/ganon/src/acmd/specials.rs
@@ -211,14 +211,14 @@ unsafe fn ganon_special_air_lw_end_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 0.790);
-        let speed_vector = smash::phx::Vector3f { x: 1.65, y: 0.0, z: 0.0 };
-        KineticModule::add_speed(boma, &speed_vector);
     }
     frame(lua_state, 2.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 80, 35, 0, 80, 4.5, 0.0, 3.2, 9.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 8.0, 80, 35, 0, 80, 4.8, 0.0, 3.2, -9.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 2, 0, Hash40::new("top"), 8.0, 80, 35, 0, 80, 4.8, 0.0, 3.2, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        let speed_vector = smash::phx::Vector3f { x: 1.65, y: 0.0, z: 0.0 };
+        KineticModule::add_speed(boma, &speed_vector);
     }
     wait(lua_state, 2.0);
     if is_excute(fighter) {


### PR DESCRIPTION
## Ganon
- fixes a bug (seemingly) that prevented down b from edge canceling
- intended speed untouched

https://user-images.githubusercontent.com/19886440/236708998-bef9c14d-1c75-4adb-9ac9-28d330bf290c.mp4

> so, all the facets were already in place to allow this to edge cancel, and im guessing it either got bugged after order of ops was introduced or it was always bugged /shrug

## Captain Falcon
- fixes big bloated aerial falcon kick effect size

- new

https://user-images.githubusercontent.com/19886440/236711951-f9b5e7ae-4412-4a0b-90bd-dc48af7f9ea7.mp4

- vanilla 

https://user-images.githubusercontent.com/19886440/236712158-f6af1eca-9943-42b0-ad5a-491178cb3f8d.mp4

> how did no one notice...