### PR TITLE
Link Boomerang and Arrow Tweaks

### DIFF
--- a/fighters/link/src/acmd/other.rs
+++ b/fighters/link/src/acmd/other.rs
@@ -188,13 +188,17 @@ unsafe fn link_boomerang_fly_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 80, 35, 0, 90, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -4, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 80, 29, 0, 91, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        AttackModule::enable_safe_pos(boma);
     }
-    frame(lua_state, 8.0);
+    frame(lua_state, 10.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 80, 40, 0, 50, 3.6, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -3, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 80, 37, 0, 74, 3.6, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
     }
-    
+    frame(lua_state, 23.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 80, 44, 0, 55, 3.6, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+    }
 }
 
 #[acmd_script( agent = "link_boomerang", script = "game_turn" , category = ACMD_GAME , low_priority)]

--- a/romfs/source/fighter/link/param/vl.prcxml
+++ b/romfs/source/fighter/link/param/vl.prcxml
@@ -18,7 +18,7 @@
     <struct index="0">
       <float hash="speed_min">2.3</float>
       <float hash="speed_max">11</float>
-      <float hash="power_max">15</float>
+      <float hash="power_max">17</float>
       <float hash="charge_attack_mul">1.0</float>
       <int hash="item_life">60</int>
     </struct>


### PR DESCRIPTION
This serves as a follow up to the most recent Link adjustments. There's a significant improvement to boomerang with higher damage capabilities and more threatening range, while arrow gets a slight bump in damage.

# Link
### Bow and Arrow
- [+] Max Damage increased 15% -> 17%

### Boomerang
- [+] No longer misses against opponents at point blank range
- [+] Early Hit Damage increased 8% -> 10% (KB Compensated)
- [+] Duration of early hit increased 7F -> 9F 
- [R] New Mid Hit added (Active on frames F10-F22)
        Damage - 8%
        Angle - 80
        KBG - 37
        BKB - 74
- [+] Late Hit KBG increased 40 -> 44
- [+] Late Hit BKB increased 50 -> 55
- [-] Hitlag Modifier reduced 1.2x -> 1.0x
- [+] Early hit extra shield damage modifier adjusted -4 -> 0
- [+] Late hit extra shield damage modifier adjusted -3 -> 0

# Hitbox Comparisons

### Old Boomerang Early Hit Max Distance
![Old Boomerang Strong Hit Distance](https://github.com/HDR-Development/HewDraw-Remix/assets/101300494/6bbefec7-9add-437e-b3dd-c2e4a495904d)

### New Boomerang Early Hit Max Distance
![Boomerang Strong Hit Distance](https://github.com/HDR-Development/HewDraw-Remix/assets/101300494/b9c96e5e-2e52-4175-b0c1-f24ec5136e69)

### New Boomerang Mid Hit Max Distance
![Boomerang Mid Hit Distance](https://github.com/HDR-Development/HewDraw-Remix/assets/101300494/650c2328-12a0-4cc6-93ad-a5e8dcfe4a50)

### Weak Hit Boomerang Max Distance (Unchanged)
![Boomerang Weak Hit Distance](https://github.com/HDR-Development/HewDraw-Remix/assets/101300494/ff8bd010-bbc4-4217-be44-58fb71bdd7f5)