### PR TITLE
DK Cargo Throw Rework

### DIFF
--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -99,7 +99,7 @@ unsafe fn game_throwfb(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 65, 52, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 46, 52, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 15.0);
@@ -122,7 +122,7 @@ unsafe fn game_throwfhi(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 90, 30, 0, 90, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 115, 30, 0, 90, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 14.0);


### PR DESCRIPTION
This is my proposed changes to DK cargo throw to turn it from it's current state of guaranteed high percent combo's and kill confirms to one that requires mix (conditioning and reads). This should create a more expressive combo game that is fun to both play with and against, while also allowing the justification of slightly tuning up some other aspects of his game. The concept is for cargo fthrow and dthrow to be conditioning for di in the direction of dk and capitalizing on di behind dk, and for cargo upthrow and bthrow to condition for di behind dk and capitalize on di in the direction dk is facing, cargo upthrow and fthrow would be for more vertical punishes and cargo dthrow and bthrow would be for more horizontal punishes.
This still needs to be tested and may require further tuning to make it feel smooth and appear visually correct. Dk may also need some small buffs to balance him out after an objective nerf like this.
If this pr isn't approved, that's okay, I just think it should be tested.
<==Donkey Kong==>
Cargo Upthrow
~[R] Angle: 90 --> 115
Cargo Backthrow
~[R] Angle: 65 --> 46