### PR TITLE
Enable zair edge cancels

### DIFF
--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -39,7 +39,8 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
             *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE,
-            *FIGHTER_STATUS_KIND_DAMAGE].contains(&status_kind) {
+            *FIGHTER_STATUS_KIND_DAMAGE,
+            *FIGHTER_STATUS_KIND_AIR_LASSO_LANDING].contains(&status_kind) {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
 


### PR DESCRIPTION
Zairs can now be edge canceled, as any other aerial can.

Fixes #726 