### PR TITLE
UpB bounce bugfixes

### DIFF
--- a/fighters/falco/src/status/special_hi.rs
+++ b/fighters/falco/src/status/special_hi.rs
@@ -45,9 +45,12 @@ pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CVal
 
 #[status_script(agent = "falco", status = FIGHTER_FALCO_STATUS_KIND_SPECIAL_HI_BOUND, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
 pub unsafe fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let ret = original!(fighter);
+
     let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
     WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
-    0.into()
+    
+    ret
 }
 
 pub fn install() {

--- a/fighters/fox/src/status/special_hi.rs
+++ b/fighters/fox/src/status/special_hi.rs
@@ -45,9 +45,12 @@ pub unsafe fn special_hi_rush_end_main(fighter: &mut L2CFighterCommon) -> L2CVal
 
 #[status_script(agent = "fox", status = FIGHTER_FOX_STATUS_KIND_SPECIAL_HI_BOUND, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
 pub unsafe fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let ret = original!(fighter);
+
     let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
     WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
-    0.into()
+    
+    ret
 }
 
 pub fn install() {

--- a/fighters/lucario/src/status.rs
+++ b/fighters/lucario/src/status.rs
@@ -232,6 +232,9 @@ pub unsafe fn pre_run(fighter: &mut L2CFighterCommon) -> L2CValue {
 
 #[status_script(agent = "lucario", status = FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
 pub unsafe fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let ret = original!(fighter);
+
     WorkModule::off_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);
-    0.into()
+    
+    ret
 }

--- a/fighters/wolf/src/status/special_hi.rs
+++ b/fighters/wolf/src/status/special_hi.rs
@@ -20,9 +20,12 @@ pub unsafe fn special_hi_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 
 #[status_script(agent = "wolf", status = FIGHTER_WOLF_STATUS_KIND_SPECIAL_HI_BOUND, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
 pub unsafe fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let ret = original!(fighter);
+
     let landing_frame = WorkModule::get_param_float(fighter.module_accessor, hash40("landing_frame"), 0);
     WorkModule::set_float(fighter.module_accessor, landing_frame, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
-    0.into()
+    
+    ret
 }
 
 pub fn install() {

--- a/romfs/source/fighter/falco/param/vl.prcxml
+++ b/romfs/source/fighter/falco/param/vl.prcxml
@@ -63,7 +63,7 @@
       <float hash="fire_rush_speed">4.2</float>
       <int hash="fire_rush_brake_frame">3</int>
       <float hash="fire_rush_brake">0.17</float>
-      <float hash="fire_crush_x_mul">1</float>
+      <float hash="fire_crush_x_mul">0.8</float>
       <float hash="fire_fall_x_mul">0.8</float>
       <int hash="fire_landing_frame">15</int>
     </struct>

--- a/romfs/source/fighter/wolf/param/vl.prcxml
+++ b/romfs/source/fighter/wolf/param/vl.prcxml
@@ -38,7 +38,7 @@
       <float hash="fire_rush_speed">3.8</float>
       <int hash="fire_rush_brake_frame">5</int>
       <float hash="fire_rush_brake">0.16</float>
-      <float hash="fire_crush_x_mul">0.75</float>
+      <float hash="fire_crush_x_mul">0.8</float>
       <float hash="fire_fall_x_mul">0.65</float>
       <int hash="fire_landing_frame">25</int>
     </struct>


### PR DESCRIPTION
Fixes an issue where Wolf, Fox, Falco, or Lucario could remain rotated after bouncing off of the ground with their upBs.