### PR TITLE
Recovery sweep hotfixes + adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -680,6 +680,12 @@ pub mod vars {
         }
     }
 
+    pub mod pikmin {
+        pub mod instance {
+            pub const SPECIAL_HI_CANCEL_ESCAPE_AIR: i32 = 0x0100;
+        }
+    }
+
     pub mod plizardon {
         pub mod instance {
             pub const DISABLE_SPECIAL_S: i32 = 0x0100;

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -136,6 +136,12 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
         && next_status == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_HI_FALL {
             next_status = *FIGHTER_PEACH_STATUS_KIND_SPECIAL_HI_AIR_END;
         }
+        // Prevent jumping out of Minecart when out of jumps
+        if boma.kind() == *FIGHTER_KIND_PICKEL
+        && next_status == *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_S_JUMP
+        && boma.get_num_used_jumps() >= boma.get_jump_count_max() {
+            return 0;
+        }
     }
     original!()(boma, next_status, clear_buffer)
 }

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -130,6 +130,12 @@ unsafe fn change_status_request_from_script_hook(boma: &mut BattleObjectModuleAc
             WorkModule::off_flag(boma, *FIGHTER_INKLING_STATUS_SPECIAL_S_FLAG_JUMP_END);
             return 0;
         }
+        // Prevents Daisy from floating out of upB
+        if boma.kind() == *FIGHTER_KIND_DAISY
+        && StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_SPECIAL_HI
+        && next_status == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_HI_FALL {
+            next_status = *FIGHTER_PEACH_STATUS_KIND_SPECIAL_HI_AIR_END;
+        }
     }
     original!()(boma, next_status, clear_buffer)
 }

--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -40,7 +40,8 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
             *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE,
-            *FIGHTER_STATUS_KIND_DAMAGE].contains(&status_kind) {
+            *FIGHTER_STATUS_KIND_DAMAGE,
+            *FIGHTER_STATUS_KIND_AIR_LASSO_LANDING].contains(&status_kind) {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
 

--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -16,7 +16,8 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
     let fighter_kind = boma.kind();
     let status_kind = StatusModule::status_kind(boma);
 
-    if boma.is_fighter() {
+    if boma.is_fighter()
+    && boma.is_situation(*SITUATION_KIND_GROUND) {
 
         if status_kind == *FIGHTER_STATUS_KIND_APPEAL {
             fix = *GROUND_CORRECT_KIND_GROUND as u32; /* GROUND_CORRECT_KIND_GROUND is i32 */
@@ -63,7 +64,8 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
                                                        *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind)) 
            || (boma.kind() == *FIGHTER_KIND_KOOPAJR && boma.is_status(*FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING))
            || (boma.kind() == *FIGHTER_KIND_SHEIK && [*FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_ATTACK,
-                                                       *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind)) {
+                                                       *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind))
+           || (boma.kind() == *FIGHTER_KIND_LUIGI && boma.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_LANDING_FALL)) {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
     }
