### PR TITLE
Tumble knockback bugfixes

### DIFF
--- a/fighters/common/src/function_hooks/collision.rs
+++ b/fighters/common/src/function_hooks/collision.rs
@@ -35,22 +35,33 @@ unsafe fn ground_module_ecb_point_calc_hook(ground_module: u64, param_1: *mut *m
         *FIGHTER_STATUS_KIND_THROWN])
     || !(*boma).is_situation(*SITUATION_KIND_AIR)
     || WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR) < ParamModule::get_int((*boma).object(), ParamType::Common, "ecb_shift_air_trans_frame") {
-        // This check passes after 9 frames of airtime, if not in a grabbed/thrown state
+        // This check passes during the first 9 frames of airtime
+        // or if in a grabbed/thrown state
         *param_3 = 0.0;
     }
 
-    // Prevents rising platwarps during aerials and tumble
-    if !StopModule::is_stop(boma) {
-        if (*boma).is_status_one_of(&[*FIGHTER_STATUS_KIND_ATTACK_AIR, *FIGHTER_STATUS_KIND_DAMAGE_FLY])
-        && KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) > 0.0
+    // Prevents rising platwarps during aerials and tumble knockback
+    if (*boma).is_fighter()
+    && !StopModule::is_stop(boma) {
+        let total_y_speed = KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND);
+        if (*boma).is_status_one_of(&[
+            *FIGHTER_STATUS_KIND_ATTACK_AIR,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_JUMP_BOARD,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_U,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
+            *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR])
+        && (*boma).status_frame() > 1
         {
-            // Forces character to ignore platforms, overrides ability to land
-            GroundModule::set_passable_check(boma, true);
-        }
-        else if (*boma).is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR)
-        && KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN) <= 0.0
-        {
-            GroundModule::set_passable_check(boma, false);
+            if total_y_speed > 0.0 {
+                // Forces character to ignore platforms, overrides ability to land
+                GroundModule::set_passable_check(boma, true);
+            }
+            else {
+                GroundModule::set_passable_check(boma, false);
+            }
         }
     }
 }

--- a/fighters/common/src/function_hooks/transition.rs
+++ b/fighters/common/src/function_hooks/transition.rs
@@ -45,8 +45,7 @@ unsafe fn is_enable_transition_term_hook(boma: &mut BattleObjectModuleAccessor, 
     
         // Disallow airdodge out of tumble until you reach your stable fall speed
         if flag == *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR
-            && ([*FIGHTER_STATUS_KIND_DAMAGE_FLY, *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR].contains(&status_kind)
-            || (status_kind == *FIGHTER_STATUS_KIND_DAMAGE_FALL && get_fighter_common_from_accessor(boma).global_table[CURRENT_FRAME].get_i32() <= 20))  {
+        && [*FIGHTER_STATUS_KIND_DAMAGE_FLY, *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR].contains(&status_kind) {
             return false;
         }
     

--- a/fighters/common/src/general_statuses/damagefall.rs
+++ b/fighters/common/src/general_statuses/damagefall.rs
@@ -25,6 +25,14 @@ unsafe fn status_DamageFall_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.sub_transition_group_check_air_cliff().get_bool() {
         return 0.into();
     }
+    if fighter.global_table[CURRENT_FRAME].get_i32() <= 20 {
+        WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR);
+        WorkModule::unable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_AIR_ESCAPE);
+    }
+    else {
+        WorkModule::enable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ESCAPE_AIR);
+        WorkModule::enable_transition_term_group(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_AIR_ESCAPE);
+    }
     if fighter.check_damage_fall_transition().get_bool() {
         return 0.into();
     }

--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -27,7 +27,8 @@ unsafe fn tumble_exit(boma: &mut BattleObjectModuleAccessor) {
         if !(WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_AIR) || WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_GANON_SPECIAL_S_DAMAGE_FALL_GROUND))
         && boma.is_cat_flag(Cat1::Dash | Cat1::TurnDash)
         {
-            boma.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+            ControlModule::reset_trigger(boma);
+            boma.change_status_req(*FIGHTER_STATUS_KIND_FALL, true);
         }
     }
 }


### PR DESCRIPTION
Platwarps were previously supposed to be disabled during tumble knockback, but the implementation did not work. This properly disables them.

Also fixes an issue where you could sometimes airdodge directly out of tumble, bypassing the 20f lockout.