### PR TITLE
Fix DACUS disabling up/down smash during cancellable recovery frames

### DIFF
--- a/fighters/common/src/general_statuses/attackdash.rs
+++ b/fighters/common/src/general_statuses/attackdash.rs
@@ -114,7 +114,13 @@ unsafe extern "C" fn sub_attack_dash_uniq(fighter: &mut L2CFighterCommon, arg: L
             VarModule::off_flag(fighter.battle_object, vars::common::status::ATTACK_DASH_CANCEL_DISABLE);
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_LW4_START);
-        } else {
+        } 
+        // Re-enable transition flags during cancellable recovery frames
+        else if CancelModule::is_enable_cancel(fighter.module_accessor) {
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
+            WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_LW4_START);
+        }
+        else {
             VarModule::on_flag(fighter.battle_object, vars::common::status::ATTACK_DASH_CANCEL_DISABLE);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);
             WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_LW4_START);


### PR DESCRIPTION
Dash Attack normally disables being able to transition into up/down smash outside the DACUS window. This also results in not being able to do up/down smash during the cancellable recovery frames of dash attack (tilts, jabs, and all other actions can still properly cancel