### PR TITLE
Standardize Getup Attacks Reverse Hit

### DIFF
--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -36,7 +36,6 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
         data.r_eff = 50;
         data.r_add = 70;
         data.sub_shield = 0;
-        data.lr_check = smash2::app::AttackLRCheck::Pos;
     }
     
     call_original!(module, id, group, data)

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -20,6 +20,7 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
         data.r_eff = 50;  // KBG
         data.r_add = 80;  // BKB
         data.sub_shield = 0;  // shield damage modifier
+        data.lr_check = smash2::app::AttackLRCheck::Pos; // always allow reverse hit
     }
     if (*boma).is_status(*FIGHTER_STATUS_KIND_SLIP_STAND_ATTACK) {
         data.power = 5.0;
@@ -27,6 +28,7 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
         data.r_eff = 50;
         data.r_add = 80;
         data.sub_shield = 0;
+        data.lr_check = smash2::app::AttackLRCheck::Pos;
     }
     if (*boma).is_status(*FIGHTER_STATUS_KIND_CLIFF_ATTACK) {
         data.power = 8.0;
@@ -34,6 +36,7 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
         data.r_eff = 50;
         data.r_add = 70;
         data.sub_shield = 0;
+        data.lr_check = smash2::app::AttackLRCheck::Pos;
     }
     
     call_original!(module, id, group, data)


### PR DESCRIPTION
Some getup attacks were able to reverse hit while others couldn't. This PR makes every getup attack possible to reverse hit.