### PR TITLE
Yoshi - P+ ftilt & upB slipoff

### DIFF
--- a/fighters/common/src/function_hooks/edge_slipoffs.rs
+++ b/fighters/common/src/function_hooks/edge_slipoffs.rs
@@ -123,7 +123,8 @@ unsafe fn correct_hook(boma: &mut BattleObjectModuleAccessor, kind: GroundCorrec
             || (fighter_kind == *FIGHTER_KIND_GAOGAEN && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
             || (fighter_kind == *FIGHTER_KIND_LUIGI && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N)
             || (fighter_kind == *FIGHTER_KIND_PEACH && status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_S_AWAY_END)
-            || (fighter_kind == *FIGHTER_KIND_DAISY && status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_S_AWAY_END) {
+            || (fighter_kind == *FIGHTER_KIND_DAISY && status_kind == *FIGHTER_PEACH_STATUS_KIND_SPECIAL_S_AWAY_END)
+            || (fighter_kind == *FIGHTER_KIND_YOSHI && status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI) {
             return original!()(boma, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
         }
     }

--- a/fighters/yoshi/src/acmd/tilts.rs
+++ b/fighters/yoshi/src/acmd/tilts.rs
@@ -6,21 +6,23 @@ use super::*;
 unsafe fn yoshi_attack_s3_hi_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+	let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+	FT_DESIRED_RATE(fighter, 5.0, 6.0);
 	frame(lua_state, 5.0);
+	FT_DESIRED_RATE(fighter, 4.0, 3.0);
 	if is_excute(fighter) {
-		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 11.0, 75, 73, 0, 52, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 11.0, 75, 73, 0, 52, 4.5, 4.3, -1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 2, 0, Hash40::new("tail2"), 11.0, 85, 73, 0, 52, 4.0, 5.0, 0.5, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_HIGH), false);
-		HIT_NODE(fighter, Hash40::new("tail1"), *HIT_STATUS_XLU);
+		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 13.0, 70, 80, 0, 40, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 13.0, 70, 80, 0, 40, 4.4, 6.56, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 2, 0, Hash40::new("tail1"), 13.0, 70, 80, 0, 40, 3.3, 13.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
 		HIT_NODE(fighter, Hash40::new("tail2"), *HIT_STATUS_XLU);
 	}
-	wait(lua_state, 3.0);
+	frame(lua_state, 9.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
-	AttackModule::clear_all(boma);
-	HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
+		AttackModule::clear_all(boma);
+		HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
 	}
-
 }
 
 
@@ -28,13 +30,15 @@ unsafe fn yoshi_attack_s3_hi_game(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_s3_hi_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-	frame(lua_state, 3.0);
+	frame(lua_state, 4.0);
 	if is_excute(fighter) {
 		FOOT_EFFECT(fighter, Hash40::new("null"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
-		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 12, 8, -7.79, -24, 49.865, 0.85, true, *EF_FLIP_YZ);
-		LAST_EFFECT_SET_RATE(fighter, 1.8);
 	}
-
+	frame(lua_state, 5.0);
+	if is_excute(fighter) {
+		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 11, 6, 18, -27, 156, 1.15, true, *EF_FLIP_YZ);
+		LAST_EFFECT_SET_RATE(fighter, 1.5);
+	}
 }
 
 
@@ -42,19 +46,21 @@ unsafe fn yoshi_attack_s3_hi_effect(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_s3_s_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+	FT_DESIRED_RATE(fighter, 5.0, 6.0);
 	frame(lua_state, 5.0);
+	FT_DESIRED_RATE(fighter, 4.0, 3.0);
 	if is_excute(fighter) {
-		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 10.0, 75, 73, 0, 52, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 10.0, 75, 73, 0, 52, 4.5, 4.3, -1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 2, 0, Hash40::new("tail2"), 10.0, 85, 73, 0, 52, 4.0, 5.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 12.0, 70, 80, 0, 40, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 12.0, 70, 80, 0, 40, 4.4, 6.56, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 2, 0, Hash40::new("tail1"), 12.0, 70, 80, 0, 40, 3.3, 13.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
 		HIT_NODE(fighter, Hash40::new("tail2"), *HIT_STATUS_XLU);
 	}
-	wait(lua_state, 3.0);
+	frame(lua_state, 9.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
 		AttackModule::clear_all(boma);
 		HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
 	}
-
 }
 
 
@@ -68,10 +74,9 @@ unsafe fn yoshi_attack_s3_s_effect(fighter: &mut L2CAgentBase) {
 	}
 	frame(lua_state, 5.0);
 	if is_excute(fighter) {
-		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 9, 10, -3.255, -12.797, 37.054, 0.85, true, *EF_FLIP_YZ);
+		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 9, 4, 173, -156, 2, 1.15, true, *EF_FLIP_YZ);
 		LAST_EFFECT_SET_RATE(fighter, 1.5);
 	}
-
 }
 
 
@@ -79,20 +84,21 @@ unsafe fn yoshi_attack_s3_s_effect(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_s3_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+	FT_DESIRED_RATE(fighter, 5.0, 6.0);
 	frame(lua_state, 5.0);
+	FT_DESIRED_RATE(fighter, 4.0, 3.0);
 	if is_excute(fighter) {
-		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 9.0, 75, 73, 0, 52, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 9.0, 75, 73, 0, 52, 4.5, 4.3, -1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		ATTACK(fighter, 2, 0, Hash40::new("tail2"), 9.0, 85, 73, 0, 52, 4.0, 5.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-		AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_LOW), false);
+		ATTACK(fighter, 0, 0, Hash40::new("tail1"), 11.0, 70, 80, 0, 40, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 1, 0, Hash40::new("tail1"), 11.0, 70, 80, 0, 40, 4.4, 6.56, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+		ATTACK(fighter, 2, 0, Hash40::new("tail1"), 11.0, 70, 80, 0, 40, 3.3, 13.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
 		HIT_NODE(fighter, Hash40::new("tail2"), *HIT_STATUS_XLU);
 	}
-	wait(lua_state, 3.0);
+	frame(lua_state, 9.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
 		AttackModule::clear_all(boma);
 		HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
 	}
-
 }
   
 
@@ -106,7 +112,7 @@ unsafe fn yoshi_attack_s3_lw_effect(fighter: &mut L2CAgentBase) {
 	}
 	frame(lua_state, 5.0);
 	if is_excute(fighter) {
-		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 3.5, 10, 1.53, -13.258, 23.277, 0.85, true, *EF_FLIP_YZ);
+		EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 6, 4, 166, -162, 9, 1.15, true, *EF_FLIP_YZ);
 		LAST_EFFECT_SET_RATE(fighter, 1.5);
 	}
 }


### PR DESCRIPTION
Brings back Smash 4's animation for ftilt, using P+'s hitbox data:
- Damage: 11% (down-angled) / 12% (side-angled) / 13% (up-angled)
- Angle: 70
- BKB: 40
- KBG: 80
- Activity: f6-8
- FAF: f30

Side-angled:
![2023060216350600-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/085e3d90-50f3-473e-8156-ace8162cd8c9)

Down-angled:
![2023060216352200-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/1966b3f9-4e7b-4739-be65-e08fa5fc3584)

Up-angled:
![2023060216351400-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/11d56d7b-9195-41fb-805d-428cb2d6772f)


Additionally, grounded upB can now slip off edges, bringing back Melee tech.

To be merged with HDR-Development/hdr-private#351

Assets:
[hdr-assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11638768/hdr-assets.zip)
