### PR TITLE
Hero followup adjustments

### DIFF
--- a/fighters/brave/src/acmd/specials.rs
+++ b/fighters/brave/src/acmd/specials.rs
@@ -444,6 +444,26 @@ unsafe fn brave_special_lw_18_effect(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "brave", scripts = ["game_speciallw19", "game_specialairlw19"], category = ACMD_GAME, low_priority )]
+unsafe fn brave_special_lw_19_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_BRAVE_INSTANCE_WORK_ID_FLAG_PLAY_MISS_SE);
+        ATTACK(fighter, 0, 0, Hash40::new("sword1"), 1.0, 361, 220, 10, 10, 3.3, 8.8, 0.0, -2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup_metal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("sword1"), 1.0, 361, 220, 10, 10, 3.8, 3.0, 0.0, -1.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup_metal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 2, 0, Hash40::new("armr"), 1.0, 361, 220, 10, 10, 2.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup_metal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        AttackModule::set_add_reaction_frame(boma, 0, 6.0, false);
+        AttackModule::set_add_reaction_frame(boma, 1, 6.0, false);
+        AttackModule::set_add_reaction_frame(boma, 2, 6.0, false);
+    }
+    frame(lua_state, 13.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+}
+
 #[acmd_script( agent = "brave", scripts = ["game_speciallw20", "game_specialairlw20"], category = ACMD_GAME, low_priority )]
 unsafe fn brave_special_lw20_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -485,6 +505,7 @@ pub fn install() {
         brave_special_lw_17_effect,
         brave_special_lw_18_game,
         brave_special_lw_18_effect,
+        brave_special_lw_19_game,
         brave_special_lw20_game,
     );
 }

--- a/fighters/brave/src/acmd/specials.rs
+++ b/fighters/brave/src/acmd/specials.rs
@@ -301,11 +301,157 @@ unsafe fn brave_special_air_lw10_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 15.0);
 }
 
