### PR TITLE
Changed Weapon Catch Behavior

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -691,6 +691,14 @@ pub fn install() {
         // Resets projectile lifetime on parry, rather than using remaining lifetime
         skyline::patching::Patch::in_text(0x33bd358).nop();
         skyline::patching::Patch::in_text(0x33bd35c).data(0x2a0a03e1);
+
+        // The following handles disabling the "Weapon Catch" animation for those who have it.
+        // You will only enter the weapon catch animation if you are completely idle.
+        // Link, Young Link, Toon Link
+        skyline::patching::Patch::in_text(0xc297f8).data(0x7100011F);
+        // Simon and Richter
+        skyline::patching::Patch::in_text(0x1195204).data(0x7100001F);
+        // Krool and Pyra are in their respective modules.
     }
     skyline::install_hooks!(
         before_collision,

--- a/fighters/eflame/src/lib.rs
+++ b/fighters/eflame/src/lib.rs
@@ -44,6 +44,6 @@ pub fn install(is_runtime: bool) {
     opff::install(is_runtime);
     unsafe {
         // Disables the sword catch animation unless you are completely idle.
-        skyline::patching::Patch::in_text(0xa0cb94).data(0x7100001F);
+        skyline::patching::Patch::in_text(0xa0cad4).data(0x7100001F);
     }
 }

--- a/fighters/eflame/src/lib.rs
+++ b/fighters/eflame/src/lib.rs
@@ -42,4 +42,8 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    unsafe {
+        // Disables the sword catch animation unless you are completely idle.
+        skyline::patching::Patch::in_text(0xa0cb94).data(0x7100001F);
+    }
 }

--- a/fighters/krool/src/lib.rs
+++ b/fighters/krool/src/lib.rs
@@ -6,6 +6,7 @@ pub mod acmd;
 
 pub mod status;
 pub mod opff;
+pub mod vtable_hook;
 
 use smash::{
     lib::{
@@ -42,6 +43,7 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    vtable_hook::install();
     use opff::*;
     smashline::install_agent_frames!(
         krool_backpack_frame

--- a/fighters/krool/src/vtable_hook.rs
+++ b/fighters/krool/src/vtable_hook.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+// Covers Canonball Suction (Applies to Kirby as well) and Crown Catch
+
+#[skyline::hook(offset = 0xc06530)]
+pub unsafe extern "C" fn krool_func(_vtable: u64, fighter: &mut Fighter) -> u64 {
+    let module_accessor = (fighter.battle_object).module_accessor;
+    let status = StatusModule::status_kind(module_accessor);
+    let kind = WorkModule::get_int(module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_KIND);
+    if status == 0x1e2 || status == 0x319
+    && WorkModule::is_flag(module_accessor, *FIGHTER_KROOL_INSTANCE_WORK_ID_FLAG_SPECIAL_N_SUCTION_IRONBALL) {
+        let status = if kind == *FIGHTER_KIND_KIRBY {
+            0x31b
+        }
+        else {
+            0x1e4
+        };
+        StatusModule::change_status_request(module_accessor, status, false);
+    }
+    else if kind != *FIGHTER_KIND_KIRBY
+    && WorkModule::is_flag(module_accessor, 0x200000EC) { // FIGHTER_KROOL_INSTANCE_WORK_ID_FLAG_CATCH_CROWN
+        if ArticleModule::is_exist(module_accessor, *FIGHTER_KROOL_GENERATE_ARTICLE_CROWN) {
+            if status == *FIGHTER_KROOL_STATUS_KIND_SPECIAL_S_FAILURE {
+                StatusModule::change_status_request(module_accessor, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_S_CATCH, false);
+                WorkModule::off_flag(module_accessor, 0x200000EB); // FIGHTER_KROOL_INSTANCE_WORK_ID_FLAG_DROP_CROWN
+            }
+        }
+        WorkModule::off_flag(module_accessor, 0x200000EC);
+    }
+    0
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        krool_func
+    );
+}


### PR DESCRIPTION
Changes the behavior of catching certain weapons.

Link, Young Link, Toon Link, Simon, Richter, and Pyra will only catch their Boomerang/Cross/Sword if they are standing completely idle.

King K. Rool will only automatically catch his crown if he performs an empty Side Special when the crown is returning to him.
Crown pickup behavior was not changed for picking up the crown after it becomes an item.
The crown catch animation's FAF was reverted to vanilla (18 frames).

Includes assets: 
[weapon_catch_assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11670382/weapon_catch_assets.zip)
