### PR TITLE
allow jc grab oos if still holding grab

### DIFF
--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -136,8 +136,12 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         );
         return 0.into();
     }
+
+    // if you are jumping oos, we do not want to trigger jc grab unless you are holding . This avoids getting grabs when buffering an aerial oos.
     if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH)
-    && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 {
+      && fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_CATCH != 0 
+      && (!fighter.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD, *FIGHTER_STATUS_KIND_GUARD_DAMAGE, *FIGHTER_STATUS_KIND_GUARD_OFF]) 
+      || fighter.is_button_on(Buttons::Catch)) {
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_CATCH),
             L2CValue::Bool(true)
@@ -263,12 +267,6 @@ unsafe fn status_JumpSquat_common(fighter: &mut L2CFighterCommon, lr_update: L2C
         for x in potential_enables.iter() {
             WorkModule::unable_transition_term(fighter.module_accessor, *x);
         }
-    }
-    
-    // if you are jumping oos, we do not want to trigger jc grab. This avoids getting grabs when buffering an aerial oos.
-
-    if fighter.is_prev_status_one_of(&[*FIGHTER_STATUS_KIND_GUARD_ON, *FIGHTER_STATUS_KIND_GUARD, *FIGHTER_STATUS_KIND_GUARD_DAMAGE, *FIGHTER_STATUS_KIND_GUARD_OFF]) {
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_CATCH);
     }
 }
 


### PR DESCRIPTION
This PR should allow players to JC grab oos if they are still holding grab (button only) during jumpsquat. Currently, you cannot JC grab oos at all, because JC grab is disabled if jumping oos to allow buffered aerials oos. This is a minor improvement on that. Needs testing.