### PR TITLE
Shield release visual improvement

### DIFF
--- a/fighters/common/src/general_statuses/shield/guard_off/main.rs
+++ b/fighters/common/src/general_statuses/shield/guard_off/main.rs
@@ -269,11 +269,16 @@ unsafe fn status_GuardOff_Common(fighter: &mut L2CFighterCommon) -> L2CValue {
         guard_off_cancel_frame,
         *FIGHTER_STATUS_GUARD_OFF_WORK_INT_CANCEL_FRAME,
     );
-    let fighter_guard_off_cancel_frame = FighterMotionModuleImpl::get_cancel_frame(
+    let mut fighter_guard_off_cancel_frame = FighterMotionModuleImpl::get_cancel_frame(
         fighter.module_accessor,
         Hash40::new("guard_off"),
         true,
     );
+    match fighter_guard_off_cancel_frame {
+        // if cancel frame is read as 0, use the animation's total length as cancel frame
+        0.0 => {fighter_guard_off_cancel_frame = MotionModule::end_frame(fighter.module_accessor)},
+        _ => {}
+    }
     let guard_off_motion_start_frame = ParamModule::get_float(fighter.battle_object, ParamType::Common, "guard_off_motion_start_frame");
     let ret_val = if 0.0 < fighter_guard_off_cancel_frame && 0 < guard_off_cancel_frame {
         (fighter_guard_off_cancel_frame - guard_off_motion_start_frame) / (guard_off_cancel_frame as f32)

--- a/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_b:
   extra:
     cancel_frame: 47

--- a/romfs/source/fighter/brave/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/brave/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 33

--- a/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 51

--- a/romfs/source/fighter/captain/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/captain/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
@@ -27,6 +27,8 @@ attack_12:
     cancel_frame: 18
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 37

--- a/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
@@ -9,6 +9,8 @@ attack_12:
     cancel_frame: 26
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 26

--- a/romfs/source/fighter/demon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/demon/motion/body/motion_patch.yaml
@@ -6,3 +6,5 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0

--- a/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_b:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 45

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 29

--- a/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/edge/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/edge/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_b:
   extra:
     cancel_frame: 33

--- a/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 25

--- a/romfs/source/fighter/elight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/elight/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 22

--- a/romfs/source/fighter/falco/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/falco/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 46

--- a/romfs/source/fighter/fox/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/fox/motion/body/motion_patch.yaml
@@ -11,6 +11,8 @@ attack_12:
     cancel_frame: 18
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
@@ -1,3 +1,6 @@
+guard_off:
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 float:
   game_script: game_float
   flags:

--- a/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 33

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -18,6 +18,8 @@ attack_13:
     cancel_frame: 30
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/ike/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ike/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 45

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 26

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 50

--- a/romfs/source/fighter/ken/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ken/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 41

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_hi4:
   extra:
     cancel_frame: 55

--- a/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_hi:
   extra:
     cancel_frame: 40

--- a/romfs/source/fighter/krool/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/krool/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 42

--- a/romfs/source/fighter/link/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/link/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 35

--- a/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 22

--- a/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 18

--- a/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   extra:
     cancel_frame: 52

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 18

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/master/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/master/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 41

--- a/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
@@ -9,6 +9,8 @@ throw_lw:
     cancel_frame: 82
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_lw3:
   extra:
     cancel_frame: 27

--- a/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
@@ -12,6 +12,8 @@ throw_lw:
     cancel_frame: 39
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 20

--- a/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_b:
   extra:
     cancel_frame: 30

--- a/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_hi:
   extra:
     cancel_frame: 46

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/nana/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/nana/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 21

--- a/romfs/source/fighter/ness/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ness/motion/body/motion_patch.yaml
@@ -15,6 +15,8 @@ special_s:
     move: false
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/packun/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/packun/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 45

--- a/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
@@ -17,6 +17,8 @@ attack_13:
     cancel_frame: 28
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 17

--- a/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 20

--- a/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 25

--- a/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 20

--- a/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_hi:
   extra:
     cancel_frame: 40

--- a/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_lw3:
 attack_hi4:
   extra:

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/pit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pit/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
@@ -17,6 +17,8 @@ attack_13:
     cancel_frame: 28
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 18

--- a/romfs/source/fighter/popo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/popo/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 21

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 85

--- a/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 22

--- a/romfs/source/fighter/richter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/richter/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 20

--- a/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
@@ -12,6 +12,8 @@ attack_12:
     cancel_frame: 20
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 18

--- a/romfs/source/fighter/robot/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/robot/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 69

--- a/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 21

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 41

--- a/romfs/source/fighter/samus/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samus/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 6
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 special_s:
   flags:
     move: false

--- a/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 special:
   extra:
     cancel_frame: 40

--- a/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 escape:
   flags:
     move: false

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 36

--- a/romfs/source/fighter/simon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/simon/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 22

--- a/romfs/source/fighter/snake/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/snake/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_13:
   extra:
     cancel_frame: 41

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 31

--- a/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   flags:
     move: false

--- a/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 catch:
   extra:
     cancel_frame: 43

--- a/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 17

--- a/romfs/source/fighter/trail/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/trail/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 8
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 30

--- a/romfs/source/fighter/wario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wario/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_hi:
   extra:
     cancel_frame: 43

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_12:
   extra:
     cancel_frame: 17

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -15,6 +15,8 @@ attack_12:
     cancel_frame: 20
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_11:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
@@ -2,6 +2,8 @@ fall:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 attack_lw3:
 special_hi:
   flags:

--- a/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_lw:
   extra:
     cancel_frame: 48

--- a/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
@@ -6,6 +6,8 @@ fall_special:
   blend_frames: 5
 guard_off:
   blend_frames: 4
+  extra:
+    cancel_frame: 0
 throw_f:
   extra:
     cancel_frame: 46


### PR DESCRIPTION
Shield release now uses the whole animation instead of a cancel frame at motion frame 8.0, which then had to be motion rated to achieve an ingame FAF of 15, which caused shield releases to look veeeerryyy slloooooooww.