+#[acmd_script( agent = "brave", scripts = ["game_speciallw14", "game_specialairlw14"], category = ACMD_GAME, low_priority )]
+unsafe fn brave_special_lw_14_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 6.0, 8.0);
+    frame(lua_state, 6.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    if is_excute(fighter) {
+        ArticleModule::generate_article(boma, *FIGHTER_BRAVE_GENERATE_ARTICLE_SLEEP, false, -1);
+        WorkModule::on_flag(boma, *FIGHTER_BRAVE_STATUS_SPECIAL_LW_FLAG_ENABLE_CONTROL_ENERGY);
+    }
+}
+
+#[acmd_script( agent = "brave", scripts = ["game_speciallw17", "game_specialairlw17"], category = ACMD_GAME, low_priority )]
+unsafe fn brave_special_lw_17_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 0.5);
+    frame(lua_state, 7.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_BRAVE_INSTANCE_WORK_ID_FLAG_PLAY_MISS_SE);
+        ATTACK(fighter, 0, 0, Hash40::new("sword1"), 22.0, 46, 67, 0, 68, 4.5, 9.0, 0.0, -2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("sword1"), 22.0, 46, 67, 0, 68, 4.5, 4.0, 0.0, -2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 2, 0, Hash40::new("armr"), 22.0, 46, 67, 0, 68, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 4, 0, Hash40::new("top"), 17.0, 50, 62, 0, 68, 7.5, 0.0, 15.0, 13.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 3, 0, Hash40::new("top"), 22.0, 46, 67, 0, 68, 8.5, 0.0, 7.5, 19.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 4, 0, Hash40::new("top"), 17.0, 50, 62, 0, 68, 7.5, 0.0, 6.0, 31.5, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_NONE);
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    FT_MOTION_RATE(fighter, 0.8);
+    frame(lua_state, 40.0);
+    FT_MOTION_RATE(fighter, 1.0);
+}
+
+#[acmd_script( agent = "brave", scripts = ["effect_speciallw17", "game_specialairlw17"], category = ACMD_EFFECT, low_priority )]
+unsafe fn brave_special_lw_17_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_WORK(fighter, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_EFFECT_KIND_LIGHTNING_SWORD_FLARE, Hash40::new("sword1"), 0, 0, 0, 0, 0, -90, 1, true);
+        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("brave_fire_sword"), Hash40::new("sword1"), 0, 0, 0, 0, 0, -90, 1.2, true);
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        AFTER_IMAGE4_ON_arg29(fighter, Hash40::new("tex_brave_firesword1"), Hash40::new("tex_brave_sword2"), 7, Hash40::new("sword1"), 1.5, 0.0, 0.0, Hash40::new("sword1"), 14.4, 0.0, 0.0, true, Hash40::new("null"), Hash40::new("sword1"), 0.0, 0.0, 0.0, 0.0, 0.0, -90.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.4, 0.1);
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        }
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        AFTER_IMAGE_OFF(fighter, 4);
+    }
+    frame(lua_state, 13.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("brave_fire_sword"), false, true);
+    }
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND_WORK(fighter, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_EFFECT_KIND_LIGHTNING_SWORD_FLARE, false, true);
+    }
+}
+
+#[acmd_script( agent = "brave", scripts = ["game_speciallw18", "game_specialairlw18"], category = ACMD_GAME, low_priority )]
+unsafe fn brave_special_lw_18_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 0.5);
+    frame(lua_state, 7.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_BRAVE_INSTANCE_WORK_ID_FLAG_PLAY_MISS_SE);
+        ATTACK(fighter, 0, 0, Hash40::new("sword1"), 17.0, 50, 7, 0, 70, 4.5, 9.0, 0.0, -2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("sword1"), 17.0, 50, 7, 0, 70, 4.5, 4.0, 0.0, -2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 2, 0, Hash40::new("armr"), 17.0, 50, 7, 0, 70, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 4, 0, Hash40::new("top"), 13.0, 60, 7, 0, 70, 7.5, 0.0, 15.0, 13.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_NONE);
+        AttackModule::set_ice_frame_mul(boma, 0, 2.0, false);
+        AttackModule::set_ice_frame_mul(boma, 1, 2.0, false);
+        AttackModule::set_ice_frame_mul(boma, 2, 2.0, false);
+        AttackModule::set_ice_frame_mul(boma, 4, 2.0, false);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 3, 0, Hash40::new("top"), 17.0, 50, 7, 0, 70, 8.5, 0.0, 7.5, 19.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 4, 0, Hash40::new("top"), 13.0, 60, 7, 0, 70, 7.5, 0.0, 6.0, 31.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_NONE);
+        AttackModule::set_ice_frame_mul(boma, 3, 2.0, false);
+        AttackModule::set_ice_frame_mul(boma, 4, 2.0, false);
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    FT_MOTION_RATE(fighter, 0.7);
+    frame(lua_state, 40.0);
+    FT_MOTION_RATE(fighter, 1.0);
+}
+
+#[acmd_script( agent = "brave", scripts = ["effect_speciallw18", "effect_specialairlw18"], category = ACMD_EFFECT, low_priority )]
+unsafe fn brave_special_lw_18_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 4.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_WORK(fighter, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_EFFECT_KIND_SWORD_FLARE, Hash40::new("sword1"), 0, 0, 0, 0, 0, -90, 1, true);
+    }
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        AFTER_IMAGE4_ON_arg29(fighter, Hash40::new("tex_brave_sword1"), Hash40::new("tex_brave_sword2"), 8, Hash40::new("sword1"), 1.5, 0.0, 0.0, Hash40::new("sword1"), 14.4, 0.0, 0.0, true, Hash40::new("null"), Hash40::new("sword1"), 0.0, 0.0, 0.0, 0.0, 0.0, -90.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.4, 0.1);
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        }
+        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("brave_ice_sword"), Hash40::new("sword1"), 0, 0, 0, 0, 0, -90, 1.3, true);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        AFTER_IMAGE_OFF(fighter, 6);
+        EFFECT_OFF_KIND_WORK(fighter, *FIGHTER_BRAVE_INSTANCE_WORK_ID_INT_EFFECT_KIND_SWORD_FLARE, false, true);
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("brave_ice_sword"), false, true);
+    }
+}
+
 #[acmd_script( agent = "brave", scripts = ["game_speciallw20", "game_specialairlw20"], category = ACMD_GAME, low_priority )]
 unsafe fn brave_special_lw20_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 35.0, 29.0);
     frame(lua_state, 35.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_BRAVE_INSTANCE_WORK_ID_FLAG_CRITICAL_HIT);
         WorkModule::on_flag(boma, *FIGHTER_BRAVE_INSTANCE_WORK_ID_FLAG_PLAY_MISS_SE);
