### PR TITLE
Recovery sweep hotfixes part 2

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -384,6 +384,8 @@ pub mod vars {
         pub mod instance {
             // int
             pub const GUNMAN_TIMER: i32 = 0x0100;
+            pub const SPECIAL_HI_FUEL: i32 = 0x0101;
+            pub const FUEL_EFFECT_HANDLER: i32 = 0x0102;
         }
     }
     pub mod peach {
@@ -1026,7 +1028,8 @@ pub mod vars {
     pub mod krool {
         pub mod instance {
             //ints
-            pub const SPECIAL_HI_FUEL: i32 = 0x0110;
+            pub const SPECIAL_HI_FUEL: i32 = 0x0100;
+            pub const FUEL_EFFECT_HANDLER: i32 = 0x0101;
         }
     }
 }

--- a/fighters/duckhunt/src/opff.rs
+++ b/fighters/duckhunt/src/opff.rs
@@ -5,10 +5,60 @@ use globals::*;
 
  
 unsafe fn duck_jump_cancel(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_FLY)
-    && fighter.status_frame() > 20
-    && fighter.is_cat_flag(Cat1::SpecialHi) {
-        fighter.change_status_req(*FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_END, true);
+    if fighter.is_status(*FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_FLY) {
+        let fuel_burn_rate = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_burn_rate");
+        let fuel = VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL);
+        VarModule::set_int(
+            fighter.battle_object,
+            vars::duckhunt::instance::SPECIAL_HI_FUEL,
+            fuel - fuel_burn_rate,
+        );
+        if (fighter.status_frame() > 20 && fighter.is_cat_flag(Cat1::SpecialHi))
+            || fuel <= 0
+        {
+            StatusModule::change_status_request_from_script(
+                fighter.module_accessor,
+                *FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_END,
+                true,
+            );
+        }
+    } else if fighter.is_situation(*SITUATION_KIND_GROUND) {
+        let fuel_max = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_max");
+        if VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL) < fuel_max {
+            let fuel_recharge_rate = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_recharge_rate");
+            VarModule::add_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL, fuel_recharge_rate);
+        }
+    }
+}
+
+unsafe fn fuel_reset(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_WIN,
+        *FIGHTER_STATUS_KIND_LOSE,
+        *FIGHTER_STATUS_KIND_ENTRY,
+        *FIGHTER_STATUS_KIND_DEAD,
+        *FIGHTER_STATUS_KIND_REBIRTH]) {
+        let fuel_max = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_max");
+        VarModule::set_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL, fuel_max);
+    }
+}
+
+unsafe fn duck_jump_fuel_indicator(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    let fuel_max = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_max") as f32;
+    let low_fuel_threshold = fuel_max * 0.33;
+    
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_FLY, *FIGHTER_DUCKHUNT_STATUS_KIND_SPECIAL_HI_END])
+    && VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL) as f32 <= low_fuel_threshold
+    && VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::FUEL_EFFECT_HANDLER) == -1 {
+        let handle = EffectModule::req_follow(fighter.module_accessor, Hash40::new("sys_bomber_sweat"), Hash40::new("duckhead"), &Vector3f{x: 0.0, y: 0.0, z: 0.0}, &Vector3f::zero(), 1.5, true, 0, 0, 0, 0, 0, true, true) as u32;
+        VarModule::set_int(fighter.battle_object, vars::duckhunt::instance::FUEL_EFFECT_HANDLER, handle as i32);
+    }
+    else if VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::FUEL_EFFECT_HANDLER) != -1 {
+        let handle = VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::FUEL_EFFECT_HANDLER) as u32;
+        if !EffectModule::is_exist_effect(fighter.module_accessor, handle as u32)
+        || VarModule::get_int(fighter.battle_object, vars::duckhunt::instance::SPECIAL_HI_FUEL) as f32 > low_fuel_threshold {
+            VarModule::set_int(fighter.battle_object, vars::duckhunt::instance::FUEL_EFFECT_HANDLER, -1);
+        }
     }
 }
 
@@ -31,6 +81,8 @@ pub fn duckhunt_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);
         duck_jump_cancel(fighter);
+        fuel_reset(fighter);
+        duck_jump_fuel_indicator(fighter);
         gunman_timer(fighter);
     }
 }

