### PR TITLE
Meta Knight - Brawl jab

### DIFF
--- a/fighters/metaknight/src/acmd/ground.rs
+++ b/fighters/metaknight/src/acmd/ground.rs
@@ -1,6 +1,175 @@
-
 use super::*;
 
+#[acmd_script( agent = "metaknight", script = "game_attack100", category = ACMD_GAME, low_priority )]
+unsafe fn game_attack100(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 361, 8, 0, 40, 7.0, 0.0, 6.5, 8.0, Some(0.0), Some(6.5), Some(13.5), 0.5, 0.6, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        AttackModule::set_add_reaction_frame(boma, 0, 3.0, false);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+    }
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 361, 8, 0, 40, 7.0, 0.0, 6.5, 8.0, Some(0.0), Some(6.5), Some(13.5), 0.5, 0.6, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        AttackModule::set_add_reaction_frame(boma, 0, 3.0, false);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 361, 8, 0, 40, 4.0, 0.0, 6.0, -3.0, Some(0.0), Some(6.0), Some(-9.5), 0.5, 0.6, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 361, 40, 0, 60, 7.0, 0.0, 6.5, 8.0, Some(0.0), Some(6.5), Some(13.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        //ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 361, 8, 0, 40, 7.0, 0.0, 6.5, 8.0, Some(0.0), Some(6.5), Some(13.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 361, 40, 0, 60, 4.0, 0.0, 6.0, -3.0, Some(0.0), Some(6.0), Some(-9.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        //ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 4);
+    }
+    frame(lua_state, 20.0);
+    FT_MOTION_RATE_RANGE(fighter, 20.0, 26.0, 7.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 26.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE);
+    }
+}
+
+#[acmd_script( agent = "metaknight", script = "effect_attack100", category = ACMD_EFFECT, low_priority )]
+unsafe fn effect_attack100(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_sword"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
+    }
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 1, 6, -1, 20, 165, 105, 0.5, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.65, 0.7));
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 0, 7, 0, 90, 0, 25, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.8, 0.65));
+    }
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 1, 6.5, -1, -165, 20, -80, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.5, 0.75));
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 0, 6, 2, -205, 160, -145, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.7, 0.85));
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 2, 6, 1, 0, -155, 105, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.7, 0.7));
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 0, 7, 0, 90, 0, -45, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.85, 0.65));
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), 2, 4, 4, -165, 20, -95, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.5, 0.75));
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_air_hi"), Hash40::new("top"), -2, 6, -4, -25, -30, -60, 1, true);
+        EffectModule::set_disable_render_offset_last(boma);
+        EffectModule::set_scale_last(boma, &Vector3f::new(1.0, 0.5, 0.75));
+    }
+}
+
+// #[acmd_script( agent = "metaknight", script = "game_attack100end", category = ACMD_GAME, low_priority )]
+// unsafe fn game_attack100end(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     AttackModule::clear_all(boma);
+//     frame(lua_state, 3.0);
+//     if is_excute(fighter) {
+//         ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 361, 100, 0, 40, 5.0, 0.0, 8.0, 11.0, None, None, None, 2.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+//         ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 361, 100, 0, 40, 6.0, 0.0, 8.0, 16.5, None, None, None, 2.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+//     }
+//     wait(lua_state, 1.0);
+//     if is_excute(fighter) {
+//         AttackModule::clear_all(boma);
+//     }
+//     FT_MOTION_RATE(fighter, 0.87);
+// }
+
+// #[acmd_script( agent = "metaknight", script = "effect_attack100end", category = ACMD_EFFECT, low_priority )]
+// unsafe fn effect_attack100end(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     if is_excute(fighter) {
+//         LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+//         EFFECT_OFF_KIND(fighter, Hash40::new("metaknight_attack"), false, false);
+//         EffectModule::set_disable_render_offset_last(boma);
+//     }
+//     frame(lua_state, 3.0);
+//     if is_excute(fighter) {
+//         EFFECT_FOLLOW(fighter, Hash40::new("metaknight_attack_end"), Hash40::new("top"), -0.0, 0, 0, 0, 0, 0, 0.9, true);
+//         EffectModule::set_disable_render_offset_last(boma);
+//         EFFECT_OFF_KIND(fighter, Hash40::new("metaknight_sword"), false, false);
+//     }
+//     frame(lua_state, 26.0);
+//     if is_excute(fighter) {
+//         FOOT_EFFECT(fighter, Hash40::new("sys_landing_smoke_s"), Hash40::new("top"), -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+//     }
+// }
+
+#[acmd_script( agent = "metaknight", script = "sound_attack100start", category = ACMD_SOUND, low_priority )]
+unsafe fn sound_attack100start(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("vc_metaknight_attack100"));
+        // match smash::app::sv_math::rand(smash::hash40("fighter"), 2) {
+        //     0 => PLAY_SE(fighter, Hash40::new("vc_metaknight_attack100")),
+        //     1 => PLAY_SE(fighter, Hash40::new("vc_metaknight_attack07")),
+        //     _ => {}
+        // };
+    }
+}
 
 #[acmd_script( agent = "metaknight", script = "game_attackdash" , category = ACMD_GAME , low_priority)]
 unsafe fn metaknight_attack_dash_game(fighter: &mut L2CAgentBase) {
@@ -29,60 +198,12 @@ unsafe fn metaknight_attack_dash_game(fighter: &mut L2CAgentBase) {
     
 }
 
-#[acmd_script( agent = "metaknight", script = "game_attack100end", category = ACMD_GAME, low_priority )]
-unsafe fn game_attack100end(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    AttackModule::clear_all(boma);
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.0, 361, 100, 0, 40, 5.0, 0.0, 8.0, 11.0, None, None, None, 2.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 361, 100, 0, 40, 6.0, 0.0, 8.0, 16.5, None, None, None, 2.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 1.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    FT_MOTION_RATE(fighter, 0.87);
-}
-
-#[acmd_script( agent = "metaknight", script = "effect_attack100end", category = ACMD_EFFECT, low_priority )]
-unsafe fn effect_attack100end(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
-        EFFECT_OFF_KIND(fighter, Hash40::new("metaknight_attack"), false, false);
-        EffectModule::set_disable_render_offset_last(boma);
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("metaknight_attack_end"), Hash40::new("top"), -0.0, 0, 0, 0, 0, 0, 0.9, true);
-        EffectModule::set_disable_render_offset_last(boma);
-        EFFECT_OFF_KIND(fighter, Hash40::new("metaknight_sword"), false, false);
-    }
-    frame(lua_state, 26.0);
-    if is_excute(fighter) {
-        FOOT_EFFECT(fighter, Hash40::new("sys_landing_smoke_s"), Hash40::new("top"), -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
-    }
-}
-
-#[acmd_script( agent = "metaknight", script = "sound_attack100start", category = ACMD_SOUND, low_priority )]
-unsafe fn sound_attack100start(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        // PLAY_STATUS(fighter, Hash40::new("vc_metaknight_attack100"));
-    }
-}
-
 pub fn install() {
     install_acmd_scripts!(
+        game_attack100,
+        effect_attack100,
+        sound_attack100start,
         metaknight_attack_dash_game,
-        game_attack100end,
-        effect_attack100end,
-        sound_attack100start
     );
 }
 

