### PR TITLE
Allow all specials to fastfall

### DIFF
--- a/fighters/common/src/opff/physics.rs
+++ b/fighters/common/src/opff/physics.rs
@@ -61,9 +61,22 @@ unsafe fn plat_cancels(fighter: &mut L2CFighterCommon) {
     }
 }
 
+// Allows all special moves to be able to fastfall
+// with fastfall conditions being:
+//   1. Must be descending (y velocity < 0.0)
+//   2. Must be able to drift horizontally (FIGHTER_KINETIC_ENERGY_ID_CONTROL enabled)
+unsafe fn global_specials_fastfall(fighter: &mut L2CFighterCommon) {
+    if StatusModule::status_kind(fighter.module_accessor) > 0x1DB  // only applies to special moves
+    && fighter.is_situation(*SITUATION_KIND_AIR) {
+        // sub_air_check_dive checks for y velocity and air drift
+        fighter.sub_air_check_dive();
+    }
+}
+
 pub unsafe fn run(fighter: &mut L2CFighterCommon, lua_state: u64, l2c_agent: &mut L2CAgent, boma: &mut BattleObjectModuleAccessor, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, fighter_kind: i32, stick_x: f32, stick_y: f32, facing: f32) {
     grab_jump_refresh(boma);
     plat_cancels(fighter);
+    global_specials_fastfall(fighter);
 
     //WorkModule::unable_transition_term(boma, *FIGHTER_STATUS_TRANSITION_TERM_ID_DAMAGE_FLY_REFLECT_D); //Melee style spike knockdown (courtesey of zabimaru), leaving it commented here just to have it saved somewhere
 }

--- a/fighters/donkey/src/opff.rs
+++ b/fighters/donkey/src/opff.rs
@@ -48,7 +48,10 @@ unsafe fn barrel_pull(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     } else {
         if status_kind == *FIGHTER_STATUS_KIND_ITEM_HEAVY_PICKUP {
             KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
+            
+            if KineticModule::get_kinetic_type(boma) != *FIGHTER_KINETIC_TYPE_FALL {
+                KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
+            }
         }
     }
 }

--- a/fighters/donkey/src/status/special_lw.rs
+++ b/fighters/donkey/src/status/special_lw.rs
@@ -57,13 +57,6 @@ unsafe fn special_lw_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 unsafe extern "C" fn special_lw_substatus(fighter: &mut L2CFighterCommon, param_1: L2CValue) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_AIR)
     && param_1.get_bool() {
-        // enable fastfall
-        if fighter.is_cat_flag(Cat2::FallJump)
-            && fighter.stick_y() < -0.66
-            && KineticModule::get_sum_speed_y(fighter.boma(), *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-            WorkModule::set_flag(fighter.boma(), true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-        }
-
         // try to pick up an item nearby
         let frame = fighter.motion_frame();
         if frame > 5.0 && frame < 16.0 {

--- a/fighters/donkey/src/status/super_lift.rs
+++ b/fighters/donkey/src/status/super_lift.rs
@@ -88,20 +88,20 @@ pub unsafe fn super_lift_turn(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 /// callback run during SUPER_LIFT_FALL
 pub unsafe fn super_lift_fall(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     
-    super_lift_fastfall(fighter);
+    //super_lift_fastfall(fighter);
 }
 
 /// callback run during SUPER_LIFT_JUMP
 pub unsafe fn super_lift_jump(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     
-    super_lift_fastfall(fighter);
+    //super_lift_fastfall(fighter);
 }
 
 /// callback run during SUPER_LIFT_PASS
 pub unsafe fn super_lift_pass(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     
     if fighter.status_frame() > 5 {
-        super_lift_fastfall(fighter);
+        //super_lift_fastfall(fighter);
     }
 }
 

--- a/fighters/falco/src/opff.rs
+++ b/fighters/falco/src/opff.rs
@@ -9,13 +9,6 @@ unsafe fn laser_ff_land_cancel(boma: &mut BattleObjectModuleAccessor, status_kin
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request(boma, *FIGHTER_STATUS_KIND_LANDING, true);
         }
-        if situation_kind == *SITUATION_KIND_AIR {
-            if boma.is_cat_flag(Cat2::FallJump)
-                && stick_y < -0.66
-                && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-            }
-        }
     }
 }
 

--- a/fighters/fox/src/opff.rs
+++ b/fighters/fox/src/opff.rs
@@ -8,10 +8,6 @@ unsafe fn laser_fastfall_landcancel(boma: &mut BattleObjectModuleAccessor, statu
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
-        } else if situation_kind == *SITUATION_KIND_AIR {
-            if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66 && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-            }
         }
     }
 }