--- a/fighters/krool/src/acmd/other.rs
+++ b/fighters/krool/src/acmd/other.rs
@@ -226,6 +226,22 @@ unsafe fn escape_air_slide_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "krool_backpack", script = "effect_fly", category = ACMD_EFFECT, low_priority )]
+unsafe fn krool_backpack_effect_fly(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    let owner_boma = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
+    if is_excute(fighter) {
+        let fuel_max = ParamModule::get_int(owner_boma.object(), ParamType::Agent, "param_special_hi.fuel_max") as f32;
+        EFFECT_FOLLOW(fighter, Hash40::new("krool_propeller"), Hash40::new("propeller"), 1, 0, 0, 0, 0, 0, 1, true);
+        if VarModule::get_int(owner_boma.object(), vars::krool::instance::SPECIAL_HI_FUEL) as f32 > fuel_max * 0.33 {
+            EFFECT_FOLLOW(fighter, Hash40::new("krool_buckpack"), Hash40::new("backpack"), -12, -1.5, -6, 0, 0, 0, 1, true);
+            EffectModule::enable_sync_init_pos_last(boma);
+        }
+        VarModule::set_int(owner_boma.object(), vars::krool::instance::FUEL_EFFECT_HANDLER, -1);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         escape_air_game,
@@ -239,7 +255,8 @@ pub fn install() {
         damageflylw_sound,
         damageflyn_sound,
         damageflyroll_sound,
-        damageflytop_sound
+        damageflytop_sound,
+        krool_backpack_effect_fly
     );
 }
 

--- a/fighters/krool/src/lib.rs
+++ b/fighters/krool/src/lib.rs
@@ -42,4 +42,8 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frames!(
+        krool_backpack_frame
+    );
 }

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -40,19 +40,6 @@ unsafe fn fuel_reset(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     }
 }
 
