### PR TITLE
Palutena Tweaks

### DIFF
--- a/fighters/palutena/src/acmd/aerials.rs
+++ b/fighters/palutena/src/acmd/aerials.rs
@@ -95,7 +95,7 @@ unsafe fn palutena_attack_air_b_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 14.0/(8.0-1.0));
+        FT_MOTION_RATE(fighter, 12.0/(8.0-1.0));
     }
     frame(lua_state, 4.0);
     if is_excute(fighter) {
@@ -105,12 +105,12 @@ unsafe fn palutena_attack_air_b_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 8.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.0);
-        ATTACK(fighter, 0, 0, Hash40::new("shoulderr"), 9.0, 361, 100, 0, 30, 4.0, 0.0, -2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);    
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 16.0, 361, 98, 0, 31, 6.7, 0.0, 10.7, -13.7, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 16.0, 361, 98, 0, 31, 6.7, 0.0, 10.7, -13.7, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("shoulderr"), 9.0, 361, 100, 0, 30, 4.0, 0.0, -2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);    
     }
     frame(lua_state, 11.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 27.0/(49.0-11.0));
+        FT_MOTION_RATE(fighter, 29.0/(49.0-11.0));
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 34.0);

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -103,8 +103,8 @@ extern "Rust" {
 // Aegis Reflector Timer Count
 unsafe fn aegis_reflector_timer(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize) {
     let gimmick_timerr = VarModule::get_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER);
-    if gimmick_timerr > 0 && gimmick_timerr < 901 {
-        if gimmick_timerr > 899 {
+    if gimmick_timerr > 0 && gimmick_timerr < 721 {
+        if gimmick_timerr > 719 {
             VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 0);
             gimmick_flash(boma);
         } else {

--- a/romfs/source/fighter/palutena/param/vl.prcxml
+++ b/romfs/source/fighter/palutena/param/vl.prcxml
@@ -25,10 +25,10 @@
   </list>
   <list hash="param_reflectionboard">
     <struct index="0">
-      <float hash="life">112</float>
+      <float hash="life">167</float>
       <int hash="durability">100</int>
-      <int hash="move_frame">240</int>
-      <float hash="move_speed">0.3</float>
+      <int hash="move_frame">80</int>
+      <float hash="move_speed">0.37</float>
       <float hash="effect_rate">5.333</float>
     </struct>
   </list>


### PR DESCRIPTION
Palutena has felt neglected for a while. This aims to touch up 2 of her overnerfed moves while maintaining the design direction and not impeding any rework plans. 
Back Air:
~[+] Startup: 15f -> 13f
~[-] FAF: Compensated, 2 more frames endlag 
~[+] Hitbox Priority: Reversed, sweetspot now takes prio over sourspot

Wall:
~[+] Cooldown: 15 seconds -> 12
~[+] Duration: 112(110?) -> 167(165?), 50% increase (effects should hopefully lineup)
~[/] Speed: 0.3x -> 0.37x (compensate distance)
~[/] Stop Frame: 240 -> 80 (pauses halfway through lifetime)
- The wall's positioning and move speed was clearly designed to cut defensive utility, also locking her specials. However, the offensive utility was overnerfed by its short presence and harsh punishment. This aims to increase the offensive utility by making the stick around in mid-range a bit longer. The cooldown being reduced will also make it nicer to play around. 

https://github.com/HDR-Development/HewDraw-Remix/assets/122749442/a2f605d0-8b38-4f50-916b-046040559f9c



