### PR TITLE
Dk minor adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -413,6 +413,7 @@ pub mod vars {
         pub mod status {
             // flags
             pub const SPECIAL_CHECKS: i32 = 0x1100;
+            pub const IS_NEUTRAL_TOSS: i32 = 0x1101;
 
             // pub const SPECIAL_AIR_LW_STOP: i32 = 0x1100;
         }

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -40,7 +40,7 @@ unsafe fn change_status_request_hook(boma: &mut BattleObjectModuleAccessor, stat
                 next_status = *ITEM_STATUS_KIND_FALL;
 
                 // set hit team to none for now?
-                ItemModule::set_hit_team(boma, *TEAM_NONE);
+                TeamModule::set_hit_team(boma, *TEAM_NONE);
             }
         }
     }

--- a/fighters/common/src/function_hooks/change_status.rs
+++ b/fighters/common/src/function_hooks/change_status.rs
@@ -38,6 +38,9 @@ unsafe fn change_status_request_hook(boma: &mut BattleObjectModuleAccessor, stat
 
                 // instead change into fall
                 next_status = *ITEM_STATUS_KIND_FALL;
+
+                // set hit team to none for now?
+                ItemModule::set_hit_team(boma, *TEAM_NONE);
             }
         }
     }

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -177,8 +177,8 @@ unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   }
 
   let toss_frame = match is_neutral_toss {
-    true => 16,
-    false => 17
+    true => 16.0,
+    false => 17.0
   };
   frame(lua_state, toss_frame);
   if is_excute(fighter) {

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -162,7 +162,11 @@ unsafe fn game_throwflw(fighter: &mut L2CAgentBase) {
 unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   let lua_state = fighter.lua_state_agent;
   let boma = fighter.boma();
-  let is_neutral_toss = boma.stick_x().abs() < 0.33;
+  
+  frame(lua_state, 1.0);
+  if is_excute(fighter) {
+    VarModule::set_flag(fighter.object(), consts::vars::donkey::status::IS_NEUTRAL_TOSS, boma.stick_x().abs() < 0.33); 
+  }
   frame(lua_state, 2.0);
   if is_excute(fighter) {
     FT_MOTION_RATE(fighter, 0.5);
@@ -176,6 +180,7 @@ unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 2.0);
   }
 
+  let is_neutral_toss = VarModule::is_flag(fighter.object(), consts::vars::donkey::status::IS_NEUTRAL_TOSS); 
   let toss_frame = match is_neutral_toss {
     true => 16.0,
     false => 17.0

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -162,7 +162,7 @@ unsafe fn game_throwflw(fighter: &mut L2CAgentBase) {
 unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   let lua_state = fighter.lua_state_agent;
   let boma = fighter.boma();
-  let is_neutral_toss = boma.is_cat_flag(Cat1::AttackN | Cat1::AttackAirN);
+  let is_neutral_toss = boma.stick_x().abs() < 0.33;
   frame(lua_state, 2.0);
   if is_excute(fighter) {
     FT_MOTION_RATE(fighter, 0.5);

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -235,7 +235,7 @@ unsafe fn game_itemheavythrowlw(fighter: &mut L2CAgentBase) {
     frame(lua_state, 14.0);
     if is_excute(fighter) {
         let main_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-        let stick_add_x = fighter.stick_x();
+        let stick_add_x = fighter.stick_x() * 0.5;
         
         // change to kinetic type fall and change to air situation
         KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -162,6 +162,7 @@ unsafe fn game_throwflw(fighter: &mut L2CAgentBase) {
 unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   let lua_state = fighter.lua_state_agent;
   let boma = fighter.boma();
+  let is_neutral_toss = boma.is_cat_flag(Cat1::AttackN | Cat1::AttackAirN);
   frame(lua_state, 2.0);
   if is_excute(fighter) {
     FT_MOTION_RATE(fighter, 0.5);
@@ -176,7 +177,10 @@ unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   }
   frame(lua_state, 17.0);
   if is_excute(fighter) {
-    ItemModule::throw_item(boma, 55.0, 3.0, 1.0, 0, true, 0.0);
+    match is_neutral_toss {
+        true => ItemModule::throw_item(boma, 75.0, 3.0, 1.0, 0, true, 0.0),
+        false => ItemModule::throw_item(boma, 55.0, 3.0, 1.0, 0, true, 0.0)
+    };
     FT_MOTION_RATE(fighter, 1.0);
   }
 }

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -175,12 +175,14 @@ unsafe fn heavy_item_throw_f(fighter: &mut L2CAgentBase) {
   if is_excute(fighter) {
     FT_MOTION_RATE(fighter, 2.0);
   }
-  frame(lua_state, 17.0);
+
+  let toss_frame = match is_neutral_toss {
+    true => 16,
+    false => 17
+  };
+  frame(lua_state, toss_frame);
   if is_excute(fighter) {
-    match is_neutral_toss {
-        true => ItemModule::throw_item(boma, 75.0, 3.0, 1.0, 0, true, 0.0),
-        false => ItemModule::throw_item(boma, 55.0, 3.0, 1.0, 0, true, 0.0)
-    };
+    ItemModule::throw_item(boma, 45.0, 3.0, 1.0, 0, true, 0.0);
     FT_MOTION_RATE(fighter, 1.0);
   }
 }

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -125,19 +125,11 @@ pub unsafe fn flatten_uspecial(fighter: &mut L2CFighterCommon) {
     }
 }
 
-/// scales down the leg during bair to reduce its range
-pub unsafe fn dk_bair_scale(fighter: &mut L2CFighterCommon) {
-    if fighter.is_motion(Hash40::new("attack_air_b")) {
-        ModelModule::set_joint_scale(fighter.boma(), Hash40::new("legl"), &Vector3f::new(1.0, 1.5, 1.5));
-    }
-}
-
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     dash_attack_jump_cancels(fighter, boma, status_kind, situation_kind);
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
     barrel_pull(fighter, boma, status_kind, situation_kind);
     headbutt_aerial_stall(fighter, boma, id, status_kind, situation_kind, frame);
-    dk_bair_scale(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_DONKEY )]

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -125,11 +125,19 @@ pub unsafe fn flatten_uspecial(fighter: &mut L2CFighterCommon) {
     }
 }
 
+/// scales down the leg during bair to reduce its range
+pub unsafe fn dk_bair_scale(fighter: &mut L2CFighterCommon) {
+    if fighter.is_motion(Hash40::new("attack_air_b")) {
+        ModelModule::set_joint_scale(fighter.boma(), Hash40::new("legl"), &Vector3f::new(1.0, 1.5, 1.5));
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     dash_attack_jump_cancels(fighter, boma, status_kind, situation_kind);
     nspecial_cancels(fighter, boma, status_kind, situation_kind);
     barrel_pull(fighter, boma, status_kind, situation_kind);
     headbutt_aerial_stall(fighter, boma, id, status_kind, situation_kind, frame);
+    dk_bair_scale(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_DONKEY )]


### PR DESCRIPTION
This PR includes some minor touch-ups after the recent DK rework.

- Superlift tilt toss now has a neutral toss variant (using a jab-like input). This has a higher angle (~45 degrees)
- Superlift tilt toss (non-neutral) now has a slightly lower forward angle
- Sets the hit team of the barrel to "none" once it hits someone. This should avoid double hits (TBD)
- Reduces leg length of bair (assets PR linked)