-unsafe fn jetpack_fuel_indicator(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_AIR_END, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_FALL])
-    && ArticleModule::is_exist(fighter.module_accessor, *FIGHTER_KROOL_GENERATE_ARTICLE_BACKPACK) {
-        let fuel_max = ParamModule::get_int(fighter.battle_object, ParamType::Agent, "param_special_hi.fuel_max") as f32;
-        if VarModule::get_int(fighter.battle_object, vars::krool::instance::SPECIAL_HI_FUEL) as f32 <= fuel_max * 0.33 {
-            let handle = VarModule::get_int(fighter.battle_object, vars::krool::instance::FUEL_EFFECT_HANDLER) as u32;
-            EffectModule::kill(fighter.module_accessor, handle, false, false);
-            let handle = EffectModule::req_follow(fighter.module_accessor, Hash40::new("krool_buckpack"), Hash40::new("backpack"), &Vector3f{x: -12.0, y: -1.5, z: -6.0}, &Vector3f::zero(), 1.0, true, 0, 0, 0, 0, 0, false, false) as u32;
-            EffectModule::set_rgb(fighter.module_accessor, handle, 0.15, 0.15, 0.15);
-        }
-    }
-}
-
 // K. Rool Side B Crown Item Grab
 unsafe fn crownerang_item_grab(boma: &mut BattleObjectModuleAccessor, status_kind: i32, cat1: i32) {
     if [
@@ -93,7 +80,6 @@ pub unsafe fn moveset(
 ) {
     jetpack_cancel(fighter, boma, status_kind, cat[0]);
     fuel_reset(fighter);
-    //jetpack_fuel_indicator(fighter);
     //crownerang_item_grab(boma, status_kind, cat[0]);
 }
 

--- a/fighters/mario/src/acmd/specials.rs
+++ b/fighters/mario/src/acmd/specials.rs
@@ -474,6 +474,7 @@ unsafe fn mario_special_hi_game(fighter: &mut L2CAgentBase) {
         }
         frame(lua_state, 3.0);
         if is_excute(fighter) {
+            SA_SET(fighter, *SITUATION_KIND_AIR);
             WorkModule::on_flag(boma, *FIGHTER_STATUS_SUPER_JUMP_PUNCH_FLAG_REVERSE_LR);
             ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 60, 100, 160, 0, 2.5, 0.0, 4.5, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
             ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 86, 100, 150, 0, 4.0, 0.0, 4.5, 5.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_COIN, *ATTACK_REGION_PUNCH);
@@ -505,8 +506,8 @@ unsafe fn mario_special_hi_game(fighter: &mut L2CAgentBase) {
         frame(lua_state, 17.0);
         if is_excute(fighter) {
             AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 140, 0, 50, 5.5, 0.0, 9.5, 6.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 140, 0, 50, 5.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {

--- a/fighters/mario/src/acmd/specials.rs
+++ b/fighters/mario/src/acmd/specials.rs
@@ -506,8 +506,8 @@ unsafe fn mario_special_hi_game(fighter: &mut L2CAgentBase) {
         frame(lua_state, 17.0);
         if is_excute(fighter) {
             AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 50, 140, 0, 40, 7.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {

--- a/fighters/pit/src/acmd/specials.rs
+++ b/fighters/pit/src/acmd/specials.rs
@@ -43,7 +43,7 @@ unsafe fn game_specialsstart(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 12.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        // WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
     frame(lua_state, 27.0);
     if is_excute(fighter) {
@@ -59,7 +59,7 @@ unsafe fn game_specialsstart(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
         WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        // WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
 }
 

--- a/fighters/pit/src/acmd/specials.rs
+++ b/fighters/pit/src/acmd/specials.rs
@@ -43,7 +43,7 @@ unsafe fn game_specialsstart(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 12.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        // WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
     frame(lua_state, 27.0);
     if is_excute(fighter) {

--- a/fighters/pit/src/opff.rs
+++ b/fighters/pit/src/opff.rs
@@ -25,7 +25,8 @@ unsafe fn upperdash_arm_jump_and_aerial_cancel(boma: &mut BattleObjectModuleAcce
         return;
     }
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S || (status_kind == *FIGHTER_PIT_STATUS_KIND_SPECIAL_S_END && frame > 6.0) {
-        if boma.is_situation(*SITUATION_KIND_GROUND) && frame > 28.0 {
+        if (boma.is_situation(*SITUATION_KIND_GROUND) || WorkModule::is_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF))
+        && frame > 28.0 {
             boma.check_jump_cancel(true);
         }
     }

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -19,7 +19,7 @@ unsafe fn pitb_special_s_start_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 12.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0.0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        // WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
     frame(lua_state, 26.0);
     if is_excute(fighter) {
@@ -35,7 +35,7 @@ unsafe fn pitb_special_s_start_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
         WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        // WorkModule::off_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
 }
 

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -19,7 +19,7 @@ unsafe fn pitb_special_s_start_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 0, 0, 0, 2.0, 0.0, 12.0, 9.0, Some(0.0), Some(4.0), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0.0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_search"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
         WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_HIT_CHECK_ONOFF);
         shield!(fighter, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, *FIGHTER_PIT_REFLECTOR_KIND_SPECIAL_S, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_S);
-        // WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
+        WorkModule::on_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF);
     }
     frame(lua_state, 26.0);
     if is_excute(fighter) {

--- a/romfs/config.json
+++ b/romfs/config.json
@@ -87,6 +87,12 @@
 		],
 		"fighter/miiswordsman/cmn": [
 			"fighter/miiswordsman/param/hdr.prc"
+		],
+		"fighter/duckhunt/cmn": [
+			"fighter/duckhunt/param/hdr.prc"
+		],
+		"fighter/krool/cmn": [
+			"fighter/krool/param/hdr.prc"
 		]
 	}
 }

--- a/romfs/source/fighter/duckhunt/param/hdr.xml
+++ b/romfs/source/fighter/duckhunt/param/hdr.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <struct hash="param_special_hi">
+        <int hash="fuel_max">600</int>
+        <int hash="fuel_burn_rate">3</int>
+        <int hash="fuel_recharge_rate">1</int>
+    </struct>
+</struct>

--- a/romfs/source/fighter/duckhunt/param/vl.prcxml
+++ b/romfs/source/fighter/duckhunt/param/vl.prcxml
@@ -23,7 +23,7 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
-      <int hash="flap_times">8</int>
+      <int hash="flap_times">7</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/krool/param/hdr.xml
+++ b/romfs/source/fighter/krool/param/hdr.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <struct hash="param_special_hi">
+        <int hash="fuel_max">540</int>
+        <int hash="fuel_burn_rate">3</int>
+        <int hash="fuel_recharge_rate">1</int>
+    </struct>
+</struct>

--- a/romfs/source/fighter/shizue/param/vl.prcxml
+++ b/romfs/source/fighter/shizue/param/vl.prcxml
@@ -6,7 +6,7 @@
       <float hash="p2_y">7</float>
     </struct>
     <struct index="1">
-      <float hash="p1_x">40</float>
+      <float hash="p1_x">60</float>
       <float hash="p1_y">36</float>
       <float hash="p2_x">5</float>
       <float hash="p2_y">-18</float>

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -26,3 +26,5 @@ toonlink: fighter/toonlink/param/hdr.prc
 younglink: fighter/younglink/param/hdr.prc
 daisy: fighter/daisy/param/hdr.prc
 miiswordsman: fighter/miiswordsman/param/hdr.prc
+duckhunt: fighter/duckhunt/param/hdr.prc
+krool: fighter/krool/param/hdr.prc

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -28,3 +28,5 @@ fighter/toonlink/param/hdr.xml
 fighter/younglink/param/hdr.xml
 fighter/daisy/param/hdr.xml
 fighter/miiswordsman/param/hdr.xml
+fighter/duckhunt/param/hdr.xml
+fighter/krool/param/hdr.xml


### PR DESCRIPTION
<<<=== MARIO ===>>>
Super Jump Punch
 ~ (*) Fixed an issue where Regular Coin/Purple Coin variants had different properties

<<<=== PIT ===>>>
Upperdash Arm
 ~ Ground
   ~ [+] The end of the animation now edge cancels
   ~ [+] When slipping off an edge, the rest of the aerial animation is now jump-cancelable

<<<=== DARK PIT ===>>>
Electrodash Arm
 ~ Ground
   ~ [+] The end of the animation now edge cancels

<<<=== DUCK HUNT ===>>>
Duck Jump
 ~ [R] Given fuel mechanic
   ~ Max fuel lasts 200 frames, restores by a rate of 60 frames per 180 frames of being grounded
   ~ When depleted, takes 600 frames to fully recharge
 ~ [-] Max distance slightly reduced (to vanilla)
 ~ [$] Added visual indicator when fuel goes below 33% (duck begins sweating)

<<<=== KING K. ROOL ===>>>
Propellerpack
 ~ [$] Added visual indicator when fuel goes below 33% (black smoke emits from Propellerpack)

<<<=== ISABELLE ===>>>
Fishing Rod
 ~ [+] Horizontal tether range reverted to vanilla