### PR TITLE
Bayonetta - jump momentum bugfix

### DIFF
--- a/fighters/bayonetta/src/status/attackair.rs
+++ b/fighters/bayonetta/src/status/attackair.rs
@@ -1,0 +1,17 @@
+use super::*;
+use globals::*;
+
+ 
+pub fn install() {
+    install_status_scripts!(
+        attack_air_pre,
+    );
+}
+
+// FIGHTER_STATUS_KIND_ATTACK_AIR //
+
+#[status_script(agent = "bayonetta", status = FIGHTER_STATUS_KIND_ATTACK_AIR, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+unsafe fn attack_air_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
+    original!(fighter)
+}

--- a/fighters/bayonetta/src/status/mod.rs
+++ b/fighters/bayonetta/src/status/mod.rs
@@ -3,10 +3,12 @@ use super::*;
 mod attack;
 mod batwithin;
 mod escape;
+mod attackair;
 
 
 pub fn install() {
     attack::install();
     batwithin::install();
     escape::install();
+    attackair::install();
 }


### PR DESCRIPTION
Fixes an issue where performing an aerial out of jump would not retain your jump momentum.