### PR TITLE
Rosalina teleport adjustment

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -440,13 +440,17 @@ pub mod vars {
             pub const TICO_X_DIST: i32 = 0x0107;
             pub const TICO_Y_DIST: i32 = 0x0108;
 
-            // flag
-            pub const IS_TICO_DEAD: i32 = 0x0105;
+            // flags
+            pub const IS_TICO_DEAD: i32 = 0x0100;
+            pub const IS_TICO_IN_HITSTUN: i32 = 0x0101;
         }
         pub mod status {
-            // int
+            // ints
             /// Used for determining what luma does
             pub const INVIS_FRAMES: i32 = 0x1100;
+
+            // flags
+            pub const IS_INVALID_TELEPORT: i32 = 0x1101;
         }
     }
 

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -447,7 +447,7 @@ pub mod vars {
         pub mod status {
             // ints
             /// Used for determining what luma does
-            pub const INVIS_FRAMES: i32 = 0x1100;
+            pub const LUMA_STATE: i32 = 0x1100;
 
             // flags
             pub const IS_INVALID_TELEPORT: i32 = 0x1101;

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -441,8 +441,7 @@ pub mod vars {
             pub const TICO_Y_DIST: i32 = 0x0108;
 
             // flags
-            pub const IS_TICO_DEAD: i32 = 0x0100;
-            pub const IS_TICO_IN_HITSTUN: i32 = 0x0101;
+            pub const IS_TICO_UNAVAILABLE: i32 = 0x0100;
         }
         pub mod status {
             // ints

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -116,11 +116,11 @@ pub unsafe fn rosetta_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 #[weapon_frame( agent = WEAPON_KIND_ROSETTA_TICO )]
 fn tico_frame(weapon: &mut L2CFighterBase) {
     unsafe {
-		if StatusModule::is_changing(boma) {
-			VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
-		}
 		let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
 		let rosetta = utils::util::get_battle_object_from_id(owner_id);
+		if StatusModule::is_changing(weapon.module_accessor) {
+			VarModule::off_flag(rosetta, vars::rosetta::instance::IS_TICO_UNAVAILABLE);
+		}
 		if weapon.is_status_one_of(&[
 			*WEAPON_ROSETTA_TICO_STATUS_KIND_DEAD,
 			*WEAPON_ROSETTA_TICO_STATUS_KIND_NONE,

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -19,6 +19,7 @@ extern "Rust" {
 //Rosalina Teleport
 unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
 	if StatusModule::is_changing(boma) {
+		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
         return;
     }
 	let fighter_kind = smash::app::utility::get_kind(boma);
@@ -27,6 +28,8 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 	if !smash::app::sv_information::is_ready_go(){
 		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
 		VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
+		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
+		VarModule::off_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT);
 	};
 	let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
 	let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
@@ -41,28 +44,35 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 			macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
 			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
 		};
-		if frame > 17.0 && frame < 20.0 {
-			HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
-			VisibilityModule::set_whole(boma, false);
-			JostleModule::set_status(boma, false);	
-			let new_x = tico_x;
-			let new_y = tico_y;
-			let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
-			PostureModule::set_pos(boma, &pos);
-			PostureModule::init_pos(boma, &pos, true, true);
-			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
-		};
-		if frame == 26.0 {
-			macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
-		};
-		if frame > 26.0{
-			VisibilityModule::set_whole(boma, true);
-			JostleModule::set_status(boma, true);	
-			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
-			HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
-		};
-		if frame > 38.0{
+		if frame > 13.0 && frame <= 17.0 && VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN) {
+			// prevent the successful teleport logic if Luma is put into hitstun during startup
+			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 0);
+			VarModule::on_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT);
+		}
+		if !VarModule::is_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT) {
+			if frame > 17.0 && frame < 20.0 {
+				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
+				VisibilityModule::set_whole(boma, false);
+				JostleModule::set_status(boma, false);	
+				let new_x = tico_x;
+				let new_y = tico_y;
+				let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
+				PostureModule::set_pos(boma, &pos);
+				PostureModule::init_pos(boma, &pos, true, true);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
+			};
+			if frame == 26.0 {
+				macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
+			};
+			if frame > 26.0{
+				VisibilityModule::set_whole(boma, true);
+				JostleModule::set_status(boma, true);	
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
+				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+			};
+		}
+		if frame > 38.0 {
 			CancelModule::enable_cancel(boma);
 		};
 	} else {
@@ -85,6 +95,7 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 	};
 	if status_kind == *FIGHTER_STATUS_KIND_DEAD {
 		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD);
+		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
 	};
 }
 
