### PR TITLE
Wolf animation adjustments

### DIFF
--- a/fighters/wolf/src/acmd/aerials.rs
+++ b/fighters/wolf/src/acmd/aerials.rs
@@ -79,13 +79,10 @@ unsafe fn wolf_attack_air_b_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 3, 0, Hash40::new("kneer"), 14.0, 361, 98, 0, 32, 4.25, 4.0, -2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
     frame(lua_state, 17.0);
-    FT_MOTION_RATE(fighter, 0.333);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 27.0);
-    FT_MOTION_RATE(fighter, 1.0);
-    frame(lua_state, 36.0);
+    frame(lua_state, 28.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
@@ -141,14 +138,14 @@ unsafe fn wolf_attack_air_hi_expression(fighter: &mut L2CAgentBase) {
 unsafe fn wolf_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    FT_MOTION_RATE(fighter, 12.0/(16.0-1.0));
-    frame(lua_state, 6.0);
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE(fighter, 4.0/(12.0-5.0));
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
-    frame(lua_state, 16.0);
+    frame(lua_state, 12.0);
     FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 16.0);  // f13 ingame
     if is_excute(fighter) {
         // Air-only
         ATTACK(fighter, 0, 0, Hash40::new("top"), 13.0, 270, 70, 0, 6, 5.0, 0.0, 6.0, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
@@ -157,11 +154,11 @@ unsafe fn wolf_attack_air_lw_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 2, 0, Hash40::new("top"), 13.0, 270, 85, 0, 30, 5.0, 0.0, 6.0, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
         ATTACK(fighter, 3, 0, Hash40::new("top"), 15.0, 270, 85, 0, 30, 6.0, 0.0, 1.0, 0.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_PUNCH);
     }
-    frame(lua_state, 19.0);
+    frame(lua_state, 19.0);  // f16 ingame
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 36.0);
+    frame(lua_state, 36.0);  // f33 ingame
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }

--- a/fighters/wolf/src/acmd/smashes.rs
+++ b/fighters/wolf/src/acmd/smashes.rs
@@ -8,12 +8,12 @@ unsafe fn wolf_attack_s4_s_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(fighter, 1.701);
-    frame(lua_state, 4.0);
+    frame(lua_state, 6.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 8.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_START_SMASH_HOLD);
     }
-    frame(lua_state, 6.0);
-    FT_MOTION_RATE(fighter, 1.000);
     frame(lua_state, 13.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("arml"), 17.0, 361, 106, 0, 30, 4.5, 3.0, 0.0, -1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -34,14 +34,14 @@ fall_aerial:
   blend_frames: 5
 attack_s4_s:
   extra:
-    cancel_frame: 66
+    cancel_frame: 57
 attack_s3_s:
 fall_special:
   blend_frames: 5
 attack_s3_lw:
 attack_air_b:
   extra:
-    cancel_frame: 46
+    cancel_frame: 38
 attack_air_f:
   extra:
     cancel_frame: 37


### PR DESCRIPTION
Adjusts animations for ftilt, fsmash, bair, and dair to enter/leave their key poses in a snappier manner, as well as linger on their key poses for longer. Frame data remains the same.

### Ftilt:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/fddb3dd5-1ceb-4bb5-9c62-8b9d1631782a

### Fsmash:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/0d7484de-671f-43c1-b5a9-075b5b6eea15

### Bair:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/241c5a4c-1608-4d61-8a69-a7ee6a6136c9

### Dair:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/874a8e1d-7e0d-4ad5-b5db-6fda03c95346


To be merged with HDR-Development/hdr-private#421