### PR TITLE
Sliding move bugfixes

### DIFF
--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -24,6 +24,8 @@ attack_11:
   extra:
     cancel_frame: 16
 attack_lw3:
+  flags:
+    move: false
   extra:
     cancel_frame: 28
 attack_hi4:

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -15,6 +15,8 @@ attack_11:
   extra:
     cancel_frame: 17
 attack_lw3:
+  flags:
+    move: false
 attack_hi4:
   extra:
     cancel_frame: 50

--- a/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
@@ -23,6 +23,8 @@ attack_11:
   extra:
     cancel_frame: 18
 attack_lw3:
+  flags:
+    move: false
 attack_hi4:
 fall_aerial:
   blend_frames: 5

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -42,6 +42,8 @@ attack_s4_s:
   extra:
     cancel_frame: 72
 attack_s3_s:
+  flags:
+    move: false
   extra:
     cancel_frame: 41
 attack_s4_hi:

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -18,6 +18,8 @@ attack_11:
   extra:
     cancel_frame: 16
 attack_lw3:
+  flags:
+    move: false
   extra:
     cancel_frame: 32
 attack_s3_s:


### PR DESCRIPTION
Fixes issues with specific moves sliding backwards once being canceled or being erroneously disjointed, so far:
- Zard dtilt
- Paisy dtilt
- Wiifit dtilt
- Shulk ftilt

Fixes #1856 