### PR TITLE
New Lucas down throw effects + miscellaneous FX fixes

### DIFF
--- a/fighters/lucas/src/acmd/smashes.rs
+++ b/fighters/lucas/src/acmd/smashes.rs
@@ -420,7 +420,7 @@ unsafe fn lucas_attack_lw4_game(fighter: &mut L2CAgentBase) {
         }
         frame(lua_state, 20.0);
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 17.0, 361, 85, 0, 46, 6.0, 0.0, 3.5, 9.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, -10, 0.0, 8, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 17.0, 361, 85, 0, 46, 6.0, 0.0, 3.5, 9.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, -10, 0.0, 8, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
         }
         wait(lua_state, 5.0);
         if is_excute(fighter) {

--- a/fighters/lucas/src/acmd/specials.rs
+++ b/fighters/lucas/src/acmd/specials.rs
@@ -31,6 +31,8 @@ unsafe fn lucas_special_air_s_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+// test
+
 #[acmd_script( agent = "lucas", scripts = ["effect_specialairs", "effect_specials"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn lucas_special_s_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;

--- a/fighters/lucas/src/acmd/specials.rs
+++ b/fighters/lucas/src/acmd/specials.rs
@@ -31,7 +31,6 @@ unsafe fn lucas_special_air_s_game(fighter: &mut L2CAgentBase) {
     }
 }
 
-// test
 
 #[acmd_script( agent = "lucas", scripts = ["effect_specialairs", "effect_specials"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn lucas_special_s_effect(fighter: &mut L2CAgentBase) {
@@ -51,6 +50,9 @@ unsafe fn lucas_special_s_sound(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_lucas_smash_h01"));
         PLAY_SE(fighter, Hash40::new("se_lucas_special_s03"));
+    }
+    frame(lua_state, 25.0);
+    if is_excute(fighter) {
         let rand = sv_math::rand(hash40("fighter"), 7) as i32;
         if rand == 0 {
             PLAY_SE_REMAIN(fighter, Hash40::new("vc_lucas_attack01"));
@@ -65,6 +67,7 @@ unsafe fn lucas_special_s_sound(fighter: &mut L2CAgentBase) {
             PLAY_SE_REMAIN(fighter, Hash40::new("vc_lucas_cliffcatch"));
         }
     }
+    
 }
 
 #[acmd_script( agent = "lucas", script = "game_specialairhi" , category = ACMD_GAME , low_priority)]

--- a/fighters/lucas/src/acmd/throws.rs
+++ b/fighters/lucas/src/acmd/throws.rs
@@ -235,8 +235,8 @@ unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 0.600);
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 7.0, 361, 100, 0, 60, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 7.0, 361, 100, 0, 60, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
     }
 
     frame(lua_state, 34.0);

--- a/fighters/lucas/src/acmd/throws.rs
+++ b/fighters/lucas/src/acmd/throws.rs
@@ -232,28 +232,64 @@ unsafe fn game_throwhi(fighter: &mut L2CAgentBase) {
 unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.500);
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        FT_MOTION_RATE(fighter, 0.6);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 7.0, 361, 100, 0, 60, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
     }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.000);
+
+    frame(lua_state, 34.0);
+    if is_excute(fighter){
+        FT_MOTION_RATE(fighter, 0.8);
         CHECK_FINISH_CAMERA(fighter, 9.0, 0.0);
     }
+
     frame(lua_state, 41.0);
     if is_excute(fighter) {
+        FT_MOTION_RATE(fighter, 1.0);
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
     }
     
+}
+
+#[acmd_script( agent = "lucas", script = "effect_throwlw", category = ACMD_EFFECT, low_priority )]
+unsafe fn effect_throwlw(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("lucas_psi_atk"), Hash40::new("throw"), 0, 5, 0, 0, 0, 0, 0.8, true);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_v_smoke_b"), Hash40::new("top"), 6, 0, 9, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, false);
+        LANDING_EFFECT(fighter, Hash40::new("lucas_psi_atk"), Hash40::new("top"), 6, 0, 9, 0, 0, 0, 1.2, 0, 0, 0, 0, 0, 0, false);
+    }
+
+    frame(lua_state, 41.0);
+    if is_excute(fighter) {
+        macros::EFFECT_FOLLOW_FLIP(fighter, Hash40::new("lucas_psi_atk_lw"), Hash40::new("lucas_psi_atk_lw"), Hash40::new("top"), 0, 0.2, 8.5, 0, 0, 0, 1.1, true, *EF_FLIP_YZ);
+        LAST_EFFECT_SET_RATE(fighter, 0.75);
+       // EFFECT_FOLLOW(fighter, Hash40::new("lucas_psi_atk"), Hash40::new("throw"), 0, 10, 0, 0, 0, 0, 0.8, true);
+    }
 }
 
 #[acmd_script( agent = "lucas", script = "expression_throwlw" , category = ACMD_EXPRESSION , low_priority)]
 unsafe fn expression_throwlw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    
