### PR TITLE
Marth animation adjustments

### DIFF
--- a/fighters/marth/src/acmd/aerials.rs
+++ b/fighters/marth/src/acmd/aerials.rs
@@ -65,18 +65,20 @@ unsafe fn marth_attack_air_f_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.0);
     }
-    frame(lua_state, 6.0);
+    frame(lua_state, 6.0);  // f5 ingame
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("sword1"), 8.0, 361, 78, 0, 40, 4.0, 0.0, 0.0, 2.75, None, None, None, 0.9, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 1, 0, Hash40::new("armr"), 7.0, 361, 80, 0, 30, 4.0, 1.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 2, 0, Hash40::new("shoulderl"), 7.0, 361, 80, 0, 30, 4.0, 0.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 3, 0, Hash40::new("sword1"), 11.0, 67, 77, 0, 50, 4.0, 0.0, 0.0, 8.25, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MARTH_SWORD, *ATTACK_REGION_SWORD);
     }
-    wait(lua_state, 4.0);
+    wait(lua_state, 4.0);  // f9 ingame
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 33.0);
+    frame(lua_state, 24.0);
+    FT_DESIRED_RATE(fighter, (44.0 - 24.0), 10.0);
+    frame(lua_state, 42.0);  // f32 ingame
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
@@ -103,7 +105,11 @@ unsafe fn marth_attack_air_b_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 32.0);
+    frame(lua_state, 15.0);
+    FT_MOTION_RATE(fighter, 2.0);
+    frame(lua_state, 23.0);  // f31 ingame
+    FT_DESIRED_RATE(fighter, (39.0 - 23.0), 10.0);
+    frame(lua_state, 23.625);  // f32 ingame
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }

--- a/fighters/marth/src/acmd/smashes.rs
+++ b/fighters/marth/src/acmd/smashes.rs
@@ -11,16 +11,12 @@ unsafe fn marth_attack_s4_s_game(fighter: &mut L2CAgentBase) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_START_SMASH_HOLD);
     }
     frame(lua_state, 4.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 5.0 / (9.75 - 4.0));
-    }
+    FT_MOTION_RATE(fighter, 5.0 / (9.75 - 4.0));
     frame(lua_state, 9.75);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0 / (10.25 - 9.75));
-    }
+    FT_MOTION_RATE(fighter, 1.0 / (10.25 - 9.75));
     frame(lua_state, 10.25);
+    FT_MOTION_RATE(fighter, 1.0 / (11.0 - 10.25));
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0 / (11.0 - 10.25));
         ATTACK(fighter, 0, 0, Hash40::new("sword1"), 14.0, 38, 72, 0, 52, 3.5, 0.0, 0.0, 2.75, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 1, 0, Hash40::new("armr"), 14.0, 38, 72, 0, 52, 3.0, 0.0, 1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 2, 0, Hash40::new("bust"), 14.0, 38, 72, 0, 52, 3.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
@@ -28,13 +24,14 @@ unsafe fn marth_attack_s4_s_game(fighter: &mut L2CAgentBase) {
         AttackModule::set_attack_height_all(boma, app::AttackHeight(*ATTACK_HEIGHT_HIGH), false);
     }
     frame(lua_state, 11.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
-    }
+    FT_MOTION_RATE(fighter, 1.0);
     frame(lua_state, 13.0);
+    FT_DESIRED_RATE(fighter, (26.0 - 13.0), 22.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
+    frame(lua_state, 26.0);  // f36 ingame
+    FT_DESIRED_RATE(fighter, (49.0 - 26.0), 13.0);
     
 }
 
@@ -129,6 +126,8 @@ unsafe fn marth_attack_lw4_game(fighter: &mut L2CAgentBase) {
         FT_MOTION_RATE(fighter, 1.000);
         AttackModule::clear_all(boma);
     }
+    frame(lua_state, 43.0);
+    FT_DESIRED_RATE(fighter, (70.0 - 43.0), 23.0);
     
 }
 


### PR DESCRIPTION
Adjusts animations for fair, bair, fsmash, and dsmash to enter/leave their key poses in a snappier manner. Frame data remains the same.

### Fair:
Before:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/9c1d0241-2d7b-4435-971f-de8cf56d01fd

After:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/ef916c85-0b32-4d52-b1c8-7ae52549642c

### Bair:
Before:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/66d0379e-d8fa-4271-add8-a8815dfc1842

After:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/1f3cdb8e-ece8-48d5-9d71-d7b2ecfcae48

### Fsmash:
Before:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/02309e94-fc8d-4c02-b364-79ecd487c641

After:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/3353e505-16f4-466a-a32e-a763d1d4d9a6

### Dsmash (tiny difference):
Before:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/74f872f3-3743-4474-89d3-8e0931762a04

After:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/f5a22ef0-89ab-42a4-b1ab-b3c31145cde8


To be merged with HDR-Development/hdr-private#387