--- a/fighters/gamewatch/src/opff.rs
+++ b/fighters/gamewatch/src/opff.rs
@@ -9,12 +9,6 @@ unsafe fn ff_chef_land_cancel(boma: &mut BattleObjectModuleAccessor, status_kind
         if situation_kind == *SITUATION_KIND_GROUND && StatusModule::prev_situation_kind(boma) == *SITUATION_KIND_AIR {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
-        if situation_kind == *SITUATION_KIND_AIR {
-            if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66
-                && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-            }
-        }
         if StatusModule::is_changing(boma) {
             let nspec_halt = Vector3f{x: 0.9, y: 1.0, z: 1.0};
             KineticModule::mul_speed(boma, &nspec_halt, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -50,11 +50,6 @@ pub fn hammer_fastfall_landcancel(fighter: &mut smash::lua2cpp::L2CFighterCommon
                 MotionModule::change_motion_force_inherit_frame(fighter.module_accessor, Hash40::new("special_s"), 33.0, 1.0, 1.0);
                 MotionModule::set_rate(fighter.module_accessor, (55.0 - 33.0)/25.0);    // equates to 17F landing lag
             }
-            if fighter.is_situation(*SITUATION_KIND_AIR) {
-                if fighter.is_cat_flag(Cat2::FallJump) && fighter.stick_y() < -0.66 && KineticModule::get_sum_speed_y(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                    WorkModule::set_flag(fighter.module_accessor, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-                }
-            }
         }
     }
 }

--- a/fighters/link/src/opff.rs
+++ b/fighters/link/src/opff.rs
@@ -93,7 +93,7 @@ pub unsafe extern "Rust" fn links_common(fighter: &mut smash::lua2cpp::L2CFighte
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    bow_fastfall(boma, status_kind, situation_kind, cat[1], stick_y);
+    //bow_fastfall(boma, status_kind, situation_kind, cat[1], stick_y);
 }
 
 #[utils::macros::opff(FIGHTER_KIND_LINK )]

--- a/fighters/lucas/src/opff.rs
+++ b/fighters/lucas/src/opff.rs
@@ -382,7 +382,7 @@ pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut
     //pk_thunder_cancel(boma, id, status_kind, situation_kind);
     //pk_thunder_wall_ride_shorten(fighter, boma, id, status_kind, situation_kind);
     //djc_momentum_helper(boma, id, status_kind, frame);
-    pk_fire_ff(boma, stick_y);
+    //pk_fire_ff(boma, stick_y);
     offense_charge(fighter, boma, situation_kind);
     offense_effct_handler(fighter);
     reset_flags(fighter, status_kind, situation_kind);

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -68,10 +68,8 @@ unsafe fn laser_blaze_ff_land_cancel(boma: &mut BattleObjectModuleAccessor, situ
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
         }
         if situation_kind == *SITUATION_KIND_AIR {
-            KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
-            if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66
-                && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
+            if KineticModule::get_kinetic_type(boma) != *FIGHTER_KINETIC_TYPE_FALL {
+                KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
             }
         }
     }

--- a/fighters/ness/src/opff.rs
+++ b/fighters/ness/src/opff.rs
@@ -116,7 +116,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     psi_magnet_jump_cancel_turnaround(fighter);
     pk_thunder_cancel(boma, id, status_kind, situation_kind);
     pk_thunder_wall_ride(boma, id, status_kind, situation_kind);