@@ -81,7 +83,8 @@ unsafe fn correct_hook(boma: &mut BattleObjectModuleAccessor, kind: GroundCorrec
     let fighter_kind = boma.kind();
 
     // It seems like everything gets caught as "landing"
-    if boma.is_fighter() {
+    if boma.is_fighter()
+    && boma.is_situation(*SITUATION_KIND_GROUND) {
         if [
             *FIGHTER_STATUS_KIND_LANDING,
             *FIGHTER_STATUS_KIND_TURN_DASH,

--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -40,8 +40,7 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
             *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR,
             // *FIGHTER_STATUS_KIND_ESCAPE_AIR_SLIDE,
-            *FIGHTER_STATUS_KIND_DAMAGE,
-            *FIGHTER_STATUS_KIND_AIR_LASSO_LANDING].contains(&status_kind) {
+            *FIGHTER_STATUS_KIND_DAMAGE].contains(&status_kind) {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
 
@@ -62,11 +61,26 @@ pub unsafe fn init_settings_edges(boma: &mut BattleObjectModuleAccessor, situati
            || (fighter_kind == *FIGHTER_KIND_BAYONETTA && [*FIGHTER_BAYONETTA_STATUS_KIND_SPECIAL_AIR_S_D,
                                                            *FIGHTER_BAYONETTA_STATUS_KIND_SPECIAL_AIR_S_D_LANDING].contains(&status_kind))
            || (fighter_kind == *FIGHTER_KIND_DOLLY && [*FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_ATTACK,
-                                                       *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind)) 
+                                                       *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_LW_LANDING,
+                                                       *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_B_LANDING,
+                                                       *FIGHTER_DOLLY_STATUS_KIND_SPECIAL_HI_LANDING].contains(&status_kind)) 
            || (boma.kind() == *FIGHTER_KIND_KOOPAJR && boma.is_status(*FIGHTER_KOOPAJR_STATUS_KIND_SPECIAL_HI_LANDING))
            || (boma.kind() == *FIGHTER_KIND_SHEIK && [*FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_ATTACK,
                                                        *FIGHTER_SHEIK_STATUS_KIND_SPECIAL_LW_LANDING].contains(&status_kind))
-           || (boma.kind() == *FIGHTER_KIND_LUIGI && boma.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_LANDING_FALL)) {
+           || (boma.kind() == *FIGHTER_KIND_LUIGI && boma.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_LANDING_FALL))
+           || (boma.kind() == *FIGHTER_KIND_PIT && boma.is_status(*FIGHTER_PIT_STATUS_KIND_SPECIAL_S_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_PITB && boma.is_status(*FIGHTER_PIT_STATUS_KIND_SPECIAL_S_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_SIMON && boma.is_status(*FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_RICHTER && boma.is_status(*FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_DEMON && boma.is_status(*FIGHTER_DEMON_STATUS_KIND_SPECIAL_S_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_RYU && boma.is_status(*FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_KEN && boma.is_status(*FIGHTER_RYU_STATUS_KIND_SPECIAL_HI_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_PACKUN && boma.is_status(*FIGHTER_PACKUN_STATUS_KIND_SPECIAL_HI_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_KROOL && boma.is_status(*FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_PIKMIN && boma.is_status(*FIGHTER_PIKMIN_STATUS_KIND_SPECIAL_HI_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_FALCO && boma.is_status(*FIGHTER_FALCO_STATUS_KIND_SPECIAL_S_FALL_LANDING))
+           || (boma.kind() == *FIGHTER_KIND_MURABITO && boma.is_status(*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_HI_LANDING))
+        {
             fix = *GROUND_CORRECT_KIND_GROUND as u32;
         }
     }
@@ -102,9 +116,11 @@ unsafe fn correct_hook(boma: &mut BattleObjectModuleAccessor, kind: GroundCorrec
             || (fighter_kind == *FIGHTER_KIND_GANON && status_kind == *FIGHTER_GANON_STATUS_KIND_SPECIAL_LW_END)
             || (fighter_kind == *FIGHTER_KIND_MIISWORDSMAN && [*FIGHTER_MIISWORDSMAN_STATUS_KIND_SPECIAL_LW3_END].contains(&status_kind))
             || (fighter_kind == *FIGHTER_KIND_KOOPA && status_kind == *FIGHTER_KOOPA_STATUS_KIND_SPECIAL_HI_G)
-            || (fighter_kind == *FIGHTER_KIND_DONKEY && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI)
-            || (fighter_kind == *FIGHTER_KIND_GAOGAEN && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
-            || (fighter_kind == *FIGHTER_KIND_LUIGI && situation_kind == *SITUATION_KIND_GROUND && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N) {
+            || (fighter_kind == *FIGHTER_KIND_DONKEY && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI)
+            || (fighter_kind == *FIGHTER_KIND_GAOGAEN && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
+            || (fighter_kind == *FIGHTER_KIND_LUIGI && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
+            || (fighter_kind == *FIGHTER_KIND_PEACH && status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_S_AWAY_END)
+            || (fighter_kind == *FIGHTER_KIND_DAISY && status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_S_AWAY_END) {
             return original!()(boma, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
         }
     }

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -118,7 +118,7 @@ unsafe fn skip_early_main_status(boma: *mut BattleObjectModuleAccessor, status_k
         || ((*boma).kind() == *FIGHTER_KIND_SIMON
             && [*FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_ATTACK_HI3, *FIGHTER_STATUS_KIND_ATTACK_S3, *FIGHTER_STATUS_KIND_ATTACK_HI4, *FIGHTER_STATUS_KIND_ATTACK_S4, *FIGHTER_STATUS_KIND_ATTACK_LW4].contains(&status_kind))
         || ((*boma).kind() == *FIGHTER_KIND_MASTER
-            && [*FIGHTER_MASTER_STATUS_KIND_SPECIAL_N_MAX_SHOOT].contains(&status_kind))
+            && [*FIGHTER_MASTER_STATUS_KIND_SPECIAL_N_MAX_SHOOT, *FIGHTER_STATUS_KIND_SPECIAL_HI].contains(&status_kind))
         || ((*boma).kind() == *FIGHTER_KIND_KIRBY
             && [*FIGHTER_KIRBY_STATUS_KIND_MASTER_SPECIAL_N_MAX_SHOOT].contains(&status_kind))
         || ((*boma).kind() == *FIGHTER_KIND_JACK

--- a/fighters/daisy/src/acmd/specials.rs
+++ b/fighters/daisy/src/acmd/specials.rs
@@ -193,8 +193,8 @@ unsafe fn daisy_special_air_hi_start_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 31.0);
     if is_excute(fighter) {
         AttackModule::set_attack_reference_joint_id(boma, Hash40::new("haver"), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y));
-        ATTACK(fighter, 0, 0, Hash40::new("havel"), 4.0, 81, 70, 0, 90, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 4.0, 81, 70, 0, 90, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 0, 0, Hash40::new("havel"), 1.0, 78, 100, 90, 0, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 1, 0, Hash40::new("arml"), 1.0, 72, 100, 60, 0, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
     }
     frame(lua_state, 33.0);
     if is_excute(fighter) {

--- a/fighters/daisy/src/acmd/specials.rs
+++ b/fighters/daisy/src/acmd/specials.rs
@@ -124,8 +124,8 @@ unsafe fn daisy_special_hi_start_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 31.0);
     if is_excute(fighter) {
         AttackModule::set_attack_reference_joint_id(boma, Hash40::new("haver"), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y));
-        ATTACK(fighter, 0, 0, Hash40::new("havel"), 4.0, 81, 70, 0, 90, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 4.0, 81, 70, 0, 90, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 0, 0, Hash40::new("havel"), 4.0, 81, 70, 0, 90, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 1, 0, Hash40::new("arml"), 4.0, 81, 70, 0, 90, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
     }
     frame(lua_state, 33.0);
     if is_excute(fighter) {
@@ -193,8 +193,8 @@ unsafe fn daisy_special_air_hi_start_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 31.0);
     if is_excute(fighter) {
         AttackModule::set_attack_reference_joint_id(boma, Hash40::new("haver"), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y));
-        ATTACK(fighter, 0, 0, Hash40::new("havel"), 1.0, 78, 100, 90, 0, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 1.0, 72, 100, 60, 0, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 0, 0, Hash40::new("havel"), 1.0, 78, 100, 90, 0, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 1, 0, Hash40::new("arml"), 1.0, 72, 100, 60, 0, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
     }
     frame(lua_state, 33.0);
     if is_excute(fighter) {

--- a/fighters/daisy/src/opff.rs
+++ b/fighters/daisy/src/opff.rs
@@ -32,9 +32,25 @@ unsafe fn up_special_freefall_land_cancel(fighter: &mut L2CFighterCommon) {
     }
 }
 
+// Prevents Daisy from being able to use both aerial jumps immediately after one another
+unsafe fn triple_jump_lockout(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
+        let triple_jump_lockout_frame = ParamModule::get_int(fighter.object(), ParamType::Agent, "triple_jump_lockout_frame");
+        if fighter.global_table[CURRENT_FRAME].get_i32() < triple_jump_lockout_frame {
+            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL);
+            WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON);
+        }
+        else {
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL);
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON);
+        }
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     wall_bounce(boma, status_kind);
     up_special_freefall_land_cancel(fighter);
+    triple_jump_lockout(fighter);
 }
 #[utils::macros::opff(FIGHTER_KIND_DAISY )]
 pub unsafe fn daisy_frame_wrapper(fighter: &mut L2CFighterCommon) {

--- a/fighters/daisy/src/opff.rs
+++ b/fighters/daisy/src/opff.rs
@@ -49,7 +49,7 @@ unsafe fn triple_jump_lockout(fighter: &mut L2CFighterCommon) {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     wall_bounce(boma, status_kind);
-    up_special_freefall_land_cancel(fighter);
+    //up_special_freefall_land_cancel(fighter);
     triple_jump_lockout(fighter);
 }
 #[utils::macros::opff(FIGHTER_KIND_DAISY )]

--- a/fighters/dolly/src/status.rs
+++ b/fighters/dolly/src/status.rs
@@ -47,13 +47,139 @@ unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommo
     }
 }
 
-// Re-enables the ability to use sideB when connecting to ground or cliff
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Re-enables the ability to use sideB when connecting to ground or cliff
     if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
     || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD]) {
         VarModule::off_flag(fighter.battle_object, vars::dolly::instance::DISABLE_SPECIAL_S);
     }
-    true.into()
+    
+    // ORIGINAL
+    if fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_WAIT {
+        FighterSpecializer_Dolly::update_opponent_lr_1on1(fighter.module_accessor, fighter.global_table[STATUS_KIND].get_i32());
+    }
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLAG_AUTO_TURN_END_STATUS);
+    let lr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLOAT_OPPONENT_LR_1ON1);
+    if lr == 0.0
+    || PostureModule::lr(fighter.module_accessor) == lr
+    || StatusModule::situation_kind(fighter.module_accessor) != *SITUATION_KIND_GROUND {
+        return 0.into();
+    }
+
+    unsafe fn update_lr(fighter: &mut L2CFighterCommon, lr: f32) {
+        PostureModule::set_lr(fighter.module_accessor, lr);
+        PostureModule::update_rot_y_lr(fighter.module_accessor);
+    }
+
+    if [
+        *FIGHTER_STATUS_KIND_WALK,
+        *FIGHTER_STATUS_KIND_SQUAT,
+        *FIGHTER_STATUS_KIND_SQUAT_RV,
+        *FIGHTER_STATUS_KIND_LANDING,
+        *FIGHTER_STATUS_KIND_LANDING_LIGHT,
+        *FIGHTER_STATUS_KIND_GUARD_ON,
+        *FIGHTER_STATUS_KIND_ESCAPE,
+        *FIGHTER_STATUS_KIND_ATTACK_HI3,
+        *FIGHTER_STATUS_KIND_ATTACK_LW3,
+        *FIGHTER_STATUS_KIND_ATTACK_HI4_START,
+        *FIGHTER_STATUS_KIND_ATTACK_LW4_START,
+        *FIGHTER_STATUS_KIND_CATCH,
+        *FIGHTER_STATUS_KIND_ITEM_SWING,
+        *FIGHTER_STATUS_KIND_SPECIAL_N,
+        *FIGHTER_STATUS_KIND_FINAL,
+        *FIGHTER_RYU_STATUS_KIND_WALK_BACK,
+    ].contains(&fighter.global_table[globals::STATUS_KIND].get_i32())
+    {
+        update_lr(fighter, lr);
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_WAIT {
+        if ![
+            *FIGHTER_STATUS_KIND_DASH,
+            *FIGHTER_RYU_STATUS_KIND_DASH_BACK,
+            *FIGHTER_STATUS_KIND_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_TURN_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL,
+            *FIGHTER_STATUS_KIND_SQUAT_RV,
+            *FIGHTER_STATUS_KIND_TREAD_DAMAGE_RV,
+            *FIGHTER_STATUS_KIND_GUARD_OFF,
+            *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
+            *FIGHTER_STATUS_KIND_ESCAPE,
+            *FIGHTER_STATUS_KIND_ESCAPE_F,
+            *FIGHTER_STATUS_KIND_ESCAPE_B,
+            *FIGHTER_STATUS_KIND_ATTACK_DASH,
+            *FIGHTER_STATUS_KIND_ATTACK_S3,
+            *FIGHTER_STATUS_KIND_ATTACK_HI3,
+            *FIGHTER_STATUS_KIND_ATTACK_S4,
+            *FIGHTER_STATUS_KIND_ATTACK_HI4,
+            *FIGHTER_STATUS_KIND_ATTACK_LW4,
+            *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR,
+            *FIGHTER_STATUS_KIND_CATCH,
+            *FIGHTER_STATUS_KIND_CATCH_DASH,
+            *FIGHTER_STATUS_KIND_CATCH_TURN,
+            *FIGHTER_STATUS_KIND_CATCH_CUT,
+            *FIGHTER_STATUS_KIND_THROW,
+            *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+            *FIGHTER_STATUS_KIND_DAMAGE,
+            *FIGHTER_STATUS_KIND_DOWN_STAND,
+            *FIGHTER_STATUS_KIND_DOWN_STAND_FB,
+            *FIGHTER_STATUS_KIND_PASSIVE,
+            *FIGHTER_STATUS_KIND_PASSIVE_FB,
+            *FIGHTER_STATUS_KIND_FURAFURA_END,
+            *FIGHTER_STATUS_KIND_DAMAGE_SONG_END,
+            *FIGHTER_STATUS_KIND_CLIFF_CLIMB,
+            *FIGHTER_STATUS_KIND_CLIFF_ATTACK,
+            *FIGHTER_STATUS_KIND_CLIFF_ESCAPE,
+            *FIGHTER_STATUS_KIND_SLIP_STAND,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_F,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_B,
+            *FIGHTER_STATUS_KIND_ITEM_LIGHT_PICKUP,
+            *FIGHTER_STATUS_KIND_ITEM_THROW,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_DASH,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_HEAVY,
+            *FIGHTER_STATUS_KIND_ITEM_SWING,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S3,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S4,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_DASH,
+            *FIGHTER_STATUS_KIND_APPEAL,
+            *FIGHTER_STATUS_KIND_SPECIAL_N
+        ].contains(&fighter.global_table[globals::STATUS_KIND_INTERRUPT].get_i32())
+        {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_SQUAT {
+        if fighter.global_table[globals::STATUS_KIND_INTERRUPT] != FIGHTER_STATUS_KIND_TURN_RUN {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ATTACK {
+        if fighter.global_table[globals::STATUS_KIND] != FIGHTER_STATUS_KIND_ATTACK || ComboModule::count(fighter.module_accessor) == 0 {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ITEM_THROW
+    && fighter.global_table[globals::SITUATION_KIND] == SITUATION_KIND_GROUND
+    {
+        let cat3 = fighter.global_table[globals::CMD_CAT3].get_i32();
+        if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_4 != 0 && cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_FB4 == 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI != 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_LW != 0 {
+            update_lr(fighter, lr);
+        }
+    }
+
+    0.into()
 }
 
 #[smashline::fighter_init]

--- a/fighters/falco/src/status/special_hi.rs
+++ b/fighters/falco/src/status/special_hi.rs
@@ -22,6 +22,19 @@ pub unsafe fn special_hi_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     let ret = original!(fighter);
     KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
+    let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+    let fall_x_mul = WorkModule::get_param_float(
+        fighter.module_accessor,
+        hash40("param_special_hi"),
+        hash40("fire_fall_x_mul")
+    );
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        air_speed_x_stable * fall_x_mul,
+        0.0
+    );
     GroundModule::select_cliff_hangdata(fighter.module_accessor, *FIGHTER_FALCO_CLIFF_HANG_DATA_SPECIAL_HI as u32);
     ret
 }

--- a/fighters/falco/src/status/special_s.rs
+++ b/fighters/falco/src/status/special_s.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> 
             }
             else if step == *FIGHTER_FALCO_ILLUSION_STEP_END {
                 if situation == *SITUATION_KIND_AIR {
-                    fighter.change_status(FIGHTER_STATUS_KIND_FALL_SPECIAL.into(), true.into());
+                    fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), true.into());
                     return 0.into();
                 }
                 if is_end

--- a/fighters/fox/src/status/special_hi.rs
+++ b/fighters/fox/src/status/special_hi.rs
@@ -22,6 +22,19 @@ pub unsafe fn special_hi_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     let ret = original!(fighter);
     KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
+    let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+    let fall_x_mul = WorkModule::get_param_float(
+        fighter.module_accessor,
+        hash40("param_special_hi"),
+        hash40("fire_fall_x_mul")
+    );
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+        air_speed_x_stable * fall_x_mul,
+        0.0
+    );
     GroundModule::select_cliff_hangdata(fighter.module_accessor, *FIGHTER_FOX_CLIFF_HANG_DATA_SPECIAL_HI as u32);
     ret
 }

--- a/fighters/fox/src/status/special_s.rs
+++ b/fighters/fox/src/status/special_s.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> 
             }
             else if step == *FIGHTER_FOX_ILLUSION_STEP_END {
                 if situation == *SITUATION_KIND_AIR {
-                    fighter.change_status(FIGHTER_STATUS_KIND_FALL_SPECIAL.into(), true.into());
+                    fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), true.into());
                     return 0.into();
                 }
                 if is_end

--- a/fighters/ganon/src/acmd/specials.rs
+++ b/fighters/ganon/src/acmd/specials.rs
@@ -327,6 +327,7 @@ unsafe fn ganon_special_hi_effect(fighter: &mut L2CAgentBase) {
         EffectModule::enable_sync_init_pos_last(fighter.module_accessor);
     }
     frame(fighter.lua_state_agent, 31.0);
+    /* vanilla electric effects
     for _ in 0..4 {
         if is_excute(fighter) {
             EFFECT(fighter, Hash40::new("ganon_attack_elec"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, true);
@@ -334,6 +335,7 @@ unsafe fn ganon_special_hi_effect(fighter: &mut L2CAgentBase) {
         wait(fighter.lua_state_agent, 2.0);
     }
     frame(fighter.lua_state_agent, 42.0);
+    */
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("ganon_raijin_hold"), false, true);
     }

--- a/fighters/ike/src/acmd/specials.rs
+++ b/fighters/ike/src/acmd/specials.rs
@@ -178,6 +178,7 @@ unsafe fn ike_special_s_attack_game(fighter: &mut L2CAgentBase) {
     if VarModule::is_flag(boma.object(), vars::ike::status::IS_QUICK_DRAW_INSTAKILL){
         frame(lua_state, 1.0);
         if is_excute(fighter) {
+            fighter.select_cliff_hangdata_from_name("special_s");
             AttackModule::clear_all(boma);
             ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 70, 100, 400, 1, 6.0, 0.0, 8.0, 13.0, Some(0.0), Some(8.0), Some(-8.0), 10.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, -5, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_IKE, *ATTACK_REGION_SWORD);
             //ATTACK(fighter, 1, 1, Hash40::new("top"), 0.0, 361, 0, 0, 0, 6.0, 0.0, 7.0, 10.0, Some(0.0), Some(5.0), Some(-10.0), 5.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, true, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_SWORD);
@@ -205,7 +206,7 @@ unsafe fn ike_special_s_attack_game(fighter: &mut L2CAgentBase) {
         }
         frame(lua_state, 12.0);
         if is_excute(fighter) {
-            notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c070), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+            notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
             if !AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT){
                 FT_MOTION_RATE(fighter, 2.0);
             }
@@ -215,6 +216,7 @@ unsafe fn ike_special_s_attack_game(fighter: &mut L2CAgentBase) {
     else {
         frame(lua_state, 1.0);
         if is_excute(fighter) {
+            fighter.select_cliff_hangdata_from_name("special_s");
             AttackModule::clear_all(boma);
             FT_MOTION_RATE(fighter, 3.0/(1.1-1.0));
         }
@@ -245,7 +247,7 @@ unsafe fn ike_special_s_attack_game(fighter: &mut L2CAgentBase) {
         }
         frame(lua_state, 12.0);
         if is_excute(fighter) {
-            notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c070), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+            notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
         }
         frame(lua_state, 15.0);
         if is_excute(fighter) {
@@ -312,6 +314,7 @@ unsafe fn ike_special_air_s_attack_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
+        fighter.select_cliff_hangdata_from_name("special_s");
         FT_MOTION_RATE(fighter, 3.0/(1.1-1.0));
     }
     frame(lua_state, 1.1);
@@ -341,7 +344,7 @@ unsafe fn ike_special_air_s_attack_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c070), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 15.0);
     if is_excute(fighter) {
@@ -459,7 +462,7 @@ unsafe fn ike_special_hi2_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 44.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c070), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 47.0);
     if is_excute(fighter) {
@@ -530,7 +533,7 @@ unsafe fn ike_special_air_hi2_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 44.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c070), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 47.0);
     if is_excute(fighter) {

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -389,7 +389,7 @@ unsafe fn quickdraw_attack_whiff_freefall(fighter: &mut L2CFighterCommon) {
     && fighter.is_situation(*SITUATION_KIND_AIR)
     && !StatusModule::is_changing(fighter.module_accessor)
     && CancelModule::is_enable_cancel(fighter.module_accessor)
-    && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) {
+    && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT | *COLLISION_KIND_MASK_SHIELD) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
         let cancel_module = *(fighter.module_accessor as *mut BattleObjectModuleAccessor as *mut u64).add(0x128 / 8) as *const u64;
         *(((cancel_module as u64) + 0x1c) as *mut bool) = false;  // CancelModule::is_enable_cancel = false

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -387,6 +387,7 @@ unsafe fn fair_wrist_bend(boma: &mut BattleObjectModuleAccessor) {
 unsafe fn quickdraw_attack_whiff_freefall(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_IKE_STATUS_KIND_SPECIAL_S_ATTACK)
     && fighter.is_situation(*SITUATION_KIND_AIR)
+    && !StatusModule::is_changing(fighter.module_accessor)
     && CancelModule::is_enable_cancel(fighter.module_accessor)
     && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);

--- a/fighters/inkling/src/opff.rs
+++ b/fighters/inkling/src/opff.rs
@@ -32,7 +32,8 @@ unsafe fn roller_jump_cancel(boma: &mut BattleObjectModuleAccessor){
     if boma.is_status(*FIGHTER_INKLING_STATUS_KIND_SPECIAL_S_END) && boma.is_situation(*SITUATION_KIND_GROUND) && boma.status_frame() > 10 {
         boma.check_jump_cancel(true);
     }
-    if boma.is_motion(Hash40::new("special_air_s_jump_end")){
+    if boma.is_motion(Hash40::new("special_air_s_jump_end"))
+    && !StatusModule::is_changing(boma) {
         if MotionModule::frame(boma) > 6.0 {
             CancelModule::enable_cancel(boma);
         }

--- a/fighters/ken/src/status.rs
+++ b/fighters/ken/src/status.rs
@@ -42,13 +42,136 @@ unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommo
     }
 }
 
-// Re-enables the ability to use sideB when connecting to ground or cliff
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Re-enables the ability to use sideB when connecting to ground or cliff
     if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
     || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD]) {
         VarModule::off_flag(fighter.battle_object, vars::shotos::instance::DISABLE_SPECIAL_S);
     }
-    true.into()
+    
+    // ORIGINAL
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLAG_AUTO_TURN_END_STATUS);
+    let lr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLOAT_OPPONENT_LR_1ON1);
+    if lr == 0.0
+    || PostureModule::lr(fighter.module_accessor) == lr
+    || StatusModule::situation_kind(fighter.module_accessor) != *SITUATION_KIND_GROUND {
+        return 0.into();
+    }
+
+    unsafe fn update_lr(fighter: &mut L2CFighterCommon, lr: f32) {
+        PostureModule::set_lr(fighter.module_accessor, lr);
+        PostureModule::update_rot_y_lr(fighter.module_accessor);
+    }
+
+    if [
+        *FIGHTER_STATUS_KIND_WALK,
+        *FIGHTER_STATUS_KIND_SQUAT,
+        *FIGHTER_STATUS_KIND_SQUAT_RV,
+        *FIGHTER_STATUS_KIND_LANDING,
+        *FIGHTER_STATUS_KIND_LANDING_LIGHT,
+        *FIGHTER_STATUS_KIND_GUARD_ON,
+        *FIGHTER_STATUS_KIND_ESCAPE,
+        *FIGHTER_STATUS_KIND_ATTACK_HI3,
+        *FIGHTER_STATUS_KIND_ATTACK_LW3,
+        *FIGHTER_STATUS_KIND_ATTACK_HI4_START,
+        *FIGHTER_STATUS_KIND_ATTACK_LW4_START,
+        *FIGHTER_STATUS_KIND_CATCH,
+        *FIGHTER_STATUS_KIND_ITEM_SWING,
+        *FIGHTER_STATUS_KIND_SPECIAL_N,
+        *FIGHTER_STATUS_KIND_FINAL,
+        *FIGHTER_RYU_STATUS_KIND_WALK_BACK,
+    ].contains(&fighter.global_table[globals::STATUS_KIND].get_i32())
+    {
+        update_lr(fighter, lr);
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_WAIT {
+        if ![
+            *FIGHTER_STATUS_KIND_DASH,
+            *FIGHTER_RYU_STATUS_KIND_DASH_BACK,
+            *FIGHTER_STATUS_KIND_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_TURN_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL,
+            *FIGHTER_STATUS_KIND_SQUAT_RV,
+            *FIGHTER_STATUS_KIND_TREAD_DAMAGE_RV,
+            *FIGHTER_STATUS_KIND_GUARD_OFF,
+            *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
+            *FIGHTER_STATUS_KIND_ESCAPE,
+            *FIGHTER_STATUS_KIND_ESCAPE_F,
+            *FIGHTER_STATUS_KIND_ESCAPE_B,
+            *FIGHTER_STATUS_KIND_ATTACK_DASH,
+            *FIGHTER_STATUS_KIND_ATTACK_S3,
+            *FIGHTER_STATUS_KIND_ATTACK_HI3,
+            *FIGHTER_STATUS_KIND_ATTACK_S4,
+            *FIGHTER_STATUS_KIND_ATTACK_HI4,
+            *FIGHTER_STATUS_KIND_ATTACK_LW4,
+            *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR,
+            *FIGHTER_STATUS_KIND_CATCH,
+            *FIGHTER_STATUS_KIND_CATCH_DASH,
+            *FIGHTER_STATUS_KIND_CATCH_TURN,
+            *FIGHTER_STATUS_KIND_CATCH_CUT,
+            *FIGHTER_STATUS_KIND_THROW,
+            *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+            *FIGHTER_STATUS_KIND_DAMAGE,
+            *FIGHTER_STATUS_KIND_DOWN_STAND,
+            *FIGHTER_STATUS_KIND_DOWN_STAND_FB,
+            *FIGHTER_STATUS_KIND_PASSIVE,
+            *FIGHTER_STATUS_KIND_PASSIVE_FB,
+            *FIGHTER_STATUS_KIND_FURAFURA_END,
+            *FIGHTER_STATUS_KIND_DAMAGE_SONG_END,
+            *FIGHTER_STATUS_KIND_CLIFF_CLIMB,
+            *FIGHTER_STATUS_KIND_CLIFF_ATTACK,
+            *FIGHTER_STATUS_KIND_CLIFF_ESCAPE,
+            *FIGHTER_STATUS_KIND_SLIP_STAND,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_F,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_B,
+            *FIGHTER_STATUS_KIND_ITEM_LIGHT_PICKUP,
+            *FIGHTER_STATUS_KIND_ITEM_THROW,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_DASH,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_HEAVY,
+            *FIGHTER_STATUS_KIND_ITEM_SWING,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S3,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S4,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_DASH,
+            *FIGHTER_STATUS_KIND_APPEAL,
+            *FIGHTER_STATUS_KIND_SPECIAL_N
+        ].contains(&fighter.global_table[globals::STATUS_KIND_INTERRUPT].get_i32())
+        {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_SQUAT {
+        if fighter.global_table[globals::STATUS_KIND_INTERRUPT] != FIGHTER_STATUS_KIND_TURN_RUN {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ATTACK {
+        if fighter.global_table[globals::STATUS_KIND] != FIGHTER_STATUS_KIND_ATTACK || ComboModule::count(fighter.module_accessor) == 0 {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ITEM_THROW
+    && fighter.global_table[globals::SITUATION_KIND] == SITUATION_KIND_GROUND
+    {
+        let cat3 = fighter.global_table[globals::CMD_CAT3].get_i32();
+        if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_4 != 0 && cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_FB4 == 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI != 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_LW != 0 {
+            update_lr(fighter, lr);
+        }
+    }
+
+    0.into()
 }
 
 #[smashline::fighter_init]

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -32,7 +32,7 @@ unsafe fn fuel_reset(boma: &mut BattleObjectModuleAccessor) {
         *FIGHTER_STATUS_KIND_ENTRY,
         *FIGHTER_STATUS_KIND_DEAD,
         *FIGHTER_STATUS_KIND_REBIRTH]) {
-        VarModule::set_int(boma.object(), vars::krool::instance::SPECIAL_HI_FUEL, 540);
+        VarModule::set_int(boma.object(), vars::krool::instance::SPECIAL_HI_FUEL, 180);
     }
 }
 

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -25,6 +25,17 @@ unsafe fn jetpack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32
     }
 }
 
+unsafe fn fuel_reset(boma: &mut BattleObjectModuleAccessor) {
+    if boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_WIN,
+        *FIGHTER_STATUS_KIND_LOSE,
+        *FIGHTER_STATUS_KIND_ENTRY,
+        *FIGHTER_STATUS_KIND_DEAD,
+        *FIGHTER_STATUS_KIND_REBIRTH]) {
+        VarModule::set_int(boma.object(), vars::krool::instance::SPECIAL_HI_FUEL, 540);
+    }
+}
+
 // K. Rool Side B Crown Item Grab
 unsafe fn crownerang_item_grab(boma: &mut BattleObjectModuleAccessor, status_kind: i32, cat1: i32) {
     if [
@@ -64,6 +75,7 @@ pub unsafe fn moveset(
     frame: f32,
 ) {
     jetpack_cancel(boma, status_kind, cat[0]);
+    fuel_reset(boma);
     //crownerang_item_grab(boma, status_kind, cat[0]);
 }
 

--- a/fighters/link/src/status.rs
+++ b/fighters/link/src/status.rs
@@ -1,11 +1,12 @@
 use super::*;
 use globals::*;
 // status script import
- 
+
+
 pub fn install() {
     install_status_scripts!(
         pre_specialhi,
-        //specialhi,
+        specialhi,
         pre_specialhi_end,
         specialhi_end,
         //special_n
@@ -14,9 +15,15 @@ pub fn install() {
 
 // FIGHTER_STATUS_KIND_SPECIAL_HI //
 
-
 #[status_script(agent = "link", status = FIGHTER_STATUS_KIND_SPECIAL_HI, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
 pub unsafe fn pre_specialhi(fighter: &mut L2CFighterCommon, arg: u64) -> L2CValue {
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        let start_speed = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let start_x_mul = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "param_special_hi.start_x_mul");
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, start_speed * start_x_mul);
+        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+    }
     let mask_flag = if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         (*FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_HI | *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK | *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON) as u64
     } else {

--- a/fighters/littlemac/src/status/special_s.rs
+++ b/fighters/littlemac/src/status/special_s.rs
@@ -2,6 +2,8 @@ use super::*;
 use globals::*;
 
 
+// FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP
+
 #[status_script(agent = "littlemac", status = FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe extern "C" fn special_s_jump_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     ControlModule::reset_trigger(fighter.module_accessor);
@@ -9,8 +11,165 @@ unsafe extern "C" fn special_s_jump_main(fighter: &mut L2CFighterCommon) -> L2CV
     original!(fighter)
 }
 
+// FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP_END
+
+#[status_script(agent = "littlemac", status = FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_JUMP_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn special_s_jump_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_AIR);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_GROUND);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_MOTION_END);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_EX1);
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_s_jump_end"), 0.0, 1.0, false, 0.0, false, false);
+    fighter.main_shift(special_s_jump_end_main_loop)
+}
+
+unsafe extern "C" fn special_s_jump_end_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) && (fighter.sub_wait_ground_check_common(false.into()).get_bool() || fighter.sub_air_check_fall_common().get_bool()) {
+        return 1.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_WAIT, false);
+        }
+        else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+        return 1.into();
+    }
+    // <HDR>
+    if fighter.global_table[PREV_SITUATION_KIND] == SITUATION_KIND_GROUND
+    && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        return 1.into();
+    }
+    // </HDR>
+    0.into()
+}
+
+// FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_BLOW_END
+
+#[status_script(agent = "littlemac", status = FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_BLOW_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+unsafe extern "C" fn special_s_blow_end_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_GROUND as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (*FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_S | *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_S as u32,
+        0
+    );
+
+    0.into()
+}
+
+#[status_script(agent = "littlemac", status = FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_S_BLOW_END, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn special_s_blow_end_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_AIR);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_GROUND);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_MOTION_END);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_LITTLEMAC_INSTANCE_WORK_ID_FLAG_MTRANS_SMPL_EX1);
+
+    let prev_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        ENERGY_STOP_RESET_TYPE_GROUND,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        prev_speed_x,
+        0.0
+    );
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_MOTION,
+        ENERGY_MOTION_RESET_TYPE_GROUND_TRANS,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_MOTION);
+    
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+    KineticModule::unable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+
+    let mut prev_motion_frame = MotionModule::frame(fighter.module_accessor);
+    if prev_motion_frame - 10.0 < 0.0 {
+        prev_motion_frame = 0.0;
+    }
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_s_blow_end"), prev_motion_frame, 1.0, false, 0.0, false, false);
+    fighter.main_shift(special_s_blow_end_main_loop)
+}
+
+unsafe extern "C" fn special_s_blow_end_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) && (fighter.sub_wait_ground_check_common(false.into()).get_bool() || fighter.sub_air_check_fall_common().get_bool()) {
+        return 1.into();
+    }
+    let landing_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_s"), hash40("special_s_blow_landing_frame_"));
+    if MotionModule::is_end(fighter.module_accessor)
+    && fighter.global_table[CURRENT_FRAME].get_i32() >= landing_frame {
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_WAIT, false);
+        }
+        else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+        return 1.into();
+    }
+    // <HDR>
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        return 1.into();
+    }
+    // </HDR>
+    0.into()
+}
+
 pub fn install() {
     install_status_scripts!(
-        special_s_jump_main
+        special_s_jump_main,
+        special_s_jump_end_main,
+        special_s_blow_end_pre,
+        special_s_blow_end_main
     );
 }

