### PR TITLE
Plant Adjustments

### DIFF
--- a/fighters/packun/src/acmd/ground.rs
+++ b/fighters/packun/src/acmd/ground.rs
@@ -81,7 +81,7 @@ unsafe fn packun_attack_13_game(fighter: &mut L2CAgentBase) {
     let sound_level = if stance.label != 2 { *ATTACK_SOUND_LEVEL_M } else { *ATTACK_SOUND_LEVEL_S };
     let sound = if stance.label != 2 { *COLLISION_SOUND_ATTR_PUNCH } else { *COLLISION_SOUND_ATTR_HEAVY };
     if stance.label == 2 {
-        FT_MOTION_RATE(fighter, (10.0/7.0));
+        FT_DESIRED_RATE(fighter, 7.0, 9.0);
     }
     if is_excute(fighter) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 5.0, 4.0);

--- a/fighters/packun/src/acmd/other.rs
+++ b/fighters/packun/src/acmd/other.rs
@@ -126,6 +126,12 @@ unsafe fn appeal_hi_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     VarModule::set_int(boma.object(), vars::packun::instance::CURRENT_STANCE, 0);
     VarModule::on_flag(fighter.object(), vars::packun::instance::STANCE_INIT);
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW);
+    }
 }
 
 #[acmd_script( agent = "packun", scripts = ["sound_appealhil", "sound_appealhir"], category = ACMD_SOUND, low_priority )]
@@ -148,6 +154,12 @@ unsafe fn appeal_s_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     VarModule::set_int(boma.object(), vars::packun::instance::CURRENT_STANCE, 2);
     VarModule::on_flag(fighter.object(), vars::packun::instance::STANCE_INIT);
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW);
+    }
 }
 
 #[acmd_script( agent = "packun", scripts = ["sound_appealsl", "sound_appealsr"], category = ACMD_SOUND, low_priority )]
@@ -179,6 +191,12 @@ unsafe fn appeal_lw_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     VarModule::set_int(boma.object(), vars::packun::instance::CURRENT_STANCE, 1);
     VarModule::on_flag(fighter.object(), vars::packun::instance::STANCE_INIT);
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_U);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_S);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_APPEAL_LW);
+    }
 }
 
 #[acmd_script( agent = "packun", scripts = ["sound_appeallwl", "sound_appeallwr"], category = ACMD_SOUND, low_priority )]

--- a/fighters/packun/src/acmd/specials.rs
+++ b/fighters/packun/src/acmd/specials.rs
@@ -52,7 +52,7 @@ unsafe fn packun_special_s_shoot_game(fighter: &mut L2CAgentBase) {
         }
     }
     else if stance == 1 {
-        FT_DESIRED_RATE(fighter, 5.0, 9.0);
+        FT_DESIRED_RATE(fighter, 5.0, 8.0);
         frame(lua_state, 5.0);
         FT_MOTION_RATE(fighter, 1.0);
         if is_excute(fighter) {

--- a/fighters/packun/src/acmd/specials.rs
+++ b/fighters/packun/src/acmd/specials.rs
@@ -34,24 +34,25 @@ unsafe fn packun_special_s_shoot_game(fighter: &mut L2CAgentBase) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 10.0, 3.0);
     }
     if stance == 0 {
-        FT_MOTION_RATE(fighter, (9.0/5.0));
+        FT_DESIRED_RATE(fighter, 5.0, 6.0);
         frame(lua_state, 5.0);
         FT_MOTION_RATE(fighter, 1.0);
         if is_excute(fighter) {
             if charged {
-                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 12.0, 30, 66, 0, 60, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 14.0, 30, 66, 0, 60, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BITE);
             }
             else {
-                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 8.0, 30, 66, 0, 60, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 10.0, 30, 66, 0, 60, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BITE);
             }
         }
         wait(lua_state, 5.0);
