### PR TITLE
Add USmash Cancel For All Grounded Jump Cancel Moves

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -505,6 +505,7 @@ pub trait BomaExt {
     unsafe fn set_center_cliff_hangdata(&mut self, x: f32, y: f32);
     unsafe fn select_cliff_hangdata_from_name(&mut self, cliff_hangdata_type: &str);
 
+    unsafe fn check_attack_hi4_cancel(&mut self, update_lr: bool) -> bool;
     // Checks for status and enables transition to jump
     unsafe fn check_jump_cancel(&mut self, update_lr: bool) -> bool;
     // Checks for status and enables transition to airdodge
@@ -940,6 +941,22 @@ impl BomaExt for BattleObjectModuleAccessor {
     /// gets the current status kind for the fighter
     unsafe fn status(&mut self) -> i32 {
         return StatusModule::status_kind(self);
+    }
+
+    unsafe fn check_attack_hi4_cancel(&mut self, repeat: bool) -> bool {
+        let fighter = crate::util::get_fighter_common_from_accessor(self);
+        if !fighter.is_situation(*SITUATION_KIND_GROUND) {
+            return false;
+        }
+        WorkModule::enable_transition_term(
+            fighter.module_accessor,
+            *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4,
+        );
+        if fighter.is_cat_flag(Cat1::AttackHi4) {
+            self.change_status_req(*FIGHTER_STATUS_KIND_ATTACK_HI4, repeat);
+            return true;
+        }
+        return false;
     }
 
     /// If update_lr is true, we set your facing direction based on your stick position

--- a/fighters/brave/src/opff.rs
+++ b/fighters/brave/src/opff.rs
@@ -106,7 +106,7 @@ unsafe fn woosh_cancel(fighter: &mut L2CFighterCommon) {
 unsafe fn kaclang_jc(fighter: &mut L2CFighterCommon) {
     if fighter.is_status(*FIGHTER_BRAVE_STATUS_KIND_SPECIAL_LW_STEEL) {
         if AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) && !fighter.is_in_hitlag() {
-            fighter.check_jump_cancel(false);
+            fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/chrom/src/opff.rs
+++ b/fighters/chrom/src/opff.rs
@@ -100,7 +100,7 @@ unsafe fn side_special_cancels(fighter: &mut L2CFighterCommon) {
         },
 
         utils::hash40!("special_s4_hi") | utils::hash40!("special_air_s4_hi") if !fighter.is_in_hitlag() => {
-            if fighter.check_jump_cancel(false) {
+            if fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false) {
                 return;
             }
 

--- a/fighters/edge/src/opff.rs
+++ b/fighters/edge/src/opff.rs
@@ -25,7 +25,7 @@ unsafe fn limit_blade_rush_jc(boma: &mut BattleObjectModuleAccessor, cat1: i32, 
         //println!("Limit Blade Rush");
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag() {
             //println!("========== Limit Blade Rush hit!");
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/falco/src/opff.rs
+++ b/fighters/falco/src/opff.rs
@@ -50,7 +50,7 @@ unsafe fn shine_jc_turnaround(fighter: &mut L2CFighterCommon) {
             *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_END]))
         && !fighter.is_in_hitlag()
         {
-            fighter.check_jump_cancel(false);
+            fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/fox/src/opff.rs
+++ b/fighters/fox/src/opff.rs
@@ -28,7 +28,7 @@ unsafe fn shine_jump_cancel(fighter: &mut L2CFighterCommon) {
         *FIGHTER_FOX_STATUS_KIND_SPECIAL_LW_END]))
     && !fighter.is_in_hitlag()
         {
-            fighter.check_jump_cancel(false);
+            fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
         }
 }   
 

--- a/fighters/gamewatch/src/opff.rs
+++ b/fighters/gamewatch/src/opff.rs
@@ -74,7 +74,7 @@ pub unsafe fn gamewatch_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
 unsafe fn jc_judge_four(boma: &mut BattleObjectModuleAccessor, motion_kind: u64, situation_kind: i32) {
     if motion_kind == hash40("special_s_4") || motion_kind == hash40("special_air_s_4") {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag() {
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/ike/src/opff.rs
+++ b/fighters/ike/src/opff.rs
@@ -47,7 +47,7 @@ unsafe fn quickdraw_jump_attack_cancels(boma: &mut BattleObjectModuleAccessor, i
     if !VarModule::is_flag(boma.object(), vars::ike::status::IS_QUICK_DRAW_INSTAKILL) {
         if situation_kind == *SITUATION_KIND_GROUND {
             VarModule::set_float(boma.object(), vars::common::instance::JUMP_SPEED_MAX_MUL, 1.346);  // 1.75 max jump speed out of Quick Draw
-            boma.check_jump_cancel(true);
+            boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/inkling/src/opff.rs
+++ b/fighters/inkling/src/opff.rs
@@ -93,7 +93,7 @@ unsafe fn roller_jump_cancel(boma: &mut BattleObjectModuleAccessor) {
         && boma.is_situation(*SITUATION_KIND_GROUND)
         && boma.status_frame() > 10
     {
-        boma.check_jump_cancel(true);
+        boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
     }
     if boma.is_motion(Hash40::new("special_air_s_jump_end"))
     && !StatusModule::is_changing(boma) {

--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -128,7 +128,7 @@ unsafe fn gut_shine(fighter: &mut L2CFighterCommon) {
     if (fighter.is_status (*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 8)  // Allows for jump cancel on frame 10 if not charged
         && !VarModule::is_flag(fighter.battle_object, vars::krool::status::GUT_CHECK_CHARGED)
         && !fighter.is_in_hitlag() {
-        fighter.check_jump_cancel(false);
+        fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
     }
 }
 

--- a/fighters/lucas/src/opff.rs
+++ b/fighters/lucas/src/opff.rs
@@ -8,7 +8,7 @@ unsafe fn psi_magnet_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32,
     if [*FIGHTER_LUCAS_STATUS_KIND_SPECIAL_LW_HIT, *FIGHTER_LUCAS_STATUS_KIND_SPECIAL_LW_END].contains(&status_kind) {
         if boma.status_frame() > 0 {
             if !boma.is_in_hitlag() {
-                boma.check_jump_cancel(false);
+                boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
             }
         }
     }

--- a/fighters/miigunner/src/opff.rs
+++ b/fighters/miigunner/src/opff.rs
@@ -45,7 +45,7 @@ unsafe fn absorb_vortex_jc_turnaround_shinejump_cancel(boma: &mut BattleObjectMo
             if (status_kind == *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD && boma.status_frame() > 3)
                 || (status_kind != *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD)
             {
-                boma.check_jump_cancel(false);
+                boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
             }
         }
         if status_kind == *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_LW3_HOLD {

--- a/fighters/miiswordsman/src/opff.rs
+++ b/fighters/miiswordsman/src/opff.rs
@@ -21,7 +21,7 @@ unsafe fn gale_stab_jc_attack(fighter: &mut L2CFighterCommon, boma: &mut BattleO
     if [*FIGHTER_MIISWORDSMAN_STATUS_KIND_SPECIAL_S2_DASH].contains(&status_kind) {
         // Jump and Attack cancels
         let pad_flag = ControlModule::get_pad_flag(boma);
-        if boma.check_jump_cancel(true) {
+        if boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false) {
             return;
         }
         if compare_mask(pad_flag, *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER) || compare_mask(pad_flag, *FIGHTER_PAD_FLAG_ATTACK_TRIGGER) {
@@ -46,7 +46,7 @@ unsafe fn gale_stab_jc_attack(fighter: &mut L2CFighterCommon, boma: &mut BattleO
         // Jump cancels
         let pad_flag = ControlModule::get_pad_flag(boma);
         if boma.status_frame() > 6 && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag() {
-            boma.check_jump_cancel(true);
+            boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/miiswordsman/src/status.rs
+++ b/fighters/miiswordsman/src/status.rs
@@ -404,7 +404,7 @@ unsafe extern "C" fn special_s2_dash_main(fighter: &mut L2CFighterCommon) -> L2C
     // Jump and Attack cancels
     let pad_flag = ControlModule::get_pad_flag(fighter.module_accessor);
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND && MotionModule::frame(fighter.module_accessor) > 7.0 {
-        if fighter.check_jump_cancel(true) {
+        if fighter.check_jump_cancel(true) || fighter.check_attack_hi4_cancel(false) {
             return 1.into()
         }
     }

--- a/fighters/ness/src/opff.rs
+++ b/fighters/ness/src/opff.rs
@@ -20,7 +20,7 @@ unsafe fn psi_magnet_jump_cancel_turnaround(fighter: &mut L2CFighterCommon) {
         *FIGHTER_NESS_STATUS_KIND_SPECIAL_LW_END]))
     && !fighter.is_in_hitlag()
         {
-            fighter.check_jump_cancel(false);
+            fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
         }
 }   
 

--- a/fighters/pichu/src/opff.rs
+++ b/fighters/pichu/src/opff.rs
@@ -140,7 +140,7 @@ unsafe fn discharge_momentum(fighter: &mut L2CFighterCommon) {
 unsafe fn zippy_zap_jump_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32) {
     if [*FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_WARP, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END].contains(&status_kind) && VarModule::is_flag(boma.object(), vars::pichu::instance::IS_CHARGE_ATTACK) {
         if AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT | *COLLISION_KIND_MASK_SHIELD) && !boma.is_in_hitlag() {
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/pikachu/src/opff.rs
+++ b/fighters/pikachu/src/opff.rs
@@ -40,7 +40,7 @@ unsafe fn jc_qa_agility(boma: &mut BattleObjectModuleAccessor, id: usize, status
     && StatusModule::prev_status_kind(boma, 0) == *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END
     && !VarModule::is_flag(boma.object(), vars::pikachu::instance::DISABLE_QA_JC)
     {
-        boma.check_jump_cancel(true);
+        boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
     }
 }
 

--- a/fighters/pit/src/opff.rs
+++ b/fighters/pit/src/opff.rs
@@ -27,7 +27,7 @@ unsafe fn upperdash_arm_jump_and_aerial_cancel(boma: &mut BattleObjectModuleAcce
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_S || (status_kind == *FIGHTER_PIT_STATUS_KIND_SPECIAL_S_END && frame > 6.0) {
         if (boma.is_situation(*SITUATION_KIND_GROUND) || WorkModule::is_flag(boma, *FIGHTER_PIT_STATUS_SPECIAL_S_WORK_ID_FLAG_CLIFF_FALL_ONOFF))
         && frame > 28.0 {
-            boma.check_jump_cancel(true);
+            boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -28,7 +28,7 @@ unsafe fn guardian_orbitar_jc(boma: &mut BattleObjectModuleAccessor, status_kind
     if [*FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_HOLD,
         *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END].contains(&status_kind) {
         if boma.status_frame() > 1 && !boma.is_in_hitlag(){
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/pzenigame/src/opff.rs
+++ b/fighters/pzenigame/src/opff.rs
@@ -39,11 +39,11 @@ unsafe fn withdraw_jc(boma: &mut BattleObjectModuleAccessor, id: usize, status_k
         CancelModule::enable_cancel(boma);
     }
     if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_LOOP].contains(&status_kind) && boma.status_frame() > 15 && !boma.is_in_hitlag() {
-        boma.check_jump_cancel(true);
+        boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
     }
 
     if [*FIGHTER_PZENIGAME_STATUS_KIND_SPECIAL_S_END].contains(&status_kind) && boma.status_frame() < 10 && !boma.is_in_hitlag() {
-        boma.check_jump_cancel(true);
+        boma.check_jump_cancel(true) || boma.check_attack_hi4_cancel(false);
     }
 }
 

--- a/fighters/robot/src/opff.rs
+++ b/fighters/robot/src/opff.rs
@@ -50,7 +50,7 @@ unsafe fn jc_sideb(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind
     if ([*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_ROBOT_STATUS_KIND_SPECIAL_S_END, *FIGHTER_ROBOT_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind))
     && (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag())
     && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) {
-                boma.check_jump_cancel(false);
+                boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
     }
 }
 
@@ -82,7 +82,7 @@ unsafe fn bair_boost_reset(boma: &mut BattleObjectModuleAccessor, status_kind: i
 unsafe fn neutral_special_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag()) {
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/robot/src/opff.rs
+++ b/fighters/robot/src/opff.rs
@@ -50,7 +50,7 @@ unsafe fn jc_sideb(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind
     if ([*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_ROBOT_STATUS_KIND_SPECIAL_S_END, *FIGHTER_ROBOT_STATUS_KIND_SPECIAL_S_ATTACK].contains(&status_kind))
     && (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag())
     && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) {
-                boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
+                boma.check_jump_cancel(false);
     }
 }
 
@@ -82,7 +82,7 @@ unsafe fn bair_boost_reset(boma: &mut BattleObjectModuleAccessor, status_kind: i
 unsafe fn neutral_special_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32) {
     if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_N {
         if (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag()) {
-            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
+            boma.check_jump_cancel(false);
         }
     }
 }

--- a/fighters/rockman/src/opff.rs
+++ b/fighters/rockman/src/opff.rs
@@ -39,7 +39,7 @@ use globals::*;
 unsafe fn jc_dtilt_hit(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if boma.is_motion(Hash40::new("attack_lw3")) {
         if (AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) && !boma.is_in_hitlag()) && frame > 12.0 {
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/shizue/src/opff.rs
+++ b/fighters/shizue/src/opff.rs
@@ -108,7 +108,7 @@ pub fn fishingrod_callback(weapon : &mut L2CFighterBase) {
 unsafe fn lloid_trap_fire_jc(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, stick_x: f32, facing: f32, frame: f32) {
     if status_kind == *FIGHTER_SHIZUE_STATUS_KIND_SPECIAL_LW_FIRE {
         if boma.status_frame() > 5 && !boma.is_in_hitlag() {
-            boma.check_jump_cancel(false);
+            boma.check_jump_cancel(false) || boma.check_attack_hi4_cancel(false);
         }
     }
 }

--- a/fighters/sonic/src/status/special_s.rs
+++ b/fighters/sonic/src/status/special_s.rs
@@ -92,7 +92,7 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
     && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT)
     && !fighter.global_table[IS_STOPPING].get_bool()
     && !StatusModule::is_changing(fighter.module_accessor) {
-        fighter.check_jump_cancel(false);
+        fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
     }
     if StatusModule::is_situation_changed(fighter.module_accessor) {
         if step != vars::sonic::SPECIAL_S_STEP_START {

--- a/fighters/trail/src/opff.rs
+++ b/fighters/trail/src/opff.rs
@@ -159,7 +159,7 @@ unsafe fn side_special_hit_check(fighter: &mut smash::lua2cpp::L2CFighterCommon,
         && (WorkModule::get_param_int(boma, hash40("param_special_s"), hash40("attack_num")) - 1) > WorkModule::get_int(boma, *FIGHTER_TRAIL_STATUS_SPECIAL_S_INT_ATTACK_COUNT) {
             VarModule::on_flag(boma.object(), vars::trail::status::SIDE_SPECIAL_HIT);
             if !VarModule::is_flag(boma.object(), vars::trail::status::UP_SPECIAL_TO_SIDE_SPECIAL)
-            && fighter.check_jump_cancel(false) {
+            && fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false) {
                 return;
             }
         }
@@ -177,7 +177,7 @@ unsafe fn side_special_hit_check(fighter: &mut smash::lua2cpp::L2CFighterCommon,
         if VarModule::is_flag(boma.object(), vars::trail::status::SIDE_SPECIAL_HIT)
         && WorkModule::get_param_int(boma, hash40("param_special_s"), hash40("attack_num")) > WorkModule::get_int(boma, *FIGHTER_TRAIL_STATUS_SPECIAL_S_INT_ATTACK_COUNT) {
             if !VarModule::is_flag(boma.object(), vars::trail::status::UP_SPECIAL_TO_SIDE_SPECIAL)
-            && fighter.check_jump_cancel(false) {
+            && fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false) {
                 return;
             }
         }

--- a/fighters/wolf/src/opff.rs
+++ b/fighters/wolf/src/opff.rs
@@ -39,7 +39,7 @@ unsafe fn shine_jump_cancel(fighter: &mut L2CFighterCommon) {
             *FIGHTER_WOLF_STATUS_KIND_SPECIAL_LW_END]))
         && !fighter.is_in_hitlag()
         {
-            fighter.check_jump_cancel(false);
+            fighter.check_jump_cancel(false) || fighter.check_attack_hi4_cancel(false);
         }
 }
 


### PR DESCRIPTION
Since grounded jumps can (and have always been able to) cancel into up smash, jump-cancelable moves are also technically up-smash-cancelable. However, due to intentional jump mechanics, accessing up smash out of jump is more obtuse in HDR/Ultimate than in any previous game. 

via JCOnyx on Discord:

```
JC UpSmash Out of Shine Input Behavior (Tap Jump Off + Stick Setting Low***)

J=Jump  A=Attack  S=Smash  Up=Up(lol)
F1       | F2       | F3       | F4       | Outcome
---------------------------------------------------
J+Up+A/S | -        | -        | NA       | UpAir
J        | Up+A/S   | -        | NA       | UpSmash
J        | J+Up+A/S | -        | NA       | UpAir
J        | Up       | Up+A/S   | NA       | UpSmash
J        | J+Up     | Up+A/S   | NA       | UpSmash
J        | J+Up     | J+Up+A/S | NA       | UpAir
J+Up     | Up+A/S   | -        | NA       | UpSmash
J+Up     | J+A/S    | -        | NA       | UpAir
J+Up     | J+Up     | Up+A/S   | NA       | UpSmash
J+Up     | J+Up     | J+Up+A/S | NA       | UpAir
Up       | J+Up+A/S | -        | -        | UpAir
Up       | J+Up     | Up+A/S   | -        | UpSmash
Up       | J+Up     | J+Up+A/S | -        | UpAir
Up       | J+Up     | Up       | Up+S     | UpSmash
Up       | J+Up     | Up       | Up+A     | UpAir ***
Up       | J+Up     | J+Up     | Up+S     | UpSmash
Up       | J+Up     | J+Up     | Up+A     | UpAir ***
Up       | J+Up     | J+Up     | J+Up+A/S | UpAir
```

In the transition from older games to Smash Ultimate, up smash cancels were introduced to statuses where jump cancel up smash was previously the only way to access the move:
- shield
- dash
- run
- skid

In order to lower the mechanical skill floor to access these tools, I'm suggesting that an up smash cancel be added to all grounded jump-cancelable moves:
- Wolf DSpecial
- Sora SSpecial (on hit)
- Sonic SSpecial (on hit)
- Isabelle DSpecial (manual rocket activation)
- MegaMan DTilt (on hit)
- Squirtle SSpecial (on whiff)
- DPit DSpecial
- Pit SSpecial (on whiff)
- Pikachu USpecial1
- Pichu USpecial (charge version, on hit)
- Ness DSpecial
- Mii Swordfigher SSpecial2
- Mii Gunner DSpecial1
- Mii Gunner DSpecial3
- Lucas DSpecial
- King K Rool DSpecial
- Inkling SSpecial (ending animation)
- Ike SSpecial
- Mr. Game & Watch SSpecial 4 (on hit)
- Fox DSpecial
- Falco DSpecial
- Sephiroth USpecial (uncharged, with wing, on hit)
- Chrom SSpecial 4 Hi (on hit)
- Hero Kaclang (on hit)