### PR TITLE
Fix sonic spring snap

### DIFF
--- a/fighters/sonic/src/opff.rs
+++ b/fighters/sonic/src/opff.rs
@@ -10,20 +10,10 @@ if status_kind == *FIGHTER_SONIC_STATUS_KIND_SPECIAL_S_TURN && boma.is_input_jum
   }
 }
 
-// Allows Sonic to land during upB before he completes the spin at the top
-unsafe fn up_special_early_landing(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP) {
-        if GroundModule::is_touch(fighter.module_accessor, *GROUND_TOUCH_FLAG_DOWN as u32) {
-            fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
-        }
-    }
-}
-
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     sonic_spindash_jump_waveland(boma, status_kind, situation_kind, cat[0]);
     //sonic_moveset(boma, situation_kind, status_kind, motion_kind, frame, cat[0], id);
     //sonic_lightspeed_dash(boma, status_kind, motion_kind, situation_kind, cat[0], id);
-    up_special_early_landing(fighter);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_SONIC )]

--- a/fighters/sonic/src/status.rs
+++ b/fighters/sonic/src/status.rs
@@ -4,6 +4,7 @@ mod dash;
 mod special_s;
 mod special_s_dash;
 mod special_lw_hold;
+mod special_hi;
 
 /// Prevents side b from being used again in air
 unsafe extern "C" fn should_use_special_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -41,4 +42,5 @@ pub fn install() {
     special_s::install();
     special_s_dash::install();
     special_lw_hold::install();
+    special_hi::install();
 }

--- a/fighters/sonic/src/status/special_hi.rs
+++ b/fighters/sonic/src/status/special_hi.rs
@@ -7,7 +7,7 @@ pub fn install() {
       pre_special_hi,
 
       pre_special_hi_jump,
-      exec_special_hi_jump
+      exec_special_hi_jump,
   );
 }
 
@@ -48,9 +48,9 @@ pub unsafe fn pre_special_hi(fighter: &mut L2CFighterCommon) -> L2CValue {
 pub unsafe fn pre_special_hi_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
 	StatusModule::init_settings(
         fighter.module_accessor,
-        SituationKind(*SITUATION_KIND_NONE),
+        SituationKind(*SITUATION_KIND_AIR),
         *FIGHTER_KINETIC_TYPE_SONIC_SPECIAL_HI_JUMP,
-        *GROUND_CORRECT_KIND_NONE as u32,
+        *GROUND_CORRECT_KIND_AIR as u32,
         GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
         true,
         *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_FLAG,
@@ -70,15 +70,18 @@ pub unsafe fn pre_special_hi_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
         *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
         0
     );
+    GroundModule::set_attach_ground(fighter.module_accessor, false);
     0.into()
 }
 
 #[status_script(agent = "sonic", status =  FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_EXEC_STATUS)]
 pub unsafe fn exec_special_hi_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
     let boma = fighter.boma();
-    let speed_y = KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-    if speed_y <= 0.0 {
-        GroundModule::correct(boma, app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    if fighter.motion_frame() > 2.0 {
+        GroundModule::set_correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    }
+    else{
+        StatusModule::set_situation_kind(fighter.module_accessor, SituationKind(*SITUATION_KIND_AIR), false);
     }
     return 0.into()
 }

--- a/fighters/sonic/src/status/special_hi.rs
+++ b/fighters/sonic/src/status/special_hi.rs
@@ -1,0 +1,84 @@
+use super::*;
+use globals::*;
+use smashline::*;
+
+pub fn install() {
+  install_status_scripts!(
+      pre_special_hi,
+
+      pre_special_hi_jump,
+      exec_special_hi_jump
+  );
+}
+
+#[status_script(agent = "sonic", status = FIGHTER_STATUS_KIND_SPECIAL_HI, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_special_hi(fighter: &mut L2CFighterCommon) -> L2CValue {
+	StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_SONIC_SPECIAL_HI_COMP,
+        *GROUND_CORRECT_KIND_NONE as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (
+            *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_KEEP
+        ) as u64,
+        (
+            *FIGHTER_STATUS_ATTR_START_TURN |
+            *FIGHTER_STATUS_ATTR_DISABLE_INTERRUPT_WARP
+        ) as u32,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    0.into()
+}
+#[status_script(agent = "sonic", status = FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_special_hi_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
+	StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_SONIC_SPECIAL_HI_JUMP,
+        *GROUND_CORRECT_KIND_NONE as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_SONIC_SPECIAL_HI_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        0,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    0.into()
+}
+
+#[status_script(agent = "sonic", status =  FIGHTER_SONIC_STATUS_KIND_SPECIAL_HI_JUMP, condition = LUA_SCRIPT_STATUS_FUNC_EXEC_STATUS)]
+pub unsafe fn exec_special_hi_jump(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let boma = fighter.boma();
+    let speed_y = KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    if speed_y <= 0.0 {
+        GroundModule::correct(boma, app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    }
+    return 0.into()
+}


### PR DESCRIPTION
When using sonic's up special near a platform, during certain frames of the move, Sonic would snap to the platform, encuring special landing lag. This should prevent Sonic from snapping to the ground during the initial spring spawn, and during the first few frames of jumping from the spring.

Addresses #1728 