+        FT_DESIRED_RATE(fighter, 40.0, 30.0);
         if is_excute(fighter) {
             AttackModule::clear_all(boma);
         }
     }
     else if stance == 1 {
-        FT_MOTION_RATE(fighter, (8.0/5.0));
+        FT_DESIRED_RATE(fighter, 5.0, 9.0);
         frame(lua_state, 5.0);
         FT_MOTION_RATE(fighter, 1.0);
         if is_excute(fighter) {
@@ -84,13 +85,13 @@ unsafe fn packun_special_s_shoot_game(fighter: &mut L2CAgentBase) {
         FT_MOTION_RATE(fighter, 1.0);
         if is_excute(fighter) {
             if charged {
-                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 16.0, 180, 100, 30, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_saving"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                ATTACK(fighter, 1, 0, Hash40::new("mouth"), 16.0, 90, 100, 80, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_saving"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 18.0, 180, 100, 30, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_saving"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 1, 0, Hash40::new("mouth"), 18.0, 90, 100, 80, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, f32::NAN, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_saving"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
                 AttackModule::set_add_reaction_frame(boma, 0, 17.0, false);
             }
             else {
-                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 10.0, 180, 100, 30, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 5.0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                ATTACK(fighter, 1, 0, Hash40::new("mouth"), 10.0, 90, 100, 80, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 5.0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 0, 0, Hash40::new("mouth"), 12.0, 180, 100, 30, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 8.0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 1, 0, Hash40::new("mouth"), 12.0, 90, 100, 80, 0, 9.0, 2.0, 0.0, 0.0, Some(7.0), Some(0.0), Some(0.0), 1.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 8.0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
                 ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 2.0);
                 AttackModule::set_add_reaction_frame(boma, 0, 9.0, false);
             }

--- a/fighters/packun/src/opff.rs
+++ b/fighters/packun/src/opff.rs
@@ -90,9 +90,9 @@ unsafe fn check_apply_speeds(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
             *FIGHTER_STATUS_KIND_PASSIVE_FB]) {
                 apply_status_speed_mul(fighter, 1.0);
         } else if VarModule::get_int(fighter.object(), vars::packun::instance::CURRENT_STANCE) == 1 {
-            apply_status_speed_mul(fighter, 0.88);
+            apply_status_speed_mul(fighter, 0.84);
         } else if VarModule::get_int(fighter.object(), vars::packun::instance::CURRENT_STANCE) == 2 {
-            apply_status_speed_mul(fighter, 0.75);
+            apply_status_speed_mul(fighter, 0.77);
         }
         VarModule::off_flag(fighter.object(), vars::packun::instance::STANCE_NEED_SET_SPEEDS);
     }
@@ -134,13 +134,12 @@ unsafe fn check_apply_speeds(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     }
 }
 
-/// checks if stance should be reset due to death or match end
+/// checks if stance should be reset due to match end
 unsafe fn check_reset(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     if fighter.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_WIN,
         *FIGHTER_STATUS_KIND_LOSE,
-        *FIGHTER_STATUS_KIND_ENTRY,
-        *FIGHTER_STATUS_KIND_DEAD]) {
+        *FIGHTER_STATUS_KIND_ENTRY]) {
             VarModule::set_int(fighter.object(), vars::packun::instance::CURRENT_STANCE, 0);
     }
 }


### PR DESCRIPTION
Further refinements to Piranha Plant's new stance mechanic, along with power increases to the less useful versions of Adaptive Maw
romfs: [hdr-assets-plant.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11762379/hdr-assets-plant.zip)

## Changelog
### Adaptive Roots:
- [-] Putrid movement speed : 0.88x → 0.84x
- [+] Prickly movement speed: 0.75x → 0.77x
- [+] Taunt FAF: F50 → F20
- [/] Stance no longer resets on death

### Jab 3:
- Prickly
  - [+] Startup: F10 → F9

### Adaptive Maw:
- Standard
  - [+] Startup: F19 → F16
  - [+] Damage (uncharged/charged): 8.0%/12.0% → 10.0%/14.0%
  - [+] Endlag: 40F → 30F
  - (!) FAF: F64 → F51
- Prickly
  - [+] Damage (uncharged/charged): 10.0%/16.0% → 12.0%/18.0%
  - [+] Shield Damage (uncharged): 5.0 → 8.0