@@ -334,6 +480,11 @@ pub fn install() {
         brave_special_hi3_game,
         brave_special_lw_start_game,
         brave_special_air_lw10_game,
+        brave_special_lw_14_game,
+        brave_special_lw_17_game,
+        brave_special_lw_17_effect,
+        brave_special_lw_18_game,
+        brave_special_lw_18_effect,
         brave_special_lw20_game,
     );
 }

--- a/fighters/brave/src/opff.rs
+++ b/fighters/brave/src/opff.rs
@@ -86,7 +86,7 @@ unsafe fn dash_cancel_frizz(fighter: &mut L2CFighterCommon) {
     {
         if fighter.check_dash_cancel() {
             let mut brave_fighter = app::Fighter{battle_object: *(fighter.battle_object)};
-            FighterSpecializer_Brave::add_sp(&mut brave_fighter, -12.0);
+            FighterSpecializer_Brave::add_sp(&mut brave_fighter, -9.0);
             EFFECT(fighter, Hash40::new("sys_flash"), Hash40::new("top"), 0, 15, -2, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
         }
     }

--- a/fighters/brave/src/opff.rs
+++ b/fighters/brave/src/opff.rs
@@ -86,7 +86,7 @@ unsafe fn dash_cancel_frizz(fighter: &mut L2CFighterCommon) {
     {
         if fighter.check_dash_cancel() {
             let mut brave_fighter = app::Fighter{battle_object: *(fighter.battle_object)};
-            FighterSpecializer_Brave::add_sp(&mut brave_fighter, -9.0);
+            FighterSpecializer_Brave::add_sp(&mut brave_fighter, -10.0);
             EFFECT(fighter, Hash40::new("sys_flash"), Hash40::new("top"), 0, 15, -2, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
         }
     }

--- a/romfs/source/fighter/brave/param/vl.prcxml
+++ b/romfs/source/fighter/brave/param/vl.prcxml
@@ -55,6 +55,8 @@
       <float hash="start_max_speed_y_mul_air">0.2</float>
       <float hash="jump_distance_m">60</float>
       <float hash="jump_max_speed_x_m">1.535</float>
+      <float hash="wait_jump_accel_y_mul">0.5</float>
+      <float hash="wait_jump_max_speed_y_mul">0.2</float>
       <float hash="jump_distance_l">85</float>
       <float hash="jump_max_speed_x_l">1.375</float>
       <int hash="landing_frame_l">26</int>

--- a/romfs/source/fighter/brave/param/vl.prcxml
+++ b/romfs/source/fighter/brave/param/vl.prcxml
@@ -56,7 +56,7 @@
       <float hash="jump_distance_m">60</float>
       <float hash="jump_max_speed_x_m">1.535</float>
       <float hash="wait_jump_accel_y_mul">0.5</float>
-      <float hash="wait_jump_max_speed_y_mul">0.2</float>
+      <float hash="wait_jump_max_speed_y_mul">0.5</float>
       <float hash="jump_distance_l">85</float>
       <float hash="jump_max_speed_x_l">1.375</float>
       <int hash="landing_frame_l">26</int>


### PR DESCRIPTION
Some small targeted adjustments to certain spells

Hitbox comparisons: https://imgur.com/a/hkRzDrR

### Frizz:
- [+] MP Cost (dash cancel): 12 -> 10

### Woosh/Swoosh/Kaswoosh:
- [+] Gravity Multiplier (charge): 1.0x -> 0.5x
- [+] Fallspeed Multiplier (charge): 1.0x -> 0.5x

### Flame Slash:
- [-] The outermost hitbox no longer hits underneath Hero on the last frame of activity
- [-] Moved outermost hitbox inward 3.0u
- [$] Adjusted vfx
- [-] Hitbox Size (outer slash): 10.5u -> 7.5u

### Kacrackle Slash:
- [-] The outermost hitbox no longer hits underneath Hero on the last frame of activity
- [-] Moved outermost hitbox inward 3.0u
- [$] Adjusted vfx
- [/] Hitlag Multiplier (outer slash): 0.7x -> 1.0x
- [-] Hitbox Size (outer slash): 10.5u -> 7.5u

### Snooze:
- [-] Startup: F6 -> F9

### Hatchet Man:
- [+] Hitbox Duration: F35-40 -> F30-35

### Metal Slash
- [+] Shield Damage: 0 -> 15