--- a/fighters/lucina/src/acmd/specials.rs
+++ b/fighters/lucina/src/acmd/specials.rs
@@ -1616,7 +1616,7 @@ unsafe fn lucina_special_hi_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         AttackModule::clear(boma, 2, false);
         AttackModule::clear(boma, 3, false);
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
@@ -1654,7 +1654,7 @@ unsafe fn lucina_special_air_hi_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         AttackModule::clear(boma, 2, false);
         AttackModule::clear(boma, 3, false);
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {

--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -283,7 +283,7 @@ unsafe fn game_specials(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
         WorkModule::on_flag(boma, *FIGHTER_LUIGI_STATUS_SPECIAL_S_RAM_FLAG_BRAKE);
     }
     frame(lua_state, 24.0);
@@ -354,7 +354,7 @@ unsafe fn game_specialairsend(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     FT_MOTION_RATE(fighter, 0.8);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
 }
 

--- a/fighters/luigi/src/opff.rs
+++ b/fighters/luigi/src/opff.rs
@@ -4,12 +4,12 @@ use super::*;
 use globals::*;
 
  
-//unsafe fn luigi_missle_ledgegrab(fighter: &mut L2CFighterCommon) {
-//    if fighter.is_status_one_of(&[*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_RAM, *FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_END]) {
-//        // allows ledgegrab during Luigi Missile
-//        fighter.sub_transition_group_check_air_cliff();
-//    }
-//}
+unsafe fn luigi_missle_ledgegrab(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_END) {
+       // allows ledgegrab during Luigi Missile
+       fighter.sub_transition_group_check_air_cliff();
+    }
+}
 
 unsafe fn special_hi_proper_landing(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_LUIGI_STATUS_KIND_SPECIAL_HI_DROP) {
@@ -20,7 +20,7 @@ unsafe fn special_hi_proper_landing(fighter: &mut L2CFighterCommon) {
 }
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    //luigi_missle_ledgegrab(fighter);
+    luigi_missle_ledgegrab(fighter);
     special_s_charge_init(fighter, status_kind);
     special_hi_proper_landing(fighter);
 }

