### PR TITLE
Spin Boost Adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -822,6 +822,7 @@ pub mod vars {
 
             pub const SPECIAL_S_HOP: i32 = 0x1100;
             pub const SPECIAL_S_ENABLE_JUMP: i32 = 0x1101;
+            pub const SPECIAL_S_ENABLE_CONTROL: i32 = 0x1102;
 
             // ints
             pub const SPECIAL_S_STEP: i32 = 0x1100;

--- a/fighters/sonic/src/acmd/specials.rs
+++ b/fighters/sonic/src/acmd/specials.rs
@@ -3,7 +3,7 @@ use super::*;
 
 #[acmd_script( agent = "sonic", script = "game_specialsbooststart", category = ACMD_GAME, low_priority )]
 unsafe fn sonic_specialsbooststart(fighter: &mut L2CAgentBase) {
-    macros::FT_MOTION_RATE(fighter, 0.75);
+    // macros::FT_MOTION_RATE(fighter, 0.75);
 }
 
 #[acmd_script( agent = "sonic", script = "sound_specialsbooststart", category = ACMD_SOUND, low_priority )]
@@ -24,7 +24,9 @@ unsafe fn sonic_specialsbooststart_exp(fighter: &mut L2CAgentBase) {
 
 #[acmd_script( agent = "sonic", script = "game_specialsboost", category = ACMD_GAME, low_priority )]
 unsafe fn sonic_specialsboost(fighter: &mut L2CAgentBase) {
+    FT_MOTION_RATE(fighter, 1.0 / 3.0);
     frame(fighter.lua_state_agent, 3.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 361, 100, 0, 45, 4.0, 0.0, 5.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
     }
@@ -119,6 +121,7 @@ unsafe fn sonic_specialairsboostend(fighter: &mut L2CAgentBase) {
     frame(fighter.lua_state_agent, 2.0);
     if macros::is_excute(fighter) {
         AttackModule::clear_all(fighter.module_accessor);
+        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
 }
 

--- a/fighters/sonic/src/acmd/specials.rs
+++ b/fighters/sonic/src/acmd/specials.rs
@@ -122,6 +122,7 @@ unsafe fn sonic_specialairsboostend(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         AttackModule::clear_all(fighter.module_accessor);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
+        VarModule::on_flag(fighter.battle_object, vars::sonic::status::SPECIAL_S_ENABLE_CONTROL);
     }
 }
 

--- a/fighters/sonic/src/status/special_s.rs
+++ b/fighters/sonic/src/status/special_s.rs
@@ -140,7 +140,7 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             let y_speed = if fighter.global_table[SITUATION_KIND].get_i32() != *SITUATION_KIND_GROUND {
                 if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) {
                     VarModule::on_flag(fighter.battle_object, vars::sonic::status::SPECIAL_S_HOP);
-                    1.3
+                    1.85
                 }
                 else {
                     KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN)
@@ -171,7 +171,7 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
                     KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
                     VarModule::on_flag(fighter.battle_object, vars::sonic::status::SPECIAL_S_HOP);
                     VarModule::on_flag(fighter.battle_object, vars::sonic::instance::USED_AIR_ACTION);
-                    1.3
+                    1.85
                 }
                 else {
                     0.0
@@ -204,6 +204,7 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
                 FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
                 y_speed
             );
+            fighter.sub_fighter_cliff_check(GROUND_CLIFF_CHECK_KIND_ON_DROP.into());
             VarModule::set_int(fighter.battle_object, vars::sonic::status::SPECIAL_S_STEP, vars::sonic::SPECIAL_S_STEP_DASH);
         }
         else if step == vars::sonic::SPECIAL_S_STEP_DASH {

--- a/fighters/sonic/src/status/special_s.rs
+++ b/fighters/sonic/src/status/special_s.rs
@@ -123,6 +123,28 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             0.0
         );
     }
+    if VarModule::is_flag(fighter.battle_object, vars::sonic::status::SPECIAL_S_ENABLE_CONTROL) {
+        sv_kinetic_energy!(
+            reset_energy,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0
+        );
+        sv_kinetic_energy!(
+            set_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            0.0,
+            0.0
+        );
+        KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+        VarModule::off_flag(fighter.battle_object, vars::sonic::status::SPECIAL_S_ENABLE_CONTROL);
+    }
     if MotionModule::is_end(fighter.module_accessor) {
         if step == vars::sonic::SPECIAL_S_STEP_START {
             MotionModule::change_motion(


### PR DESCRIPTION
# Changelog
* Spin Boost can now grab the ledge during the dash if Sonic is currently falling.
  * Spin Boost can grab ledge at any time when the air version becomes actionable.
* The move now checks if you're holding Special on frame 8.
* Holding Special now boosts Sonic further upwards. This allows Sonic to be actionable just before touching the ground.
* Sonic can drift left or right if he ends Spin Boost in the air.
* Framedata and hitbox data untouched.