### PR TITLE
Inkling Up B Landing Lag Reduction

### DIFF
--- a/romfs/source/fighter/inkling/param/vl.prcxml
+++ b/romfs/source/fighter/inkling/param/vl.prcxml
@@ -40,7 +40,7 @@
     <struct index="0">
       <float hash="height_mul_on_ground">0.95</float>
       <float hash="height_mul_on_air">1</float>
-      <int hash="landing_frame">30</int>
+      <int hash="landing_frame">20</int>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Since she lost the landing hitbox on up b, Inkling now has very little mix on her up b as the hitbox on the way up is only at the start and she has 30 frames of landing lag, meanwhile fox, a character with a very similar archetype, has hitboxes the whole way through, the ability to angle in every direction, and has 20 frames of landing lag.
This is a small change to make the landing lag on inkling up b 20 frames instead of 30 to give her some mix, so that grabbing ledge is not an instant win condition of edge guarding her.