--- a/fighters/marth/src/acmd/specials.rs
+++ b/fighters/marth/src/acmd/specials.rs
@@ -680,7 +680,7 @@ unsafe fn marth_special_hi_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 7.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
@@ -717,7 +717,7 @@ unsafe fn marth_special_air_hi_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 7.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {

--- a/fighters/master/src/acmd/specials.rs
+++ b/fighters/master/src/acmd/specials.rs
@@ -451,7 +451,7 @@ unsafe fn master_special_air_hi_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 2.0, 6.0);
         ArticleModule::generate_article(boma, *FIGHTER_MASTER_GENERATE_ARTICLE_SWORD, false, 0);
-        ArticleModule::change_motion(boma, *FIGHTER_MASTER_GENERATE_ARTICLE_SWORD, Hash40::new("special_airhi"), false, 0.0);
+        ArticleModule::change_motion(boma, *FIGHTER_MASTER_GENERATE_ARTICLE_SWORD, Hash40::new("special_air_hi_start"), false, -1.0);
     }
     frame(lua_state, 8.0);
     if is_excute(fighter) {

--- a/fighters/metaknight/src/status/special_s.rs
+++ b/fighters/metaknight/src/status/special_s.rs
@@ -14,7 +14,8 @@ pub fn install() {
 pub unsafe fn special_s_end_end(fighter: &mut L2CFighterCommon) -> L2CValue {
     let ret = original!(fighter);
     // Land cancel on sideB rebound
-    if fighter.is_motion_one_of(&[Hash40::new("special_air_s_finish"), Hash40::new("special_air_s_finish_c2"), Hash40::new("special_air_s_finish_c3"), Hash40::new("special_air_s_finish_c4")]) {
+    if fighter.is_motion_one_of(&[Hash40::new("special_air_s_finish"), Hash40::new("special_air_s_finish_c2"), Hash40::new("special_air_s_finish_c3"), Hash40::new("special_air_s_finish_c4")])
+    && VarModule::is_flag(fighter.battle_object, vars::metaknight::instance::DOWN_SPECIAL_HIT) {
         let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
         WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
         WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);

--- a/fighters/metaknight/src/status/special_s.rs
+++ b/fighters/metaknight/src/status/special_s.rs
@@ -15,7 +15,7 @@ pub unsafe fn special_s_end_end(fighter: &mut L2CFighterCommon) -> L2CValue {
     let ret = original!(fighter);
     // Land cancel on sideB rebound
     if fighter.is_motion_one_of(&[Hash40::new("special_air_s_finish"), Hash40::new("special_air_s_finish_c2"), Hash40::new("special_air_s_finish_c3"), Hash40::new("special_air_s_finish_c4")])
-    && VarModule::is_flag(fighter.battle_object, vars::metaknight::instance::DOWN_SPECIAL_HIT) {
+    && VarModule::is_flag(fighter.battle_object, vars::metaknight::instance::SIDE_SPECIAL_HIT) {
         let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
         WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
         WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -2567,6 +2567,11 @@ unsafe fn miiswordsman_special_hi3_game(fighter: &mut L2CAgentBase) {
 unsafe fn miiswordsman_special_air_hi3_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    let start_speed = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+    let start_x_mul = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "param_special_hi3.start_x_mul");
+    fighter.clear_lua_stack();
+    lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, start_speed * start_x_mul);
+    app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
     frame(lua_state, 8.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 367, 100, 115, 0, 6.0, 0.0, 9.0, 7.0, Some(0.0), Some(6.0), Some(14.0), 0.75, 0.3, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);

--- a/fighters/packun/src/status/special_hi.rs
+++ b/fighters/packun/src/status/special_hi.rs
@@ -90,8 +90,49 @@ pub unsafe extern "C" fn special_hi_main_loop(fighter: &mut L2CFighterCommon) ->
     }
 }
 
+// FIGHTER_PACKUN_STATUS_KIND_SPECIAL_HI_LANDING
+
+#[status_script(agent = "packun", status = FIGHTER_PACKUN_STATUS_KIND_SPECIAL_HI_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn special_hi_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let landing_lag = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_hi"), hash40("landing_frame"));
+    let anim_length = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new("special_hi_landing"));
+    let rate: f32 = if landing_lag > 0 {
+        anim_length / landing_lag as f32
+    } else {
+        1.0
+    };
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_hi_landing"), 0.0, rate, false, 0.0, false, false);
+    fighter.main_shift(special_hi_landing_main_loop)
+}
+
+unsafe extern "C" fn special_hi_landing_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+    if CancelModule::is_enable_cancel(fighter.module_accessor) && (fighter.sub_wait_ground_check_common(false.into()).get_bool() || fighter.sub_air_check_fall_common().get_bool()) {
+        return 1.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_WAIT, false);
+        }
+        else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+        return 1.into();
+    }
+    // <HDR>
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        return 1.into();
+    }
+    // </HDR>
+    0.into()
+}
+
 pub fn install() {
     install_status_scripts!(
-        special_hi_main
+        special_hi_main,
+        special_hi_landing_main
     );
 }

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -29,7 +29,8 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
 }
 
 unsafe fn side_special_freefall(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_S_RETURN)
