### PR TITLE
Parry Sound Bugfix

### DIFF
--- a/fighters/common/src/general_statuses/shield/misc.rs
+++ b/fighters/common/src/general_statuses/shield/misc.rs
@@ -385,6 +385,7 @@ pub unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         }
 
         if fighter.is_parry_input() {
+            SoundModule::stop_all_sound(fighter.module_accessor);
             fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), true.into());
             VarModule::on_flag(
                 fighter.object(),

--- a/fighters/common/src/general_statuses/shield/misc.rs
+++ b/fighters/common/src/general_statuses/shield/misc.rs
@@ -385,7 +385,6 @@ pub unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         }
 
         if fighter.is_parry_input() {
-            SoundModule::stop_all_sound(fighter.module_accessor);
             fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), true.into());
             VarModule::on_flag(
                 fighter.object(),

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -143,6 +143,7 @@ pub unsafe fn taunt_parry_forgiveness(fighter: &mut L2CFighterCommon) {
     && fighter.is_parry_input()
     {
         EffectModule::kill_all(fighter.module_accessor, *EFFECT_SUB_ATTRIBUTE_NONE as u32, true, false);
+        SoundModule::stop_all_sound(fighter.module_accessor);
         fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());
     }
 }


### PR DESCRIPTION
Small bugfix that kills sound effects and voice clips upon initiating a parry. intended to prevent stuff like this:

https://github.com/HDR-Development/HewDraw-Remix/assets/69305550/8f6ab239-4bdb-4dc2-b3f7-f858d265e039

