### PR TITLE
Robin Levin Buffer/Switch

### DIFF
--- a/fighters/robin/src/opff.rs
+++ b/fighters/robin/src/opff.rs
@@ -32,6 +32,26 @@ unsafe fn elwind1_burn(fighter: &mut L2CFighterCommon) {
     }
 }
 
+unsafe fn levin_leniency(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    let levin = *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THUNDER_SWORD_CURRENT_POINT;
+    if boma.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR) 
+    && boma.status_frame() <= 5 
+    && !fighter.is_flag(*FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON) 
+    && boma.is_button_on(Buttons::Smash | Buttons::SpecialRaw) 
+    && !StatusModule::is_changing(boma)
+    && WorkModule::get_int(boma, levin) > 0 {
+        VisibilityModule::set_int64(boma, Hash40::new("sword").hash as i64, Hash40::new("sword_thunder").hash as i64);
+        fighter.on_flag(*FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
+        VisibilityModule::set_int64(boma, Hash40::new("sword").hash as i64, Hash40::new("sword_thunder").hash as i64);
+        if WorkModule::get_int(boma, levin) == 1 {
+            app::FighterSpecializer_Reflet::set_flag_to_table(fighter.module_accessor as *mut app::FighterModuleAccessor, *FIGHTER_REFLET_MAGIC_KIND_SWORD, true, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THROWAWAY_TABLE);
+            WorkModule::dec_int(boma, levin);
+        } else {
+            WorkModule::dec_int(boma, levin);
+        } 
+    }
+}
+
 // Lengthen sword
 unsafe fn sword_length(boma: &mut BattleObjectModuleAccessor) {
     let long_sword_scale = Vector3f{x: 1.0, y: 1.175, z: 1.0475};
@@ -41,6 +61,7 @@ unsafe fn sword_length(boma: &mut BattleObjectModuleAccessor) {
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     nspecial_cancels(boma, status_kind, situation_kind);
     elwind1_burn(fighter);
+    levin_leniency(fighter, boma);
     sword_length(boma);
 }
 

--- a/fighters/robin/src/opff.rs
+++ b/fighters/robin/src/opff.rs
@@ -33,22 +33,20 @@ unsafe fn elwind1_burn(fighter: &mut L2CFighterCommon) {
 }
 
 unsafe fn levin_leniency(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    let levin = *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THUNDER_SWORD_CURRENT_POINT;
     if boma.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR) 
     && boma.status_frame() <= 5 
     && !fighter.is_flag(*FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON) 
     && boma.is_button_on(Buttons::Smash | Buttons::SpecialRaw) 
-    && !StatusModule::is_changing(boma)
-    && WorkModule::get_int(boma, levin) > 0 {
-        VisibilityModule::set_int64(boma, Hash40::new("sword").hash as i64, Hash40::new("sword_thunder").hash as i64);
-        fighter.on_flag(*FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
-        VisibilityModule::set_int64(boma, Hash40::new("sword").hash as i64, Hash40::new("sword_thunder").hash as i64);
-        if WorkModule::get_int(boma, levin) == 1 {
-            app::FighterSpecializer_Reflet::set_flag_to_table(fighter.module_accessor as *mut app::FighterModuleAccessor, *FIGHTER_REFLET_MAGIC_KIND_SWORD, true, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THROWAWAY_TABLE);
+    && !StatusModule::is_changing(boma) {
+        let levin = *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THUNDER_SWORD_CURRENT_POINT;
+        if WorkModule::get_int(boma, levin) > 0 {
+            if WorkModule::get_int(boma, levin) == 1 {
+                app::FighterSpecializer_Reflet::set_flag_to_table(fighter.module_accessor as *mut app::FighterModuleAccessor, *FIGHTER_REFLET_MAGIC_KIND_SWORD, true, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_THROWAWAY_TABLE);
+            }
+            fighter.on_flag(*FIGHTER_REFLET_INSTANCE_WORK_ID_FLAG_THUNDER_SWORD_ON);
+            VisibilityModule::set_int64(boma, Hash40::new("sword").hash as i64, Hash40::new("sword_thunder").hash as i64);
             WorkModule::dec_int(boma, levin);
-        } else {
-            WorkModule::dec_int(boma, levin);
-        } 
+        }
     }
 }
 


### PR DESCRIPTION
 (follow up on https://github.com/HDR-Development/HewDraw-Remix/pull/1662)
Previously I added a fix to make tilt input aerials switch to bronze. This had the unintended side-effect of lowering accessibility, as you needed a dedicated smash button or a frame perfect A+B Smash input to do levin nair. This adds 5 frames (match normal buffer frames) to input B or Smash at the start of each aerial. This should make Robin playable on more control schemes. LMK if frame buffer needs changing. I tested it to make sure that it uses and checks for durability and allows robin to throw the sword on resource burnout.