+    if fighter.is_prev_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_S_DASH)
+    && fighter.is_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_S_RETURN)
     && fighter.is_situation(*SITUATION_KIND_AIR)
     && CancelModule::is_enable_cancel(fighter.module_accessor) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);

--- a/fighters/pacman/src/opff.rs
+++ b/fighters/pacman/src/opff.rs
@@ -31,6 +31,7 @@ unsafe fn bonus_fruit_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind
 unsafe fn side_special_freefall(fighter: &mut L2CFighterCommon) {
     if fighter.is_prev_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_S_DASH)
     && fighter.is_status(*FIGHTER_PACMAN_STATUS_KIND_SPECIAL_S_RETURN)
+    && !StatusModule::is_changing(fighter.module_accessor)
     && fighter.is_situation(*SITUATION_KIND_AIR)
     && CancelModule::is_enable_cancel(fighter.module_accessor) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);

--- a/fighters/peach/src/acmd/specials.rs
+++ b/fighters/peach/src/acmd/specials.rs
@@ -130,8 +130,8 @@ unsafe fn peach_special_air_hi_start_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 31.0);
     if is_excute(fighter) {
         AttackModule::set_attack_reference_joint_id(boma, Hash40::new("haver"), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y), app::AttackDirectionAxis(*ATTACK_DIRECTION_Y));
-        ATTACK(fighter, 0, 0, Hash40::new("havel"), 4.0, 81, 105, 0, 90, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 4.0, 81, 105, 0, 90, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 0, 0, Hash40::new("havel"), 3.0, 78, 95, 0, 72, 5.2, 0.0, 4.5, -2.0, Some(0.0), Some(4.5), Some(2.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
+        ATTACK(fighter, 1, 0, Hash40::new("arml"), 3.0, 72, 95, 0, 72, 3.0, 0.0, -1.0, 0.0, Some(0.0), Some(1.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_magic"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PARASOL);
     }
     frame(lua_state, 33.0);
     if is_excute(fighter) {

--- a/fighters/pickel/src/lib.rs
+++ b/fighters/pickel/src/lib.rs
@@ -42,4 +42,6 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frames!(pickel_trolley_frame);
 }

--- a/fighters/pikmin/src/lib.rs
+++ b/fighters/pikmin/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/pikmin/src/status/mod.rs
+++ b/fighters/pikmin/src/status/mod.rs
@@ -1,0 +1,15 @@
+use super::*;
+use globals::*;
+
+
+pub fn install() {
+    install_status_scripts!(
+        escape_air_end
+    );
+}
+
+#[status_script(agent = "pikmin", status = FIGHTER_STATUS_KIND_ESCAPE_AIR, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+pub unsafe fn escape_air_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::off_flag(fighter.battle_object, vars::pikmin::instance::SPECIAL_HI_CANCEL_ESCAPE_AIR);
+    fighter.status_end_EscapeAir()
+}

--- a/fighters/pit/src/opff.rs
+++ b/fighters/pit/src/opff.rs
@@ -34,6 +34,7 @@ unsafe fn upperdash_arm_jump_and_aerial_cancel(boma: &mut BattleObjectModuleAcce
 unsafe fn upperdash_arm_whiff_freefall(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_S)
     && fighter.is_situation(*SITUATION_KIND_AIR)
+    && !StatusModule::is_changing(fighter.module_accessor)
     && MotionModule::frame(fighter.module_accessor) >= MotionModule::end_frame(fighter.module_accessor) - 1.0
     && !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);

--- a/fighters/pzenigame/src/opff.rs
+++ b/fighters/pzenigame/src/opff.rs
@@ -31,7 +31,10 @@ unsafe fn withdraw_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status_k
         *FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_END].contains(&status_kind)
         || status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S && frame > 11.0 {
     */
-    if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_HIT].contains(&status_kind) && frame >= 13.0 && !boma.is_in_hitlag() {
+    if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_HIT].contains(&status_kind)
+    && !StatusModule::is_changing(boma)
+    && frame >= 13.0
+    && !boma.is_in_hitlag() {
         //boma.check_jump_cancel(true);
         CancelModule::enable_cancel(boma);
     }

--- a/fighters/richter/src/lib.rs
+++ b/fighters/richter/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/richter/src/status/attacklw3.rs
+++ b/fighters/richter/src/status/attacklw3.rs
@@ -1,0 +1,46 @@
+use super::*;
+use globals::*;
+
+
+// FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING
+
+#[status_script(agent = "richter", status = FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn attack_lw32_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let landing_lag = WorkModule::get_param_int(fighter.module_accessor, hash40("param_private"), hash40("attack_lw32_landing_frame"));
+    let anim_length = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new("attack_lw32_landing"));
+    let rate: f32 = if landing_lag > 0 {
+        anim_length / landing_lag as f32
+    } else {
+        1.0
+    };
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_lw32_landing"), 0.0, rate, false, 0.0, false, false);
+    fighter.main_shift(attack_lw32_landing_main_loop)
+}
+
+unsafe extern "C" fn attack_lw32_landing_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) && (fighter.sub_wait_ground_check_common(false.into()).get_bool() || fighter.sub_air_check_fall_common().get_bool()) {
+        return 1.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_WAIT, false);
+        }
+        else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+        return 1.into();
+    }
+    // <HDR>
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        return 1.into();
+    }
+    // </HDR>
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        attack_lw32_landing_main
+    );
+}

--- a/fighters/richter/src/status/mod.rs
+++ b/fighters/richter/src/status/mod.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+mod attacklw3;
+
+
+pub fn install() {
+    attacklw3::install();
+}

--- a/fighters/roy/src/acmd/specials.rs
+++ b/fighters/roy/src/acmd/specials.rs
@@ -1283,7 +1283,7 @@ unsafe fn roy_special_hi_game(fighter: &mut L2CAgentBase) {
     }
     wait(lua_state, 1.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 33.0);
     if is_excute(fighter) {
@@ -1331,7 +1331,7 @@ unsafe fn roy_special_air_hi_game(fighter: &mut L2CAgentBase) {
     }
     wait(lua_state, 1.0);
     if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES);
     }
     frame(lua_state, 30.0);
     if is_excute(fighter) {

--- a/fighters/ryu/src/status.rs
+++ b/fighters/ryu/src/status.rs
@@ -60,13 +60,136 @@ unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommo
     }
 }
 
-// Re-enables the ability to use sideB when connecting to ground or cliff
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Re-enables the ability to use sideB when connecting to ground or cliff
     if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
     || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD]) {
         VarModule::off_flag(fighter.battle_object, vars::shotos::instance::DISABLE_SPECIAL_S);
     }