@@ -108,43 +119,51 @@ pub unsafe fn rosetta_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 }
 #[weapon_frame( agent = WEAPON_KIND_ROSETTA_TICO )]
 fn tico_frame(weapon: &mut L2CFighterBase) {
-    unsafe { 
-			let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
-			let rosetta = utils::util::get_battle_object_from_id(owner_id);
-			let rosetta_boma = &mut *(*rosetta).module_accessor;
-			if weapon.is_status(*WEAPON_ROSETTA_TICO_STATUS_KIND_DEAD) || weapon.is_status(*WEAPON_ROSETTA_TICO_STATUS_KIND_NONE) {
-				VarModule::on_flag(rosetta, vars::rosetta::instance::IS_TICO_DEAD);
+    unsafe {
+		let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
+		let rosetta = utils::util::get_battle_object_from_id(owner_id);
+		let rosetta_boma = &mut *(*rosetta).module_accessor;
+		if weapon.is_status_one_of(&[
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DEAD,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_NONE]) {
+			VarModule::on_flag(rosetta, vars::rosetta::instance::IS_TICO_DEAD);
+		}
+		else if weapon.is_status_one_of(&[
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_AIR,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_FALL,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_FLY,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_FLY_REFLECT_U]) {
+			VarModule::on_flag(rosetta, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
+		}
+		if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) > 0 {
+			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 1 {
+				macros::EFFECT(weapon, Hash40::new("rosetta_escape"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, true);
 			};
-			if weapon.is_status(*WEAPON_ROSETTA_TICO_STATUS_KIND_REBIRTH){
-				VarModule::off_flag(rosetta, vars::rosetta::instance::IS_TICO_DEAD);
+			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 2 {
+				let new_x = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_X) as f32;
+				let new_y = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_Y) as f32;
+				HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
+				VisibilityModule::set_whole(weapon.module_accessor, false);
+				JostleModule::set_status(weapon.module_accessor, false);	
+				let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
+				PostureModule::set_pos(weapon.module_accessor, &pos);
+				PostureModule::init_pos(weapon.module_accessor, &pos, true, true);
 			};
-			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) > 0 {
-				if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 1 {
-					macros::EFFECT(weapon, Hash40::new("rosetta_escape"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, true);
-				};
-				if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 2 {
-					let new_x = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_X) as f32;
-					let new_y = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_Y) as f32;
-					HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
-					VisibilityModule::set_whole(weapon.module_accessor, false);
-					JostleModule::set_status(weapon.module_accessor, false);	
-					let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
-					PostureModule::set_pos(weapon.module_accessor, &pos);
-					PostureModule::init_pos(weapon.module_accessor, &pos, true, true);
-				};
-				if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 3 {
-					macros::EFFECT(weapon, Hash40::new("rosetta_escape_end"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-				};
-				if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 4 {
-					JostleModule::set_status(weapon.module_accessor, true);	
-					VisibilityModule::set_whole(weapon.module_accessor, true);
-					VarModule::set_int(rosetta, vars::rosetta::instance::COOLDOWN, 300); //300 Frame (5 second) cooldown
-					VarModule::set_int(rosetta, vars::rosetta::status::INVIS_FRAMES, 0);
-					HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
-				};
-			} else {
-				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_X, PostureModule::pos_x(weapon.module_accessor) as i32);
-				VarModule::set_int(rosetta, vars::rosetta::instance::TICO_Y, PostureModule::pos_y(weapon.module_accessor) as i32);
+			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 3 {
+				macros::EFFECT(weapon, Hash40::new("rosetta_escape_end"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
 			};
+			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 4 {
+				JostleModule::set_status(weapon.module_accessor, true);	
+				VisibilityModule::set_whole(weapon.module_accessor, true);
+				VarModule::set_int(rosetta, vars::rosetta::instance::COOLDOWN, 300); //300 Frame (5 second) cooldown
+				VarModule::set_int(rosetta, vars::rosetta::status::INVIS_FRAMES, 0);
+				HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
+			};
+		} else {
+			VarModule::set_int(rosetta, vars::rosetta::instance::TICO_X, PostureModule::pos_x(weapon.module_accessor) as i32);
+			VarModule::set_int(rosetta, vars::rosetta::instance::TICO_Y, PostureModule::pos_y(weapon.module_accessor) as i32);
+		};
 	};
 }

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -22,31 +22,29 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
         return;
     }
-	let fighter_kind = smash::app::utility::get_kind(boma);
-	let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as usize;
-	let frame = MotionModule::frame(boma);
 	if !smash::app::sv_information::is_ready_go(){
 		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
 		VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_DEAD);
 		VarModule::off_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
 		VarModule::off_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT);
 	};
-	let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
-	let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
-	let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
-	let tico_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
-	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, (GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: rosa_x, y: rosa_y}, &Vector2f{ x: tico_x, y: tico_y}, false)) as i32);
-	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (rosa_x-tico_x) as i32);
-	VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (rosa_y-tico_y) as i32);
 	//Teleport!
 	if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_DEAD) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