--- a/fighters/metaknight/src/opff.rs
+++ b/fighters/metaknight/src/opff.rs
@@ -108,11 +108,7 @@ unsafe fn up_special_proper_landing(fighter: &mut smash::lua2cpp::L2CFighterComm
 }
 
 unsafe fn attack_100_end_early(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, motion_kind: u64, frame: f32) {
-    if motion_kind != hash40("attack_100") {
-        return;
-    }
-    if frame >= 19.0 
-    || (frame >= 10.0 && !fighter.is_button_on(Buttons::AttackRaw)) {
+    if motion_kind == hash40("attack_100") && frame >= 22.0 {
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_100_end"), 0.0, 1.0, false, 0.0, false, false);
     }
 }
@@ -125,7 +121,7 @@ pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut
     reset_flags(boma, id, status_kind, situation_kind);
     sword_length(boma);
     up_special_proper_landing(fighter);
-    attack_100_end_early(fighter, boma, motion_kind, frame);
+    //attack_100_end_early(fighter, boma, motion_kind, frame);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_METAKNIGHT )]

--- a/fighters/metaknight/src/status/attack_100.rs
+++ b/fighters/metaknight/src/status/attack_100.rs
@@ -1,0 +1,94 @@
+use super::*;
+use globals::*;
+
+#[status_script(agent = "metaknight", status = FIGHTER_STATUS_KIND_ATTACK_100, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn metaknight_attack100_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_status_Attack100_common();
+    fighter.sub_shift_status_main(L2CValue::Ptr(metaknight_attack100_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn metaknight_attack100_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool() {
+            return 0.into();
+        }
+    }
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_AIR {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        return 0.into();
+    }
+    let jump_attack_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_ATTACK_MINI_JUMP_ATTACK_FRAME);
+    if 0 < jump_attack_frame {
+        if !StopModule::is_stop(fighter.module_accessor)
+        && fighter.sub_check_button_jump().get_bool() {
+            let log = fighter.status_attack();
+            let info = log[0x10f40d7b92u64].get_i64();
+            let mot = MotionModule::motion_kind(fighter.module_accessor);
+            MotionAnimcmdModule::call_script_single(
+                fighter.module_accessor,
+                *FIGHTER_ANIMCMD_EXPRESSION,
+                Hash40::new_raw(mot),
+                -1
+            );
+            WorkModule::set_int64(fighter.module_accessor, info, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+            fighter.change_status_jump_mini_attack(true.into());
+            return 0.into();
+        }
+    }
+    if 1 == jump_attack_frame {
+        if !fighter.global_table[IS_STOPPING].get_bool()
+        && WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND) > 0 {
+            let log = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+            FighterStatusModuleImpl::reset_log_action_info(fighter.module_accessor, log);
+            WorkModule::set_int64(fighter.module_accessor, 0, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+        }
+    }
+    let step = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_WORK_INT_100_STEP);
+    if step == *FIGHTER_STATUS_ATTACK_100_STEP_START {
+        if !StopModule::is_stop(fighter.module_accessor) {
+            fighter.attack_100_start_uniq_chk(false.into());
+        }
+        fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(L2CFighterCommon_bind_address_call_attack_100_start_uniq_chk as *const () as _));
+        let motion = MotionModule::motion_kind(fighter.module_accessor);
+        if motion == hash40("attack_100_start")
+        && !MotionModule::is_end(fighter.module_accessor) {
+            return 0.into();
+        }
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE_CHECK);
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE_INPUT);
+        MotionModule::change_motion(
+            fighter.module_accessor,
+            Hash40::new("attack_100"),
+            0.0,
+            1.0,
+            false,
+            0.0,
+            false,
+            false
+        );
+        WorkModule::set_int(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_100_STEP_LOOP, *FIGHTER_STATUS_ATTACK_WORK_INT_100_STEP);
+    }
+    else if step == *FIGHTER_STATUS_ATTACK_100_STEP_LOOP {
+        if !StopModule::is_stop(fighter.module_accessor) {
+            fighter.sub_attack_100_uniq_check(false.into());
+        }
+        fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(L2CFighterCommon_bind_address_call_sub_attack_100_uniq_check as *const () as _));
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE) {
+            return 0.into();
+        }
+        else {
+            fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), false.into());
+        }
+        //if MotionModule::is_end(fighter.module_accessor) {
+        
+        //}
+    }
+    0.into()
+}
+
+pub fn install() {
+    install_status_scripts!(
+        metaknight_attack100_main,
+    );
+}