-    true.into()
+    
+    // ORIGINAL
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLAG_AUTO_TURN_END_STATUS);
+    let lr = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SPECIAL_COMMAND_USER_INSTANCE_WORK_ID_FLOAT_OPPONENT_LR_1ON1);
+    if lr == 0.0
+    || PostureModule::lr(fighter.module_accessor) == lr
+    || StatusModule::situation_kind(fighter.module_accessor) != *SITUATION_KIND_GROUND {
+        return 0.into();
+    }
+
+    unsafe fn update_lr(fighter: &mut L2CFighterCommon, lr: f32) {
+        PostureModule::set_lr(fighter.module_accessor, lr);
+        PostureModule::update_rot_y_lr(fighter.module_accessor);
+    }
+
+    if [
+        *FIGHTER_STATUS_KIND_WALK,
+        *FIGHTER_STATUS_KIND_SQUAT,
+        *FIGHTER_STATUS_KIND_SQUAT_RV,
+        *FIGHTER_STATUS_KIND_LANDING,
+        *FIGHTER_STATUS_KIND_LANDING_LIGHT,
+        *FIGHTER_STATUS_KIND_GUARD_ON,
+        *FIGHTER_STATUS_KIND_ESCAPE,
+        *FIGHTER_STATUS_KIND_ATTACK_HI3,
+        *FIGHTER_STATUS_KIND_ATTACK_LW3,
+        *FIGHTER_STATUS_KIND_ATTACK_HI4_START,
+        *FIGHTER_STATUS_KIND_ATTACK_LW4_START,
+        *FIGHTER_STATUS_KIND_CATCH,
+        *FIGHTER_STATUS_KIND_ITEM_SWING,
+        *FIGHTER_STATUS_KIND_SPECIAL_N,
+        *FIGHTER_STATUS_KIND_FINAL,
+        *FIGHTER_RYU_STATUS_KIND_WALK_BACK,
+    ].contains(&fighter.global_table[globals::STATUS_KIND].get_i32())
+    {
+        update_lr(fighter, lr);
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_WAIT {
+        if ![
+            *FIGHTER_STATUS_KIND_DASH,
+            *FIGHTER_RYU_STATUS_KIND_DASH_BACK,
+            *FIGHTER_STATUS_KIND_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_TURN_RUN_BRAKE,
+            *FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL,
+            *FIGHTER_STATUS_KIND_SQUAT_RV,
+            *FIGHTER_STATUS_KIND_TREAD_DAMAGE_RV,
+            *FIGHTER_STATUS_KIND_GUARD_OFF,
+            *FIGHTER_STATUS_KIND_GUARD_DAMAGE,
+            *FIGHTER_STATUS_KIND_ESCAPE,
+            *FIGHTER_STATUS_KIND_ESCAPE_F,
+            *FIGHTER_STATUS_KIND_ESCAPE_B,
+            *FIGHTER_STATUS_KIND_ATTACK_DASH,
+            *FIGHTER_STATUS_KIND_ATTACK_S3,
+            *FIGHTER_STATUS_KIND_ATTACK_HI3,
+            *FIGHTER_STATUS_KIND_ATTACK_S4,
+            *FIGHTER_STATUS_KIND_ATTACK_HI4,
+            *FIGHTER_STATUS_KIND_ATTACK_LW4,
+            *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR,
+            *FIGHTER_STATUS_KIND_CATCH,
+            *FIGHTER_STATUS_KIND_CATCH_DASH,
+            *FIGHTER_STATUS_KIND_CATCH_TURN,
+            *FIGHTER_STATUS_KIND_CATCH_CUT,
+            *FIGHTER_STATUS_KIND_THROW,
+            *FIGHTER_STATUS_KIND_CAPTURE_CUT,
+            *FIGHTER_STATUS_KIND_DAMAGE,
+            *FIGHTER_STATUS_KIND_DOWN_STAND,
+            *FIGHTER_STATUS_KIND_DOWN_STAND_FB,
+            *FIGHTER_STATUS_KIND_PASSIVE,
+            *FIGHTER_STATUS_KIND_PASSIVE_FB,
+            *FIGHTER_STATUS_KIND_FURAFURA_END,
+            *FIGHTER_STATUS_KIND_DAMAGE_SONG_END,
+            *FIGHTER_STATUS_KIND_CLIFF_CLIMB,
+            *FIGHTER_STATUS_KIND_CLIFF_ATTACK,
+            *FIGHTER_STATUS_KIND_CLIFF_ESCAPE,
+            *FIGHTER_STATUS_KIND_SLIP_STAND,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_F,
+            *FIGHTER_STATUS_KIND_SLIP_STAND_B,
+            *FIGHTER_STATUS_KIND_ITEM_LIGHT_PICKUP,
+            *FIGHTER_STATUS_KIND_ITEM_THROW,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_DASH,
+            *FIGHTER_STATUS_KIND_ITEM_THROW_HEAVY,
+            *FIGHTER_STATUS_KIND_ITEM_SWING,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S3,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_S4,
+            *FIGHTER_STATUS_KIND_ITEM_SWING_DASH,
+            *FIGHTER_STATUS_KIND_APPEAL,
+            *FIGHTER_STATUS_KIND_SPECIAL_N
+        ].contains(&fighter.global_table[globals::STATUS_KIND_INTERRUPT].get_i32())
+        {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_SQUAT {
+        if fighter.global_table[globals::STATUS_KIND_INTERRUPT] != FIGHTER_STATUS_KIND_TURN_RUN {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ATTACK {
+        if fighter.global_table[globals::STATUS_KIND] != FIGHTER_STATUS_KIND_ATTACK || ComboModule::count(fighter.module_accessor) == 0 {
+            update_lr(fighter, lr);
+        }
+        return 0.into();
+    }
+
+    if fighter.global_table[globals::STATUS_KIND] == FIGHTER_STATUS_KIND_ITEM_THROW
+    && fighter.global_table[globals::SITUATION_KIND] == SITUATION_KIND_GROUND
+    {
+        let cat3 = fighter.global_table[globals::CMD_CAT3].get_i32();
+        if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_4 != 0 && cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_FB4 == 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_HI != 0 {
+            update_lr(fighter, lr);
+        } else if cat3 & *FIGHTER_PAD_CMD_CAT3_FLAG_ITEM_LIGHT_THROW_LW != 0 {
+            update_lr(fighter, lr);
+        }
+    }
+
+    0.into()
 }
 
 #[smashline::fighter_init]

--- a/fighters/simon/src/lib.rs
+++ b/fighters/simon/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod acmd;
 
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -40,6 +40,6 @@ use smashline::*;
 
 pub fn install(is_runtime: bool) {
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -32,6 +32,7 @@ unsafe fn dair_cancels(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMo
     //Act out of it much faster on hit so you can actually followup on people with good DI
     if status_kind == *FIGHTER_STATUS_KIND_ATTACK_AIR
     && motion_kind == hash40("attack_air_lw2")
+    && !StatusModule::is_changing(fighter.module_accessor)
     {
         if frame > 15.0 {
             CancelModule::enable_cancel(fighter.module_accessor);

--- a/fighters/simon/src/status/attacklw3.rs
+++ b/fighters/simon/src/status/attacklw3.rs
@@ -1,0 +1,46 @@
+use super::*;
+use globals::*;
+
+
+// FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING
+
+#[status_script(agent = "simon", status = FIGHTER_SIMON_STATUS_KIND_ATTACK_LW32_LANDING, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe extern "C" fn attack_lw32_landing_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let landing_lag = WorkModule::get_param_int(fighter.module_accessor, hash40("param_private"), hash40("attack_lw32_landing_frame"));
+    let anim_length = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new("attack_lw32_landing"));
+    let rate: f32 = if landing_lag > 0 {
+        anim_length / landing_lag as f32
+    } else {
+        1.0
+    };
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_lw32_landing"), 0.0, rate, false, 0.0, false, false);
+    fighter.main_shift(attack_lw32_landing_main_loop)
+}
+
+unsafe extern "C" fn attack_lw32_landing_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) && (fighter.sub_wait_ground_check_common(false.into()).get_bool() || fighter.sub_air_check_fall_common().get_bool()) {
+        return 1.into();
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_WAIT, false);
+        }
+        else {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+        return 1.into();
+    }
+    // <HDR>
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        return 1.into();
+    }
+    // </HDR>
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        attack_lw32_landing_main
+    );
+}

--- a/fighters/simon/src/status/mod.rs
+++ b/fighters/simon/src/status/mod.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+mod attacklw3;
+
+
+pub fn install() {
+    attacklw3::install();
+}

--- a/fighters/toonlink/src/status.rs
+++ b/fighters/toonlink/src/status.rs
@@ -4,9 +4,53 @@ use globals::*;
 
 pub fn install() {
     install_status_scripts!(
+        pre_specialhi,
         pre_specialhi_end,
         specialhi_end
     );
+}
+
+// FIGHTER_STATUS_KIND_SPECIAL_HI //
+
+#[status_script(agent = "toonlink", status = FIGHTER_STATUS_KIND_SPECIAL_HI, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_specialhi(fighter: &mut L2CFighterCommon, arg: u64) -> L2CValue {
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        let start_speed = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let start_x_mul = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "param_special_hi.start_x_mul");
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, start_speed * start_x_mul);
+        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+    }
+    let mask_flag = if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        (*FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_HI | *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK | *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON) as u64
+    } else {
+        0 as u64
+    };
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        0,
+        0,
+        0,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        mask_flag,
+        *FIGHTER_STATUS_ATTR_START_TURN as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    0.into()
 }
 
 // FIGHTER_LINK_STATUS_KIND_SPECIAL_HI_END //

--- a/fighters/younglink/src/status.rs
+++ b/fighters/younglink/src/status.rs
@@ -4,9 +4,53 @@ use globals::*;
 
 pub fn install() {
     install_status_scripts!(
+        pre_specialhi,
         pre_specialhi_end,
         specialhi_end
     );
+}
+
+// FIGHTER_STATUS_KIND_SPECIAL_HI //
+
+#[status_script(agent = "younglink", status = FIGHTER_STATUS_KIND_SPECIAL_HI, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_specialhi(fighter: &mut L2CFighterCommon, arg: u64) -> L2CValue {
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        let start_speed = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        let start_x_mul = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "param_special_hi.start_x_mul");
+        fighter.clear_lua_stack();
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, start_speed * start_x_mul);
+        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+    }
+    let mask_flag = if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        (*FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_HI | *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK | *FIGHTER_LOG_MASK_FLAG_ACTION_TRIGGER_ON) as u64
+    } else {
+        0 as u64
+    };
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        0,
+        0,
+        0,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        mask_flag,
+        *FIGHTER_STATUS_ATTR_START_TURN as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    0.into()
 }
 
 // FIGHTER_LINK_STATUS_KIND_SPECIAL_HI_END //

