### PR TITLE
Robin Bug Fix: Tilt inputs correctly use bronze sword

### DIFF
--- a/fighters/robin/src/acmd/ground.rs
+++ b/fighters/robin/src/acmd/ground.rs
@@ -105,8 +105,9 @@ unsafe fn reflet_attack_100_end_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     frame(lua_state, 5.0);
     if is_excute(fighter) {
-       ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 74, 186, 0, 80, 5.0, 0.0, 13.0, 9.0, Some(0.0), Some(6.5), Some(9.0), 3.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
-       ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 74, 186, 0, 80, 5.0, 0.0, 13.0, 17.0, Some(0.0), Some(6.5), Some(17.0), 3.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+        AttackModule::clear_all(fighter.module_accessor);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 74, 186, 0, 80, 5.0, 0.0, 13.0, 9.0, Some(0.0), Some(6.5), Some(9.0), 3.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 74, 186, 0, 80, 5.0, 0.0, 13.0, 17.0, Some(0.0), Some(6.5), Some(17.0), 3.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
     }
     wait(lua_state, 2.0);
     FT_MOTION_RATE(fighter, 1.1);

--- a/fighters/robin/src/lib.rs
+++ b/fighters/robin/src/lib.rs
@@ -3,8 +3,7 @@
 #![allow(non_snake_case)]
 
 pub mod acmd;
-
-//pub mod status;
+pub mod status;
 pub mod opff;
 
 use smash::{
@@ -66,6 +65,6 @@ pub fn install(is_runtime: bool) {
     smashline::install_agent_resets!(reflet_reset);
     smashline::install_agent_init_callbacks!(reflet_init);
     acmd::install();
-    //status::install();
+    status::install();
     opff::install(is_runtime);
 }

--- a/fighters/robin/src/status.rs
+++ b/fighters/robin/src/status.rs
@@ -1,0 +1,19 @@
+use super::*;
+use globals::*;
+
+#[status_script(agent = "reflet", status = FIGHTER_STATUS_KIND_ATTACK_AIR, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
+pub unsafe fn init_attack_air(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_button_off(Buttons::Smash) {
+        VisibilityModule::set_int64(fighter.module_accessor, Hash40::new("sword").hash as i64, Hash40::new("sword_normal").hash as i64);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
+        0.into()
+    } else {
+        0.into()
+    }
+}
+
+pub fn install() {
+    install_status_scripts!(
+        init_attack_air
+    );
+}

--- a/fighters/robin/src/status.rs
+++ b/fighters/robin/src/status.rs
@@ -3,13 +3,10 @@ use globals::*;
 
 #[status_script(agent = "reflet", status = FIGHTER_STATUS_KIND_ATTACK_AIR, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
 pub unsafe fn init_attack_air(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.is_button_off(Buttons::Smash) {
-        VisibilityModule::set_int64(fighter.module_accessor, Hash40::new("sword").hash as i64, Hash40::new("sword_normal").hash as i64);
-        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
-        0.into()
-    } else {
-        0.into()
-    }
+    VisibilityModule::set_int64(fighter.module_accessor, Hash40::new("sword").hash as i64, Hash40::new("sword_normal").hash as i64);
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
+    fighter.sub_attack_air_uniq_process_init();
+    0.into()
 }
 
 pub fn install() {


### PR DESCRIPTION
Before using the smash button would enable levin as expected, but tilt inputs wouldn't enable bronze sword. This makes it function logically. 