### PR TITLE
Taunt parry hotfix

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -519,6 +519,8 @@ pub trait BomaExt {
     unsafe fn try_pickup_item(&mut self, range: f32, bone: Option<Hash40>, offset: Option<&Vector2f>) -> Option<&mut BattleObjectModuleAccessor> ;
 
     unsafe fn get_player_idx_from_boma(&mut self) -> i32;
+
+    unsafe fn is_parry_input(&mut self) -> bool;
 }
 
 impl BomaExt for BattleObjectModuleAccessor {
@@ -1212,6 +1214,17 @@ impl BomaExt for BattleObjectModuleAccessor {
         let next = *((next + 0x58) as *const u64);
         let next = *((next + 0x8) as *const u64);
         *((next + 0x8) as *const i32)
+    }
+
+    unsafe fn is_parry_input(&mut self) -> bool {
+        let is_taunt_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_HI as u8) < ControlModule::get_command_life_count_max(self) as i32  // checks if Taunt input was pressed within max tap buffer window
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_L as u8) < ControlModule::get_command_life_count_max(self) as i32
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_R as u8) < ControlModule::get_command_life_count_max(self) as i32
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_LW as u8) < ControlModule::get_command_life_count_max(self) as i32;
+        let is_special_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_SPECIAL as u8) < ControlModule::get_command_life_count_max(self) as i32;  // checks if Special input was pressed within max tap buffer window
+
+        (self.is_button_on(Buttons::TauntParry) && is_taunt_buffered)
+        || (self.is_button_on(Buttons::SpecialParry) && is_special_buffered)
     }
 }
 

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -1217,11 +1217,13 @@ impl BomaExt for BattleObjectModuleAccessor {
     }
 
     unsafe fn is_parry_input(&mut self) -> bool {
-        let is_taunt_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_HI as u8) < ControlModule::get_command_life_count_max(self) as i32  // checks if Taunt input was pressed within max tap buffer window
-                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_L as u8) < ControlModule::get_command_life_count_max(self) as i32
-                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_R as u8) < ControlModule::get_command_life_count_max(self) as i32
-                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_LW as u8) < ControlModule::get_command_life_count_max(self) as i32;
-        let is_special_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_SPECIAL as u8) < ControlModule::get_command_life_count_max(self) as i32;  // checks if Special input was pressed within max tap buffer window
+        let max_tap_buffer_window = ControlModule::get_command_life_count_max(self) as i32;
+
+        let is_taunt_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_HI as u8) < max_tap_buffer_window  // checks if Taunt input was pressed within max tap buffer window
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_L as u8) < max_tap_buffer_window
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_S_R as u8) < max_tap_buffer_window
+                                    || ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_APPEAL_LW as u8) < max_tap_buffer_window;
+        let is_special_buffered = ControlModule::get_trigger_count(self, *CONTROL_PAD_BUTTON_SPECIAL as u8) < max_tap_buffer_window;  // checks if Special input was pressed within max tap buffer window
 
         (self.is_button_on(Buttons::TauntParry) && is_taunt_buffered)
         || (self.is_button_on(Buttons::SpecialParry) && is_special_buffered)

--- a/fighters/common/src/general_statuses/shield/misc.rs
+++ b/fighters/common/src/general_statuses/shield/misc.rs
@@ -384,11 +384,7 @@ pub unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
             return true.into();
         }
 
-        let is_taunt_buffered = ControlModule::get_trigger_count(fighter.module_accessor, (*CONTROL_PAD_BUTTON_APPEAL_HI + *CONTROL_PAD_BUTTON_APPEAL_LW + *CONTROL_PAD_BUTTON_APPEAL_S_L + *CONTROL_PAD_BUTTON_APPEAL_S_R) as u8) < ControlModule::get_command_life_count_max(fighter.module_accessor) as i32;  // checks if Taunt input was pressed within max tap buffer window
-        let is_special_buffered = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL as u8) < ControlModule::get_command_life_count_max(fighter.module_accessor) as i32;  // checks if Special input was pressed within max tap buffer window
-
-        if (fighter.is_button_on(Buttons::TauntParry) && is_taunt_buffered)
-        || (fighter.is_button_on(Buttons::SpecialParry) && is_special_buffered) {
+        if fighter.is_parry_input() {
             fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), true.into());
             VarModule::on_flag(
                 fighter.object(),

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -140,11 +140,7 @@ pub unsafe fn taunt_parry_forgiveness(fighter: &mut L2CFighterCommon) {
     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_APPEAL, *FIGHTER_STATUS_KIND_SPECIAL_N])
     && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
     && fighter.global_table[CURRENT_FRAME].get_i32() <= 1
-    && {let is_taunt_buffered = ControlModule::get_trigger_count(fighter.module_accessor, (*CONTROL_PAD_BUTTON_APPEAL_HI + *CONTROL_PAD_BUTTON_APPEAL_LW + *CONTROL_PAD_BUTTON_APPEAL_S_L + *CONTROL_PAD_BUTTON_APPEAL_S_R) as u8) < ControlModule::get_command_life_count_max(fighter.module_accessor) as i32;  // checks if Taunt input was pressed within max tap buffer window
-        let is_special_buffered = ControlModule::get_trigger_count(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL as u8) < ControlModule::get_command_life_count_max(fighter.module_accessor) as i32;  // checks if Special input was pressed within max tap buffer window
-
-        (fighter.is_button_on(Buttons::TauntParry) && is_taunt_buffered)
-        || (fighter.is_button_on(Buttons::SpecialParry) && is_special_buffered) }
+    && fighter.is_parry_input()
     {
         EffectModule::kill_all(fighter.module_accessor, *EFFECT_SUB_ATTRIBUTE_NONE as u32, true, false);
         fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());


### PR DESCRIPTION
Taunt Parry input did not work as described in the previous PR. It now only works when Taunt is pressed within 5f tap buffer window.