### PR TITLE
Float Hotfix

### DIFF
--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -55,7 +55,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             if status_kind == *FIGHTER_STATUS_KIND_ATTACK_AIR {
                 if VarModule::is_flag(boma.object(), vars::common::instance::FLOAT_PAUSE_AERIAL) {
                     VarModule::on_flag(boma.object(), vars::common::instance::AERIAL_NO_FLOAT);
-                    WorkModule::set_int(boma, 0, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
+                    WorkModule::set_int(boma, -1, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
                 }
             } else {
                 if VarModule::is_flag(boma.object(), vars::common::instance::AERIAL_NO_FLOAT) {
@@ -91,6 +91,12 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             }
             // Immediately transition to fall/double jump fall when activating float
             if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) && boma.left_stick_y() < -0.66 && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 {
+                if status_kind == *FIGHTER_STATUS_KIND_JUMP && boma.status_frame() == 1 { //add height on ground-level float like peach
+                    if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) == VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) {
+                        let pos = smash::phx::Vector3f { x: PostureModule::pos_x(boma), y: PostureModule::pos_y(boma) + 1.5, z: 0.0 };
+                        PostureModule::set_pos(boma, &pos);
+                    }
+                }
                 if [*FIGHTER_STATUS_KIND_JUMP, *FIGHTER_STATUS_KIND_CLIFF_JUMP1, *FIGHTER_STATUS_KIND_CLIFF_JUMP2, *FIGHTER_STATUS_KIND_CLIFF_JUMP3, *FIGHTER_STATUS_KIND_DAMAGE_FALL, *FIGHTER_STATUS_KIND_PASS].contains(&status_kind) {
                     VarModule::on_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT);
                     ControlModule::reset_trigger(boma);
@@ -122,12 +128,12 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             }
 
             // Omnidirectional float for Dark Samus and Mewtwo
-            if fighter_kind == *FIGHTER_KIND_SAMUSD || fighter_kind == *FIGHTER_KIND_MEWTWO {
-                if ([*FIGHTER_STATUS_KIND_FALL, *FIGHTER_STATUS_KIND_FALL_AERIAL].contains(&status_kind) && boma.status_frame() > 2) // Omnidirection float only after F3 of initiating the float
-                    || (status_kind == *FIGHTER_STATUS_KIND_ATTACK_AIR && (WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0)) /* If in aerial attack and float has been initiated and are current floating */ {
-                    if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 {
+            if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 
+            && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) {
+                if !VarModule::is_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT) { VarModule::on_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT); }
+                if (fighter_kind == *FIGHTER_KIND_SAMUSD || fighter_kind == *FIGHTER_KIND_MEWTWO) && VarModule::get_int(boma.object(), vars::common::instance::FLOAT_STYLE) == 1 {
+                    if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) || boma.left_stick_y() >= 0.5) && VarModule::get_int(fighter.battle_object, vars::common::instance::FLOAT_TIMER) > 1 {
                         if boma.left_stick_y() != 0.0 {
-                            if !VarModule::is_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT) { VarModule::on_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT); }
                             let mut motion_vec = Vector3f{x: 0.0, y: 0.0, z: 0.0};
                             if boma.left_stick_y() > 0.0 {
                                 motion_vec.y = motion_value;
@@ -137,10 +143,12 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
                             KineticModule::add_speed_outside(boma, *KINETIC_OUTSIDE_ENERGY_TYPE_WIND_NO_ADDITION, &motion_vec);
                         }
                     }
+                //} else if VarModule::get_int(boma.object(), vars::common::instance::FLOAT_STYLE) == 0 {
+                //    let mut motion_vec = Vector3f{x: 0.0, y: 0.0, z: 0.0};
+                //    KineticModule::add_speed_outside(boma, *KINETIC_OUTSIDE_ENERGY_TYPE_WIND_NO_ADDITION, &motion_vec);
                 }
             }
-        }
-
+        }   
         // One float per airtime
         if (![*FIGHTER_STATUS_KIND_FALL,
             *FIGHTER_STATUS_KIND_FALL_AERIAL,
@@ -150,11 +158,15 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             *FIGHTER_STATUS_KIND_CLIFF_JUMP2,
             *FIGHTER_STATUS_KIND_CLIFF_JUMP3,
             *FIGHTER_STATUS_KIND_ATTACK_AIR,
-            *FIGHTER_STATUS_KIND_DAMAGE_FALL].contains(&status_kind) || !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) || !ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP)) && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) {
+            *FIGHTER_STATUS_KIND_DAMAGE_FALL].contains(&status_kind) 
+        || !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) 
+        || (boma.is_button_off(Buttons::Jump) && boma.left_stick_y() < 0.5))
+        && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) 
+        && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) >= 0 
+        {
             WorkModule::set_int(boma, 0, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
             WorkModule::off_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY);
         }
-
     }
 
     // Reset Float Time
@@ -167,7 +179,6 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
         WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF);
         WorkModule::set_int(boma, VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION), *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
     }
-    
 }
 
 pub unsafe fn float_effects(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, fighter_kind: i32) {


### PR DESCRIPTION
Fixes 1f floats when holding up, and fixes held floats out of jumps not rising until end. I also made them pop the user up if input as a ground float like peach. 
Remaining Quirks:
-I couldn't figure out why robin's float would slowly fall unless you held up or down (couldn't figure out)
-Floats do not block transition to airdodge unlike peach's (easy change)
-Held up stick floats dont cancel upon using aerial (annoying) 
-Sometimes frame perfect float aerials on robin cancel into fastfall??
Bandaid for issues that could be fixed better by a competent coder and custom status scripts

https://github.com/HDR-Development/HewDraw-Remix/assets/122749442/28f40816-c937-42f3-9aea-93e626f4e451


