### PR TITLE
Reset tech lockout timer on hit

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -246,6 +246,7 @@ pub mod vars {
 
             pub const IS_JAB_LOCK_ROLL: i32 = 0x1000;
             pub const IS_SPIKE: i32 = 0x1001;
+            pub const DAMAGE_FLY_RESET_TRIGGER: i32 = 0x1002;
 
             pub const SUICIDE_THROW_CAN_CLATTER: i32 = 0x1000;
 

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -418,9 +418,14 @@ unsafe fn sub_DamageFlyCommon_hook(fighter: &mut L2CFighterCommon) -> L2CValue {
     }
     else {
         if !fighter.global_table[IS_STOPPING].get_bool()
-        && fighter.sub_DamageFlyChkUniq().get_bool()
         {
-            return true.into();
+            if fighter.sub_DamageFlyChkUniq().get_bool() {
+                return true.into();
+            }
+            if fighter.global_table[CURRENT_FRAME].get_i32() > 1 && !VarModule::is_flag(fighter.battle_object, vars::common::status::DAMAGE_FLY_RESET_TRIGGER) {
+                ControlModule::reset_trigger(fighter.module_accessor);
+                VarModule::on_flag(fighter.battle_object, vars::common::status::DAMAGE_FLY_RESET_TRIGGER);
+            }
         }
         return false.into();
     }


### PR DESCRIPTION
The 40f tech lockout timer will now be reset once hitlag is over **or** when bouncing off a surface.

This should remedy situations where it feels as though a tech was input with the proper timing, but lockout from a previous tech attempt or a grab input prevented you from teching.