### PR TITLE
Yoshi/Mewtwo - fix DJC override aerial arcs

### DIFF
--- a/fighters/mewtwo/src/acmd/aerials.rs
+++ b/fighters/mewtwo/src/acmd/aerials.rs
@@ -67,9 +67,7 @@ unsafe fn mewtwo_attack_air_b_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 7.0/(13.0-1.0));
-    }
+    MotionModule::set_rate(boma, (13.0 - 1.0) / 7.0);
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
@@ -77,9 +75,7 @@ unsafe fn mewtwo_attack_air_b_game(fighter: &mut L2CAgentBase) {
         HIT_NO(fighter, 13, *HIT_STATUS_NORMAL);
     }
     frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
-    }
+    MotionModule::set_rate(boma, 1.0);
     frame(lua_state, 13.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("s_tail1"), 13.0, 361, 98, 0, 22, 5.5, 3.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_TAIL);
@@ -104,9 +100,7 @@ unsafe fn mewtwo_attack_air_hi_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 7.0/(10.0-1.0));
-    }
+    MotionModule::set_rate(boma, (10.0 - 1.0) / 7.0);
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         HIT_NO(fighter, 12, *HIT_STATUS_NORMAL);
@@ -114,9 +108,7 @@ unsafe fn mewtwo_attack_air_hi_game(fighter: &mut L2CAgentBase) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
     frame(lua_state, 7.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
-    }
+    MotionModule::set_rate(boma, 1.0);
     frame(lua_state, 9.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("s_tail3"), 12.0, 72, 103, 0, 13, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_TAIL);
@@ -141,16 +133,14 @@ unsafe fn mewtwo_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 14.0/(19.0-1.0));
-    }
+    MotionModule::set_rate(boma, (19.0 - 1.0) / 14.0);
     frame(lua_state, 4.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
     frame(lua_state, 19.0);
+    MotionModule::set_rate(boma, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
         ATTACK(fighter, 0, 0, Hash40::new("top"), 16.0, 270, 62, 0, 12, 5.5, 0.0, -7.7, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_purple"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 13.0, 70, 105, 0, 20, 7.5, 0.0, -5.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_purple"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }

--- a/fighters/yoshi/src/acmd/aerials.rs
+++ b/fighters/yoshi/src/acmd/aerials.rs
@@ -81,9 +81,7 @@ unsafe fn yoshi_attack_air_b_game(fighter: &mut L2CAgentBase) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
     frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 2.0);
-    }
+    MotionModule::set_rate(boma, 0.5);
     frame(lua_state, 10.5);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("tail1"), 4.5, 366, 45, 0, 25, 4.5, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
@@ -111,8 +109,8 @@ unsafe fn yoshi_attack_air_b_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 2, 0, Hash40::new("tail2"), 5.5, 60, 100, 0, 48, 5.0, 6.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
     }
     frame(lua_state, 19.5);
+    MotionModule::set_rate(boma, (50.0 - 29.0) / 13.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 13.0/(50.0-29.0));
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 44.0);
@@ -126,10 +124,6 @@ unsafe fn yoshi_attack_air_b_game(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_air_b_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 2.0);
-    }
     frame(lua_state, 10.5);
     if is_excute(fighter) {
         EFFECT_FOLLOW_ALPHA(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 3, -4, 175.671, -17.429, 82.039, 1, true, 0.3);
@@ -152,7 +146,7 @@ unsafe fn yoshi_attack_air_b_effect(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_air_hi_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    FT_MOTION_RATE(fighter, 5.0/(4.2-0.0));
+    MotionModule::set_rate(boma, (4.2 - 0.0) / 5.0);
     frame(lua_state, 4.2);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
@@ -169,9 +163,7 @@ unsafe fn yoshi_attack_air_hi_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.9);
-    }
+    MotionModule::set_rate(boma, 1.11);
     frame(lua_state, 33.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
@@ -183,7 +175,6 @@ unsafe fn yoshi_attack_air_hi_game(fighter: &mut L2CAgentBase) {
 unsafe fn yoshi_attack_air_hi_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    FT_MOTION_RATE(fighter, 5.0/(4.2-0.0));
     frame(lua_state, 4.2);
     if is_excute(fighter) {
         EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1, 12, -2, 111, -66.6, -211, 0.9, true, *EF_FLIP_YZ);


### PR DESCRIPTION
Fixes an issue where performing certain DJC override aerials would alter the double jump arc.

Replaces `FT_MOTION_RATE` calls with `MotionModule::set_rate`.

Fixes #1695