### PR TITLE
Samuses hotfix

### DIFF
--- a/romfs/source/fighter/samus/param/vl.prcxml
+++ b/romfs/source/fighter/samus/param/vl.prcxml
@@ -76,7 +76,7 @@
     <struct index="0">
       <float hash="sp_lw_ar_vy0">1.28</float>
       <float hash="sp_lw_bj_ang_max">50</float>
-      <float hash="sp_lw_bj_spd0">2.33</float>
+      <float hash="sp_lw_bj_spd0">1.75</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/samusd/param/vl.prcxml
+++ b/romfs/source/fighter/samusd/param/vl.prcxml
@@ -81,7 +81,7 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
-      <float hash="sjump_ar_vy0">2.5</float>
+      <float hash="sjump_ar_vy0">2.85</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Samus and Dark Samus recently had their ground and air physics swapped, but I had forgotten to account for the height gain from Samus's bomb explosion

Also fixes Dark Samus's up special not being correctly swapped height-wise

## Samus
### Bomb
 - [-] Bounce Height (explosion): 2.33 -> 1.75

## Dark Samus
### Screw Attack
 - [+] Initial Speed: 2.5 -> 2.85