--- a/fighters/zelda/src/acmd/specials.rs
+++ b/fighters/zelda/src/acmd/specials.rs
@@ -161,13 +161,17 @@ unsafe fn zelda_special_hi_game(fighter: &mut L2CAgentBase) {
         if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
             FT_MOTION_RATE(fighter, 10.0/(34.0 - 1.0));
         }
-        else {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 361, 89, 0, 80, 6.5, 0.0, 11.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 361, 87, 0, 60, 10.5, 0.0, 11.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+    }
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        JostleModule::set_status(boma, true);
+        if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
+            ATTACK(fighter, 0, 0, Hash40::new("rot"), 10.0, 361, 89, 0, 80, 7.5, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+            ATTACK(fighter, 1, 0, Hash40::new("rot"), 7.0, 361, 87, 0, 60, 12.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
             ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 0.75);
         }
     }
-    wait(lua_state, 3.0);
+    wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -188,13 +192,16 @@ unsafe fn zelda_special_air_hi_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         JostleModule::set_status(boma, true);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
+    }
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
         if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 55, 93, 0, 80, 6.5, 0.0, 11.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 8.0, 55, 85, 0, 60, 10.5, 0.0, 11.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+            ATTACK(fighter, 0, 0, Hash40::new("rot"), 12.0, 55, 93, 0, 80, 8.0, 0.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+            ATTACK(fighter, 1, 0, Hash40::new("rot"), 8.0, 55, 85, 0, 60, 13.0, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
             ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 0.75);
         }
     }
-    wait(lua_state, 3.0);
+    wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }

--- a/romfs/config.json
+++ b/romfs/config.json
@@ -81,6 +81,9 @@
 		],
 		"fighter/younglink/cmn": [
 			"fighter/younglink/param/hdr.prc"
+		],
+		"fighter/daisy/cmn": [
+			"fighter/daisy/param/hdr.prc"
 		]
 	}
 }

--- a/romfs/config.json
+++ b/romfs/config.json
@@ -84,6 +84,9 @@
 		],
 		"fighter/daisy/cmn": [
 			"fighter/daisy/param/hdr.prc"
+		],
+		"fighter/miiswordsman/cmn": [
+			"fighter/miiswordsman/param/hdr.prc"
 		]
 	}
 }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -2711,7 +2711,7 @@
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_f">9</float>
       <float hash="landing_attack_air_frame_lw">11</float>
-      <bool hash="wall_jump_type">false</bool>
+      <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.75</float>
       <float hash="tread_mini_jump_speed_y_mul">0.75</float>
       <int hash="attack_hi4_hold_keep_frame">1</int>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1500,7 +1500,7 @@
       <int hash="jump_squat_frame">4</int>
       <float hash="jump_initial_y">12.0835</float>
       <float hash="mini_jump_y">14.32</float>
-      <float hash="jump_aerial_y">28.8</float>
+      <float hash="jump_aerial_y">25</float>
       <float hash="air_accel_x_mul">0.05</float>
       <float hash="air_accel_x_add">0.02</float>
       <float hash="air_speed_x_stable">1.035</float>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -2934,7 +2934,7 @@
       <float hash="landing_attack_air_frame_hi">8</float>
       <float hash="landing_attack_air_frame_lw">12</float>
       <int hash="landing_heavy_frame">4</int>
-      <int hash="jump_count_max">2</int>
+      <int hash="jump_count_max">3</int>
       <bool hash="wall_jump_type">true</bool>
       <float hash="tread_jump_speed_y_mul">0.8</float>
       <float hash="tread_mini_jump_speed_y_mul">0.8</float>

--- a/romfs/source/fighter/daisy/param/hdr.xml
+++ b/romfs/source/fighter/daisy/param/hdr.xml
@@ -1,0 +1,4 @@
+ <?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <int hash="triple_jump_lockout_frame">25</int>
+</struct>

--- a/romfs/source/fighter/daisy/param/vl.prcxml
+++ b/romfs/source/fighter/daisy/param/vl.prcxml
@@ -46,9 +46,6 @@
     <struct index="0">
       <float hash="special_hi_start_dir_mul">30</float>
       <float hash="special_hi_start_trans_speed_mul">0.8</float>
-      <float hash="special_hi_fall_accel_x_mul">0.8</float>
-      <float hash="special_hi_fall_accel_y_mul">-0.01</float>
-      <int hash="special_hi_parasol_limit_time">120</int>
       <int hash="special_hi_landing_mot_frame">30</int>
     </struct>
     <hash40 index="1">dummy</hash40>

--- a/romfs/source/fighter/daisy/param/vl.prcxml
+++ b/romfs/source/fighter/daisy/param/vl.prcxml
@@ -46,6 +46,7 @@
     <struct index="0">
       <float hash="special_hi_start_dir_mul">30</float>
       <float hash="special_hi_start_trans_speed_mul">0.8</float>
+      <int hash="special_hi_parasol_limit_time">0</int>
       <int hash="special_hi_landing_mot_frame">30</int>
     </struct>
     <hash40 index="1">dummy</hash40>

--- a/romfs/source/fighter/falco/param/vl.prcxml
+++ b/romfs/source/fighter/falco/param/vl.prcxml
@@ -2,7 +2,7 @@
 <struct>
   <list hash="cliff_hang_data">
     <struct index="0">
-      <float hash="p1_y">18</float>
+      <float hash="p1_y">19</float>
       <float hash="p2_y">7</float>
     </struct>
     <struct index="1">

--- a/romfs/source/fighter/fox/param/vl.prcxml
+++ b/romfs/source/fighter/fox/param/vl.prcxml
@@ -2,7 +2,7 @@
 <struct>
   <list hash="cliff_hang_data">
     <struct index="0">
-      <float hash="p1_y">18</float>
+      <float hash="p1_y">20</float>
       <float hash="p2_y">7</float>
     </struct>
     <struct index="1">

--- a/romfs/source/fighter/jack/param/vl.prcxml
+++ b/romfs/source/fighter/jack/param/vl.prcxml
@@ -8,11 +8,14 @@
       <float hash="p1_x">46</float>
       <float hash="p1_y">85</float>
       <float hash="p2_x">-5</float>
+      <float hash="p2_y">-25</float>
     </struct>
     <hash40 index="2">dummy</hash40>
     <struct index="3">
-      <float hash="p1_x">46</float>
-      <float hash="p2_x">-46</float>
+      <float hash="p1_x">20</float>
+      <float hash="p1_y">85</float>
+      <float hash="p2_x">-5</float>
+      <float hash="p2_y">18</float>
     </struct>
   </list>
   <struct hash="param_private">

--- a/romfs/source/fighter/krool/param/vl.prcxml
+++ b/romfs/source/fighter/krool/param/vl.prcxml
@@ -32,6 +32,7 @@
     <struct index="0">
       <float hash="special_hi_start_air_mul_spd_x">1</float>
       <float hash="special_hi_fly_mul_max_acl_x">0.045</float>
+      <float hash="special_hi_fall_acl_y">0.1</float>
       <int hash="special_hi_landing_frame">24</int>
     </struct>
     <hash40 index="1">dummy</hash40>

--- a/romfs/source/fighter/link/param/hdr.xml
+++ b/romfs/source/fighter/link/param/hdr.xml
@@ -8,4 +8,7 @@
             <float hash="p2_y">8</float>
         </struct>
     </struct>
+    <struct hash="param_special_hi">
+        <float hash="start_x_mul">0.5</float>
+    </struct>
 </struct>

--- a/romfs/source/fighter/link/param/vl.prcxml
+++ b/romfs/source/fighter/link/param/vl.prcxml
@@ -30,8 +30,10 @@
     <struct index="0">
       <float hash="rslash_air_start_spd_y">2.345</float>
       <float hash="rslash_air_gravity_y_mul">0.535</float>
-      <float hash="rslash_air_accel_x_mul">0</float>
-      <float hash="rslash_air_max_x_mul">0.45</float>
+      <float hash="rslash_air_accel_x_mul">0.01</float>
+      <float hash="rslash_air_max_x_mul">0.5</float>
+      <float hash="rslash_end_air_accel_x_mul">0.01</float>
+      <float hash="rslash_end_air_max_x">0.5</float>
       <float hash="rslash_air_spd_x_mul">0.4</float>
       <float hash="rslash_air_init_spd_mul">1.0</float>
 

--- a/romfs/source/fighter/master/param/vl.prcxml
+++ b/romfs/source/fighter/master/param/vl.prcxml
@@ -12,10 +12,10 @@
     </struct>
     <hash40 index="2">dummy</hash40>
     <struct index="3">
-      <float hash="p1_x">60</float>
+      <float hash="p1_x">30</float>
       <float hash="p1_y">70</float>
       <float hash="p2_x">-5</float>
-      <float hash="p2_y">-30</float>
+      <float hash="p2_y">20</float>
     </struct>
   </list>
   <list hash="param_special_n">

--- a/romfs/source/fighter/miiswordsman/param/hdr.xml
+++ b/romfs/source/fighter/miiswordsman/param/hdr.xml
@@ -1,0 +1,6 @@
+ <?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <struct hash="param_special_hi3">
+        <float hash="start_x_mul">0.5</float>
+    </struct>
+</struct>

--- a/romfs/source/fighter/miiswordsman/param/vl.prcxml
+++ b/romfs/source/fighter/miiswordsman/param/vl.prcxml
@@ -47,8 +47,9 @@
     </struct>
     <struct index="2">
       <float hash="hi3_air_start_spd_y">2.3</float>
-      <float hash="hi3_air_gravity_y_mul">0.525</float>
-      <float hash="hi3_air_accel_x_mul">0.35</float>
+      <float hash="hi3_air_gravity_y_mul">0.55</float>
+      <float hash="hi3_air_spd_x_mul">0.4</float>
+      <float hash="hi3_air_accel_x_mul">0.01</float>
       <float hash="hi3_air_max_x_mul">0.5</float>
     </struct>
     <hash40 index="3">dummy</hash40>

--- a/romfs/source/fighter/pickel/param/vl.prcxml
+++ b/romfs/source/fighter/pickel/param/vl.prcxml
@@ -50,14 +50,10 @@
   </list>
   <list hash="param_trolley">
     <struct index="0">
-      <float hash="reaction_threshold_to_damage_s">0</float>
-      <float hash="reaction_threshold_to_damage_l">0</float>
       <float hash="reaction_threshold_to_damage_motion_s">0</float>
       <float hash="reaction_threshold_to_damage_motion_l">0</float>
     </struct>
     <struct index="1">
