### PR TITLE
Mewtwo TP Hotfix

### DIFF
--- a/fighters/mewtwo/src/opff.rs
+++ b/fighters/mewtwo/src/opff.rs
@@ -9,7 +9,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
         return;
     }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI
-    && StatusModule::is_changing(boma) {
+    && boma.status_frame() == 1 {
         VarModule::off_flag(boma.object(), vars::mewtwo::instance::GROUNDED_TELEPORT);
         if situation_kind == *SITUATION_KIND_GROUND {
             VarModule::on_flag(boma.object(), vars::mewtwo::instance::GROUNDED_TELEPORT);
@@ -38,7 +38,7 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
 unsafe fn dj_upB_jump_refresh(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
         // If first 3 frames of dj
-        if fighter.status_frame() <= 2 {
+        if fighter.status_frame() <= 3 {
             VarModule::on_flag(fighter.battle_object, vars::mewtwo::instance::UP_SPECIAL_JUMP_REFRESH);
         }
         else {


### PR DESCRIPTION
Makes mewtwo able to jump out of grounded teleport again, changes frame double jump is restored to 3. 