+
+    frame(fighter.lua_state_agent, 3.0);
+    if macros::is_excute(fighter) {
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_elecattack"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+
+    frame(fighter.lua_state_agent, 10.0);
+    if macros::is_excute(fighter) {
+        macros::QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_attackm"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
 }
 
 pub fn install() {
@@ -266,6 +302,7 @@ pub fn install() {
         game_throwb,
         game_throwhi,
         game_throwlw,
+        effect_throwlw,
         expression_throwlw,
     );
 }

--- a/fighters/lucas/src/acmd/throws.rs
+++ b/fighters/lucas/src/acmd/throws.rs
@@ -234,14 +234,14 @@ unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.600);
+        FT_MOTION_RATE(fighter, 0.550);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 7.0, 361, 100, 0, 60, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
     }
 
     frame(lua_state, 34.0);
     if is_excute(fighter){
-        FT_MOTION_RATE(fighter, 0.800);
+        FT_MOTION_RATE(fighter, 0.750);
         CHECK_FINISH_CAMERA(fighter, 9.0, 0.0);
     }
 

--- a/fighters/lucas/src/acmd/throws.rs
+++ b/fighters/lucas/src/acmd/throws.rs
@@ -234,20 +234,20 @@ unsafe fn game_throwlw(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.6);
+        FT_MOTION_RATE(fighter, 0.600);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 105, 50, 0, 85, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 7.0, 361, 100, 0, 60, 0.5, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_THROW);
     }
 
     frame(lua_state, 34.0);
     if is_excute(fighter){
-        FT_MOTION_RATE(fighter, 0.8);
+        FT_MOTION_RATE(fighter, 0.800);
         CHECK_FINISH_CAMERA(fighter, 9.0, 0.0);
     }
 
     frame(lua_state, 41.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
+        FT_MOTION_RATE(fighter, 1.00);
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
     }
     
@@ -270,7 +270,7 @@ unsafe fn effect_throwlw(fighter: &mut L2CAgentBase) {
     frame(lua_state, 41.0);
     if is_excute(fighter) {
         macros::EFFECT_FOLLOW_FLIP(fighter, Hash40::new("lucas_psi_atk_lw"), Hash40::new("lucas_psi_atk_lw"), Hash40::new("top"), 0, 0.2, 8.5, 0, 0, 0, 1.1, true, *EF_FLIP_YZ);
-        LAST_EFFECT_SET_RATE(fighter, 0.75);
+        LAST_EFFECT_SET_RATE(fighter, 0.70);
        // EFFECT_FOLLOW(fighter, Hash40::new("lucas_psi_atk"), Hash40::new("throw"), 0, 10, 0, 0, 0, 0, 0.8, true);
     }
 }


### PR DESCRIPTION

https://github.com/HDR-Development/HewDraw-Remix/assets/64927775/56a099e4-bb58-4505-af7c-737ca3a0db54

Lucas' down throw in HDR still makes use of Ultimate's bury effect, which in its sped up form is quite jarring visually. This PR changes the down throw to resemble his down throw in PM/Brawl, without visual the bury effect, and a new visual on the hitbox that makes it look like a PSI blast hits them out of the ground after they're initially hit. It matches up a bit better overall with his kit and looks better in combos and strings, and also makes more sense because what was that bury throw anyway.

The FaF of the throw should be the exact same. Similarly, the timing for the throw should be extremely similar (for combo DI), so this is neither a buff nor a nerf, purely a visual change

I've also fixed the timing of his voice lines on his side special to come out upon using the move rather than on the first frame, and made his down smash sound effect louder to better fit the strength of the move as previously it felt quite underwhelming to hit.