-      <float hash="reaction_threshold_to_damage_s">0</float>
-      <float hash="reaction_threshold_to_damage_l">0</float>
       <float hash="reaction_threshold_to_damage_motion_s">0</float>
       <float hash="reaction_threshold_to_damage_motion_l">0</float>
     </struct>

--- a/romfs/source/fighter/sheik/param/vl.prcxml
+++ b/romfs/source/fighter/sheik/param/vl.prcxml
@@ -45,7 +45,7 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="speed_y">3.0</float>
-      <float hash="warp_speed_add">1.34</float>
+      <float hash="warp_speed_add">1</float>
       <float hash="special_hi_landing_frame">30</float>
     </struct>
     <hash40 index="1">dummy</hash40>

--- a/romfs/source/fighter/tantan/param/vl.prcxml
+++ b/romfs/source/fighter/tantan/param/vl.prcxml
@@ -5,14 +5,17 @@
       <float hash="p1_y">26</float>
     </struct>
     <struct index="1">
-      <float hash="p2_x">-5</float>
-    </struct>
-    <hash40 index="2">dummy</hash40>
-    <struct index="3">
       <float hash="p1_x">67</float>
       <float hash="p1_y">70</float>
       <float hash="p2_x">-5</float>
       <float hash="p2_y">-25</float>
+    </struct>
+    <hash40 index="2">dummy</hash40>
+    <struct index="3">
+      <float hash="p1_x">31</float>
+      <float hash="p1_y">70</float>
+      <float hash="p2_x">-5</float>
+      <float hash="p2_y">18</float>
     </struct>
   </list>
   <list hash="param_spiral">

--- a/romfs/source/fighter/toonlink/param/hdr.xml
+++ b/romfs/source/fighter/toonlink/param/hdr.xml
@@ -9,4 +9,7 @@
         </struct>
     </struct>
     <int hash="triple_jump_lockout_frame">25</int>
+    <struct hash="param_special_hi">
+        <float hash="start_x_mul">0.5</float>
+    </struct>
 </struct>

--- a/romfs/source/fighter/toonlink/param/vl.prcxml
+++ b/romfs/source/fighter/toonlink/param/vl.prcxml
@@ -33,7 +33,10 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="rslash_air_gravity_y_mul">0.53</float>
-      <float hash="rslash_air_accel_x_mul">0</float>
+      <float hash="rslash_air_accel_x_mul">0.01</float>
+      <float hash="rslash_air_max_x_mul">0.6</float>
+      <float hash="rslash_end_air_accel_x_mul">0.01</float>
+      <float hash="rslash_end_air_max_x">0.6</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/younglink/param/hdr.xml
+++ b/romfs/source/fighter/younglink/param/hdr.xml
@@ -8,4 +8,7 @@
             <float hash="p2_y">8</float>
         </struct>
     </struct>
+    <struct hash="param_special_hi">
+        <float hash="start_x_mul">0.5</float>
+    </struct>
 </struct>

--- a/romfs/source/fighter/younglink/param/vl.prcxml
+++ b/romfs/source/fighter/younglink/param/vl.prcxml
@@ -55,8 +55,10 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="rslash_air_start_spd_y">2.3</float>
-      <float hash="rslash_air_accel_x_mul">0</float>
-      <float hash="rslash_air_max_x_mul">0.7</float>
+      <float hash="rslash_air_accel_x_mul">0.01</float>
+      <float hash="rslash_air_max_x_mul">0.8</float>
+      <float hash="rslash_end_air_accel_x_mul">0.01</float>
+      <float hash="rslash_end_air_max_x">0.8</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -25,3 +25,4 @@ pitb: fighter/pitb/param/hdr.prc
 toonlink: fighter/toonlink/param/hdr.prc
 younglink: fighter/younglink/param/hdr.prc
 daisy: fighter/daisy/param/hdr.prc
+miiswordsman: fighter/miiswordsman/param/hdr.prc

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -24,3 +24,4 @@ pit: fighter/pit/param/hdr.prc
 pitb: fighter/pitb/param/hdr.prc
 toonlink: fighter/toonlink/param/hdr.prc
 younglink: fighter/younglink/param/hdr.prc
+daisy: fighter/daisy/param/hdr.prc

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -26,3 +26,4 @@ fighter/pit/param/hdr.xml
 fighter/pitb/param/hdr.xml
 fighter/toonlink/param/hdr.xml
 fighter/younglink/param/hdr.xml
+fighter/daisy/param/hdr.xml

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -27,3 +27,4 @@ fighter/pitb/param/hdr.xml
 fighter/toonlink/param/hdr.xml
 fighter/younglink/param/hdr.xml
 fighter/daisy/param/hdr.xml
+fighter/miiswordsman/param/hdr.xml


### PR DESCRIPTION
<<<=== LINK ===>>>
Spin Attack
 ~ Air
   > [-] Horizontal speed is now halved on activation
   > [+] Max horizontal speed: 0.45 -> 0.5
   > [+] Base air acceleration: 0.0 -> 0.01

<<<=== FOX ===>>>
Fox Illusion
 ~ (*) Fixed an issue where edge canceling would send into freefall

Fire Fox
 ~ [+] Ledgegrab box during startup raised slightly, allowing frame-perfect ledge stalls again
 ~ [-] Aerial drift at peak (right before special fall) slightly reduced

<<<=== LUIGI ===>>>
Green Missile
 ~ [+] Re-enabled ability to grab ledge, shortly after hitboxes clear

Super Jump Punch
 ~ [+] Landing can now be edge canceled

<<<=== PEACH ===>>>
Peach Bomber
 ~ [+] Can now be edge canceled

<<<=== SHEIK ===>>>
Vanish
 ~ [-] Teleport speed: 2.34 -> 2.0

<<<=== ZELDA ===>>>
Farore's Wind
 ~ Reappearance
   > [-] Startup reverted: F1 -> F2

<<<=== FALCO ===>>>
Falco Phantasm
 ~ (*) Fixed an issue where edge canceling would send into freefall

Fire Bird
 ~ [+] Ledgegrab box during startup raised slightly, allowing frame-perfect ledge stalls again
 ~ [-] Aerial drift at peak (right before special fall) slightly reduced

<<<=== MARTH ===>>>
Dolphin Slash
 ~ [+] Can now grab ledge backwards

<<<=== YOUNG LINK ===>>>
Spin Attack
 ~ Air
   > [-] Horizontal speed is now halved on activation
   > [+] Max horizontal speed: 0.7 -> 0.8
   > [+] Base air acceleration: 0.0 -> 0.01

<<<=== ROY ===>>>
Blazer
 ~ [+] Can now grab ledge backwards

<<<=== META KNIGHT ===>>>
Drill Rush
 ~ [-] Rebound no longer land cancels

<<<=== PIT ===>>>
Upperdash Arm
 ~ (*) Fixed an issue where initiating the move would sometimes immediately send into freefall
 ~ [+] Landing can now be edge canceled

<<<=== IKE ===>>>
Quick Draw
 ~ (*) Fixed an issue where hitting the attack on shield would send into freefall
 ~ [+] Can now grab ledge, shortly after hitboxes clear

<<<=== OLIMAR ===>>>
Winged Pikmin
 ~ [-] Airdodge canceling now sends into freefall directly after
 ~ [+] Landing can now be edge canceled

<<<=== TOON LINK ===>>>
General
 ~ [-] Double/triple jump heights properly reduced: 28.8 -> 25.0

Spin Attack
 ~ Air
   > [-] Horizontal speed is now halved on activation
   > [+] Max horizontal speed: 0.19 -> 0.6
   > [+] Base air acceleration: 0.0 -> 0.01

<<<=== VILLAGER ===>>>
Balloon Trip
 ~ [+] Landing can now be edge canceled

<<<=== LITTLE MAC ===>>>
Jolt Haymaker
 ~ [+] Can now be edge canceled

<<<=== MII SWORDFIGHTER ===>>>
Hero's Spin
 ~ Air
   > [-] Horizontal speed is now halved on activation
   > [-] Base air acceleration: 0.35 -> 0.01
   > [-] Gravity multiplier: 0.525 -> 0.55

<<<=== DARK PIT ===>>>
Electrodash Arm
 ~ (*) Fixed an issue where initiating the move would sometimes immediately send into freefall
 ~ [+] Landing can now be edge canceled

<<<=== PAC-MAN ===>>>
Power Pellet
 ~ (*) Fixed an issue where an opponent attacking the Power Pellet during the charge would send Pac-Man into freefall

<<<=== LUCINA ===>>>
Dolphin Slash
 ~ [+] Can now grab ledge backwards

<<<=== RYU ===>>>
General
 ~ (*) Fixed issues with auto-turn

<<<=== INKLING ===>>>
Splat Roller
 ~ (*) Fixed an issue where after jump canceling, you could cancel an aerial into another aerial

<<<=== DAISY ===>>>
General
 ~ [+] Reinstated 3rd jump
 ~ (*) Added a 25 frame lockout between subsequent aerial jumps in line with other multijump characters

Daisy Bomber
 ~ [+] Can now be edge canceled

Daisy Parasol
 ~ (!) Hover removed, immediately transitions into special fall after rising
 ~ [-] Final hitbox weakened significantly; no longer launches
 ~ [-] Removed land cancel from special fall

<<<=== SIMON ===>>>
Down Tilt
 ~ Hit 2
   > (!) Can now be edge canceled

Dair
 ~ (*) Fixed an issue where after connecting dair, you could cancel the next aerial into another aerial

<<<=== RICHTER ===>>>
Down Tilt
 ~ Hit 2
   > (!) Can now be edge canceled


<<<=== KING K. ROOL ===>>>
Propellerpack
 ~ (*) Fuel now properly resets on death/match start
 ~ [+] Landing can now be edge canceled
 ~ [/] Descends faster after reaching the peak or canceling

<<<=== KEN ===>>>
General
 ~ (*) Fixed issues with auto-turn

<<<=== PIRANHA PLANT ===>>>
Piranhacopter
 ~ [+] Landing can now be edge canceled

<<<=== TERRY ===>>>
General
 ~ (*) Fixed issues with auto-turn

Crack Shoot
 ~ [+] Can now be edge canceled

Rising Tackle
 ~ [+] Can now be edge canceled

<<<=== STEVE ===>>>
Minecart
 ~ (*) Fixed an issue where using the move could cause various game-breaking bugs
 ~ [-] Jumping out of the Minecart in midair consumes double jump
 ~ [-] Can no longer jump out of Minecart without a double jump

<<<=== MYTHRA ===>>>
General
 ~ [+] Reinstated walljump

<<<=== KAZUYA ===>>>
Devil Fist
 ~ [+] Landing can now be edge canceled


Resolves #238 
Fixes #240 