+		let frame = MotionModule::frame(boma);
+		let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
+		let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
+		let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;
+		let tico_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_Y) as f32;
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_RAYCAST, (GroundModule::ray_check(boma, &smash::phx::Vector2f{ x: rosa_x, y: rosa_y}, &Vector2f{ x: tico_x, y: tico_y}, false)) as i32);
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_X_DIST, (rosa_x-tico_x) as i32);
+		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::TICO_Y_DIST, (rosa_y-tico_y) as i32);
 		if frame == 13.0 {
 			macros::EFFECT(fighter, Hash40::new("rosetta_escape"), Hash40::new("top"), 0, 0, -3, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 1);
+			VarModule::set_int(fighter.battle_object, vars::rosetta::status::LUMA_STATE, 1);
 		};
 		if frame > 13.0 && frame <= 17.0 && VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_IN_HITSTUN) {
 			// prevent the successful teleport logic if Luma is put into hitstun during startup
-			VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 0);
+			VarModule::set_int(fighter.battle_object, vars::rosetta::status::LUMA_STATE, 0);
 			VarModule::on_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT);
 		}
 		if !VarModule::is_flag(fighter.battle_object, vars::rosetta::status::IS_INVALID_TELEPORT) {
@@ -59,16 +57,16 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 				let pos = smash::phx::Vector3f { x: new_x, y: new_y, z: 0.0 };
 				PostureModule::set_pos(boma, &pos);
 				PostureModule::init_pos(boma, &pos, true, true);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 2);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::LUMA_STATE, 2);
 			};
 			if frame == 26.0 {
 				macros::EFFECT(fighter, Hash40::new("rosetta_escape_end"), Hash40::new("top"), 0, 0, -1.5, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 3);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::LUMA_STATE, 3);
 			};
 			if frame > 26.0{
 				VisibilityModule::set_whole(boma, true);
 				JostleModule::set_status(boma, true);	
-				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
+				VarModule::set_int(fighter.battle_object, vars::rosetta::status::LUMA_STATE, 4);
 				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
 			};
 			if frame > 38.0 {
@@ -137,11 +135,11 @@ fn tico_frame(weapon: &mut L2CFighterBase) {
 			*WEAPON_ROSETTA_TICO_STATUS_KIND_DAMAGE_FLY_REFLECT_U]) {
 			VarModule::on_flag(rosetta, vars::rosetta::instance::IS_TICO_IN_HITSTUN);
 		}
