### PR TITLE
Remove Drift DI

### DIFF
--- a/fighters/common/src/opff/tech.rs
+++ b/fighters/common/src/opff/tech.rs
@@ -299,7 +299,7 @@ pub unsafe fn run(
     dash_drop(boma, status_kind);
     run_squat(boma, status_kind, stick_y); // Must be done after dash_drop()
     double_shield_button_airdodge(boma, status_kind, situation_kind, cat[0]);
-    drift_di(fighter, boma, status_kind, situation_kind);
+    //drift_di(fighter, boma, status_kind, situation_kind);
     waveland_plat_drop(boma, cat[1], status_kind);
     respawn_taunt(boma, status_kind);
     teeter_cancel(fighter, boma);

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -7,9 +7,9 @@
     <int hash="ecb_shift_air_trans_frame">9</int>
     <float hash="general_flick_y_sens">-0.66</float>
     <struct hash="drift_di">
-        <float hash="speed_mul_base">0.005</float>
-        <float hash="speed_mul_add_max">0.0025</float>
-        <float hash="speed_lerp_max">3.0</float>
+        <float hash="speed_mul_base">0.0</float>
+        <float hash="speed_mul_add_max">0.0</float>
+        <float hash="speed_lerp_max">0.0</float>
     </struct>
     <int hash="glide_toss_cancel_frame">5</int>
     <int hash="air_escape_snap_frame">5</int>


### PR DESCRIPTION
Drift DI has been in an extremely weakened form for about a year now, so much so that it is barely noticeable in 99% of scenarios, and has little gameplay impact.

This PR removes Drift DI entirely, returning the combo system to that of past games.