### PR TITLE
Float Hotfix (pt 2)

### DIFF
--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -109,7 +109,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
                     MotionModule::change_motion(boma, Hash40::new("fall"), 0.0, 1.0, false, 0.0, false, false);
                 } else if status_kind == *FIGHTER_STATUS_KIND_JUMP {
                     if StatusModule::is_changing(boma) { //peach ground-float mechanic
-                        let pos = smash::phx::Vector3f { x: PostureModule::pos_x(boma), y: PostureModule::pos_y(boma) + 3.5, z: 0.0 };
+                        let pos = smash::phx::Vector3f { x: PostureModule::pos_x(boma), y: PostureModule::pos_y(boma) + 3.5, z: PostureModule::pos_z(boma) };
                         PostureModule::set_pos(boma, &pos);
                     }
                     VarModule::on_flag(fighter.battle_object, vars::common::instance::OMNI_FLOAT);
@@ -242,6 +242,10 @@ pub unsafe fn float_effects(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
                 else if timer % 15 == 0 {  // every 15 frames
                     // drain 1 bar of Elwind
                     WorkModule::dec_int(boma, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT);
+                } 
+                if timer % 30 == 0 {
+                    let mut reflet_fighter = app::Fighter{battle_object: *(fighter.battle_object)};
+                    app::FighterSpecializer_Reflet::change_hud_kind(&mut reflet_fighter, *FIGHTER_REFLET_MAGIC_KIND_EL_WIND);
                 }
             }
         }

--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -89,6 +89,12 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             if !WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF) {
                 WorkModule::on_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF);
             }
+            if WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF) 
+            && !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY)
+            && !ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP)
+            {
+                WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF);
+            }
             // Immediately transition to fall/double jump fall when activating float
             if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) && boma.left_stick_y() < -0.66 && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 {
                 if [*FIGHTER_STATUS_KIND_CLIFF_JUMP1, *FIGHTER_STATUS_KIND_CLIFF_JUMP2, *FIGHTER_STATUS_KIND_CLIFF_JUMP3, *FIGHTER_STATUS_KIND_DAMAGE_FALL, *FIGHTER_STATUS_KIND_PASS].contains(&status_kind) {
@@ -131,7 +137,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             // Omnidirectional float for Dark Samus and Mewtwo
             if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) > 0 
             && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) 
-            && (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) || boma.left_stick_y() > 0.66) {
+            && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) {
                 if boma.left_stick_y() != 0.0 && VarModule::get_int(fighter.battle_object, vars::common::instance::FLOAT_TIMER) > 2 {
                     let mut motion_vec = Vector3f{x: 0.0, y: 0.0, z: 0.0};
                     if boma.left_stick_y() > 0.0 {
@@ -154,7 +160,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             *FIGHTER_STATUS_KIND_ATTACK_AIR,
             *FIGHTER_STATUS_KIND_DAMAGE_FALL].contains(&status_kind) 
         || !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY) 
-        || (boma.is_button_off(Buttons::Jump) && boma.left_stick_y() <= 0.66))
+        || boma.is_button_off(Buttons::Jump))
         && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) < VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) 
         && WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) >= 0 
         && !StatusModule::is_changing(boma)


### PR DESCRIPTION
I spent more time working on floats until I could fix a few more annoying issues. Fixes:
- Holding up no longer starts float on its own, now requires a jump input. Fixes a ton of misinputs that could happen when sdi'ing or manually inputting aerials, helps tap jump users
- Floats starting frame 7, not able to aerial out of float until frame 8 (robin)
- Aerials' float lockout wouldn't take into account cancel frames, not allowing you to float when actionable (made jump+down input eat djs)
- Appears to fix robin's grounded float instantly cancelling into fastfall if input too fast, likely due to the above changes to the aerial float restrictions.
- Robin float now brings up the meter every other tick, before using an aerial would prevent you from seeing the meter at all until the next time you used a wind move