### PR TITLE
Increase minimum camera zoom

### DIFF
--- a/fighters/common/src/function_hooks/camera.rs
+++ b/fighters/common/src/function_hooks/camera.rs
@@ -69,8 +69,8 @@ unsafe fn normal_camera(ptr: u64, float: f32) {
 #[skyline::hook(offset = 0x26207f0)]
 pub fn parse_stprm_active_camera_params(param_obj: u64, params: &mut NormalCameraParams) {
     call_original!(param_obj, params);
-    params.normal_camera_min_distance = params.normal_camera_min_distance.max(120.0);
-    params.normal_camera_min_distance_2 = params.normal_camera_min_distance_2.max(120.0);
+    params.normal_camera_min_distance = params.normal_camera_min_distance.max(145.0);
+    params.normal_camera_min_distance_2 = params.normal_camera_min_distance_2.max(145.0);
     params.swing_rate_x = 0.0;
     params.swing_rate_y = 0.0;
     params.normal_camera_vertical_angle = params.normal_camera_vertical_angle.max(-5.0_f32.to_radians());


### PR DESCRIPTION
The camera is further zoomed out by default now.
Global min camera zoom value increased 120 -> 145

Before:

![2023081013143400-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/b0d7bd71-6c2b-4657-8327-7076b46dc82c)

After:

![2023081013092800-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/98b0ca6f-9400-4792-a390-4bfbcb2f481d)

To be merged with HDR-Development/hdr-private#435