--- a/fighters/metaknight/src/status/mod.rs
+++ b/fighters/metaknight/src/status/mod.rs
@@ -1,8 +1,9 @@
 use super::*;
 
 mod special_s;
-
+mod attack_100;
 
 pub fn install() {
     special_s::install();
+    attack_100::install();
 }


### PR DESCRIPTION
Brings back Meta Knight's Brawl jab animation

Assets: [assets-metaknight.zip](https://github.com/HDR-Development/HewDraw-Remix/files/11774760/assets-metaknight.zip)

- Hitbox Duration: F4-5/F8-9/F12-13/F17-18/F21-22
- Front 1/Front 2/Back 1
  - Damage: 2.0%
  - Angle: 361
  - BKB: 40
  - KBG: 8
  - Hitlag Multiplier: 0.5x
  - SDI Multiplier: 0.6x
  - Shieldstun Multiplier: 4.0x
  - Hitbox Size (front/back): 7.0/4.0u
- Front 3/Back 2
  - Damage: 3.0%
  - Angle: 361
  - BKB: 60
  - KBG: 40
  - Shieldstun Multiplier: 4.0x
  - Hitbox Size (front/back): 7.0/4.0u
- FAF 30

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/64ef0fa6-feea-4fd2-a452-785dcf1e63b6

Front
![Screenshot 2023-06-16 16-25-01](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/e2db9035-d0e8-4cda-83b3-6ab78398ab60)

Back
![Screenshot 2023-06-16 16-25-06](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/8933ac89-435f-43d8-85cf-307972b5e83a)