### PR TITLE
Clank lag + electric hitlag changes

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -662,7 +662,7 @@ unsafe fn status_module__change_status(status_module: *const u64, status_kind_ne
 // Only extra elec hitlag for hit character
 #[skyline::hook(offset = 0x406804, inline)]
 unsafe fn change_elec_hitlag_for_attacker(ctx: &mut skyline::hooks::InlineCtx) {
-  let is_attacker = *ctx.registers[2].w.as_ref() & 1 != 0;
+  let is_attacker = *ctx.registers[4].w.as_ref() & 1 == 0;
   if *ctx.registers[8].x.as_ref() == smash::hash40("collision_attr_elec") && is_attacker {
     *ctx.registers[8].x.as_mut() = smash::hash40("collision_attr_normal");
   }


### PR DESCRIPTION
Gives fighter with stronger move less clank lag than other fighter when clanking.

Additionally, the 1.5x hitlag multiplier on electric attacks now only applies to the receiver, not the attacker.