-    pk_fire_ff(boma, stick_y);
+    //pk_fire_ff(boma, stick_y);
     uair_scaling(boma);
 }
 

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -14,12 +14,6 @@ unsafe fn bow_ff_lc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, sit
                 StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_LANDING, false);
             }
         }
-        if situation_kind == *SITUATION_KIND_AIR {
-            if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66
-                && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
-            }
-        }
     }
 }
 

--- a/fighters/rockman/src/opff.rs
+++ b/fighters/rockman/src/opff.rs
@@ -55,11 +55,8 @@ unsafe fn blade_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind: i32,
 
 unsafe fn side_special_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat2: i32, stick_y: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S && situation_kind == *SITUATION_KIND_AIR {
-        KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
-        if boma.is_cat_flag(Cat2::FallJump)
-        && stick_y < -0.66
-        && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-            WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
+        if KineticModule::get_kinetic_type(boma) != *FIGHTER_KINETIC_TYPE_FALL {
+            KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
         }
     }
 }

--- a/fighters/simon/src/opff.rs
+++ b/fighters/simon/src/opff.rs
@@ -18,11 +18,8 @@ unsafe fn holy_water_ac(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectM
 unsafe fn axe_ff(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat2: i32, stick_y: f32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if situation_kind == *SITUATION_KIND_AIR {
-            KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
-            if boma.is_cat_flag(Cat2::FallJump)
-                && stick_y < -0.66
-                && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
+            if KineticModule::get_kinetic_type(boma) != *FIGHTER_KINETIC_TYPE_FALL {
+                KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
             }
         }
     }

--- a/fighters/toonlink/src/opff.rs
+++ b/fighters/toonlink/src/opff.rs
@@ -43,7 +43,7 @@ extern "Rust" {
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    heros_bow_ff(boma, status_kind, situation_kind, cat[1], stick_y);
+    //heros_bow_ff(boma, status_kind, situation_kind, cat[1], stick_y);
 	sword_length(boma);
     triple_jump_lockout(fighter);
     

--- a/fighters/younglink/src/opff.rs
+++ b/fighters/younglink/src/opff.rs
@@ -84,7 +84,7 @@ unsafe fn holdable_dair(boma: &mut BattleObjectModuleAccessor, motion_kind: u64,
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
-    fire_arrow_ff(fighter, boma, status_kind, situation_kind, cat[1], stick_y);
+    //fire_arrow_ff(fighter, boma, status_kind, situation_kind, cat[1], stick_y);
     bombchu_timer(fighter, boma, id);
     bombchu_reset(fighter, id, status_kind);
     bombchu_training(fighter, id, status_kind);

--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -95,9 +95,8 @@ unsafe fn nayru_fastfall_land_cancel(boma: &mut BattleObjectModuleAccessor, stat
         }
         else if situation_kind == *SITUATION_KIND_AIR {
             if frame >= 31.0 {
-                KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
-                if boma.is_cat_flag(Cat2::FallJump) && stick_y < -0.66 && KineticModule::get_sum_speed_y(boma, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY) <= 0.0 {
-                    WorkModule::set_flag(boma, true, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE);
+                if KineticModule::get_kinetic_type(boma) != *FIGHTER_KINETIC_TYPE_FALL {
+                    KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_FALL);
                 }
             }
         }


### PR DESCRIPTION
Gives all special moves the ability to fastfall, with vanilla's fastfall conditions being:
- Must be descending (y velocity < 0.0)
- Must be able to drift horizontally (`FIGHTER_KINETIC_ENERGY_ID_CONTROL` enabled)

Note that these conditions mean many special moves will still not be able to fastfall, as many do not allow your character to drift during them (e.g. Kirby Inhale, Samus Charge Shot charge, Falcon Kick, etc.). If in the future, any of these were given the ability to drift, they would then be allowed to fastfall with this change.

This is mostly to address many recovery moves having an awkward period of time before reaching special fall where you cannot fastfall, though it looks like you should.