-		if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) > 0 {
-			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 1 {
+		if VarModule::get_int(rosetta, vars::rosetta::status::LUMA_STATE) > 0 {
+			if VarModule::get_int(rosetta, vars::rosetta::status::LUMA_STATE) == 1 {
 				macros::EFFECT(weapon, Hash40::new("rosetta_escape"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, true);
 			};
-			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 2 {
+			if VarModule::get_int(rosetta, vars::rosetta::status::LUMA_STATE) == 2 {
 				let new_x = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_X) as f32;
 				let new_y = VarModule::get_int(rosetta, vars::rosetta::instance::ROSA_Y) as f32;
 				HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_XLU), 0);
@@ -151,14 +149,14 @@ fn tico_frame(weapon: &mut L2CFighterBase) {
 				PostureModule::set_pos(weapon.module_accessor, &pos);
 				PostureModule::init_pos(weapon.module_accessor, &pos, true, true);
 			};
-			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 3 {
+			if VarModule::get_int(rosetta, vars::rosetta::status::LUMA_STATE) == 3 {
 				macros::EFFECT(weapon, Hash40::new("rosetta_escape_end"), Hash40::new("rot"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
 			};
-			if VarModule::get_int(rosetta, vars::rosetta::status::INVIS_FRAMES) == 4 {
+			if VarModule::get_int(rosetta, vars::rosetta::status::LUMA_STATE) == 4 {
 				JostleModule::set_status(weapon.module_accessor, true);	
 				VisibilityModule::set_whole(weapon.module_accessor, true);
 				VarModule::set_int(rosetta, vars::rosetta::instance::COOLDOWN, 300); //300 Frame (5 second) cooldown
-				VarModule::set_int(rosetta, vars::rosetta::status::INVIS_FRAMES, 0);
+				VarModule::set_int(rosetta, vars::rosetta::status::LUMA_STATE, 0);
 				HitModule::set_whole(weapon.module_accessor, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
 			};
 		} else {

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -71,10 +71,10 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 				VarModule::set_int(fighter.battle_object, vars::rosetta::status::INVIS_FRAMES, 4);
 				HitModule::set_whole(boma, smash::app::HitStatus(*HIT_STATUS_NORMAL), 0);
 			};
+			if frame > 38.0 {
+				CancelModule::enable_cancel(boma);
+			};
 		}
-		if frame > 38.0 {
-			CancelModule::enable_cancel(boma);
-		};
 	} else {
 		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_X, PostureModule::pos_x(boma) as i32);
 		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y, PostureModule::pos_y(boma) as i32);

--- a/fighters/rosetta/src/opff.rs
+++ b/fighters/rosetta/src/opff.rs
@@ -21,6 +21,7 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 	if StatusModule::is_changing(boma) {
         return;
     }
+	let frame = MotionModule::frame(boma);
 	if !smash::app::sv_information::is_ready_go(){
 		VarModule::set_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN, 0);
 		VarModule::off_flag(boma.object(), vars::rosetta::instance::IS_TICO_UNAVAILABLE);
@@ -28,7 +29,6 @@ unsafe fn teleport(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
 	}
 	//Teleport!
 	if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_LW && !VarModule::is_flag(fighter.battle_object, vars::rosetta::instance::IS_TICO_UNAVAILABLE) && VarModule::get_int(fighter.battle_object, vars::rosetta::instance::COOLDOWN) == 0 {
-		let frame = MotionModule::frame(boma);
 		let rosa_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_X) as f32;
 		let rosa_y = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::ROSA_Y) as f32;
 		let tico_x = VarModule::get_int(fighter.battle_object, vars::rosetta::instance::TICO_X) as f32;


### PR DESCRIPTION
Prevents Rosalina from teleporting if Luma is put into hitstun before the two swap positions. If unsuccessful, Rosalina does not enter teleport cooldown