### PR TITLE
Give Bowser Jr. an ECB offset

### DIFF
--- a/fighters/koopajr/src/status.rs
+++ b/fighters/koopajr/src/status.rs
@@ -69,9 +69,6 @@ unsafe fn sub_escape_air_common(fighter: &mut L2CFighterCommon) {
 
 unsafe extern "C" fn sub_escape_air_uniq(fighter: &mut L2CFighterCommon, arg: L2CValue) -> L2CValue {
     if arg.get_bool() {
-        if fighter.handle_waveland(false) {
-            return 1.into();
-        }
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_WORK_INT_FRAME);
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_INT_SLIDE_FRAME);
         // if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_AIR_LASSO) {
@@ -167,12 +164,9 @@ unsafe extern "C" fn sub_escape_air_common_main(fighter: &mut L2CFighterCommon) 
         if sub_escape_air_common_strans_main(fighter).get_bool() {
             return L2CValue::Bool(true);
         }
-        if fighter.handle_waveland(false) {
-            return true.into();
-        }
         if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
             fighter.change_status(
-                L2CValue::I32(*FIGHTER_STATUS_KIND_LANDING),
+                L2CValue::I32(*FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING),
                 L2CValue::Bool(false)
             );
             return L2CValue::Bool(true);

--- a/romfs/source/fighter/koopajr/param/vl.prcxml
+++ b/romfs/source/fighter/koopajr/param/vl.prcxml
@@ -1,5 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
+  <list hash="map_coll_data">
+    <hash40 index="0">dummy</hash40>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+    <hash40 index="4">dummy</hash40>
+    <struct index="5">
+      <hash40 hash="node">clownshaft2</hash40>
+    </struct>
+    <struct index="6">
+      <hash40 hash="node">clownshaft2</hash40>
+    </struct>
+  </list>
+  <list hash="jostle_map_coll_data">
+    <hash40 index="0">dummy</hash40>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+    <hash40 index="4">dummy</hash40>
+    <struct index="5">
+      <hash40 hash="node">clownshaft2</hash40>
+    </struct>
+    <struct index="6">
+      <hash40 hash="node">clownshaft2</hash40>
+    </struct>
+  </list>
   <list hash="cliff_hang_data">
     <struct index="0">
       <float hash="p1_y">20.5</float>


### PR DESCRIPTION
Bowser Jr. is currently the only character without an ECB bottom offset. This affects the feel of everything from aerial spacing, tech timing, and most importantly, wavelanding, as the engine uses your ECB bottom for waveland snapping.

This adds a slight ECB offset from Bowser Jr,'s base position; the game now uses the `clownshaft2` bone for ECB bottom after 10 frames in the air, rather than the `top` bone.

This should bring Bowser Jr.'s gamefeel more in line with the rest of the cast, as well as letting him have an easier time wavelanding.