### PR TITLE
Implement Blast Attack

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -863,6 +863,8 @@ pub mod vars {
         }
         pub mod status {
             // flags
+            pub const SPECIAL_N_BLAST_ATTACK: i32 = 0x1100;
+
             pub const PULSE_HITBOX: i32 = 0x1100;
 
             pub const SPECIAL_S_HOP: i32 = 0x1100;

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -1,6 +1,7 @@
 use super::*;
 use globals::*;
 mod special_hi_h;
+mod sonic;
  
 pub fn install() {
     smashline::install_agent_init_callbacks!(kirby_init);
@@ -10,6 +11,7 @@ pub fn install() {
     );
 
     special_hi_h::install();
+    sonic::install();
 }
 
 pub fn add_statuses() {

--- a/fighters/kirby/src/status/sonic.rs
+++ b/fighters/kirby/src/status/sonic.rs
@@ -1,0 +1,112 @@
+use super::*;
+use globals::*;
+use smashline::*;
+
+
+pub fn install() {
+    install_status_scripts!(
+        main_special_n,
+        pre_special_n_homing_start
+    );
+}
+
+#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_SONIC_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn main_special_n(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        hash40("special_n_start")
+    }
+    else {
+        hash40("special_air_n_start")
+    };
+    FighterMotionModuleImpl::change_motion_kirby_copy(
+        fighter.module_accessor,
+        Hash40::new_raw(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    fighter.set_situation(SITUATION_KIND_AIR.into());
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_FORCE_LOUPE);
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_SONIC_INSTANCE_WORK_FLAG_SPECIAL_N_FALL);
+    if !StopModule::is_stop(fighter.module_accessor) {
+        special_n_substatus(fighter);
+    }
+    fighter.global_table[SUB_STATUS2].assign(&L2CValue::Ptr(special_n_substatus as *const () as _));
+    fighter.main_shift(special_n_main_loop)
+}
+
+unsafe extern "C" fn special_n_substatus(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let attack_frame_coeff = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_attack_frame_coeff"));
+    let ratio = 1.0 / attack_frame_coeff;
+    let mut advance_counter = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    advance_counter += ratio;
+    WorkModule::set_float(fighter.module_accessor, advance_counter, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    let auto_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_auto_attack_frame"));
+    if auto_attack_frame as f32 <= advance_counter {
+        fighter.global_table[SUB_STATUS2].assign(&L2CValue::I32(0));
+        fighter.global_table[SUB_STATUS].assign(&L2CValue::I32(0));
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if MotionModule::is_end(fighter.module_accessor) {
+        FighterMotionModuleImpl::change_motion_kirby_copy(
+            fighter.module_accessor,
+            Hash40::new("special_n_spin"),
+            0.0,
+            1.0,
+            false,
+            0.0,
+            false,
+            false
+        );
+        return fighter.main_shift(special_n_main_loop2);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_n_main_loop2(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let advance_counter = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    let enable_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_enable_attack_frame"));
+    let auto_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_auto_attack_frame"));
+    let attack_frame_diff = advance_counter - enable_attack_frame as f32;
+    let mut add_power = 0.0;
+    if 0.0 < attack_frame_diff {
+        let auto_frame_diff = auto_attack_frame - auto_attack_frame;
+        let ratio = attack_frame_diff / auto_frame_diff as f32;
+        add_power = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_add_attack_power"));
+        add_power *= ratio;
+    }
+    WorkModule::set_float(fighter.module_accessor, add_power, *FIGHTER_SONIC_INSTANCE_WORK_ID_FLOAT_SPECIAL_N_ADD_ATTACK_POWER);
+    if auto_attack_frame as f32 <= advance_counter {
+        fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_SONIC_SPECIAL_N_HOMING_START.into(), false.into());
+        return 0.into();
+    }
+    let pad_flag = fighter.global_table[PAD_FLAG].get_i32();
+    if 5.0 <= advance_counter {
+        if pad_flag & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0 {
+            WorkModule::set_float(fighter.module_accessor, 0.0, *FIGHTER_SONIC_INSTANCE_WORK_ID_FLOAT_SPECIAL_N_ADD_ATTACK_POWER);
+            VarModule::on_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK);
+            fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_SONIC_SPECIAL_N_HOMING_START.into(), true.into());
+        }
+    }
+    if enable_attack_frame as f32 <= advance_counter {
+        if pad_flag & *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER != 0 {
+            fighter.change_status(FIGHTER_KIRBY_STATUS_KIND_SONIC_SPECIAL_N_HOMING_START.into(), true.into());
+        }
+    }
+    0.into()
+}
+
+#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_SONIC_SPECIAL_N_HOMING_START, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_special_n_homing_start(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let blast_attack = VarModule::is_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK);
+    let ret = original!(fighter);
+    VarModule::set_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK, blast_attack);
+    ret
+}

--- a/fighters/sonic/src/acmd/specials.rs
+++ b/fighters/sonic/src/acmd/specials.rs
@@ -246,10 +246,11 @@ unsafe fn sonic_special_air_lw_dash_game(agent: &mut L2CAgentBase) {
 unsafe fn sonic_special_n_homing_start_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
- if is_excute(fighter) {
-        SEARCH(fighter, 0, 0, Hash40::new("top"), 40.0, 0.0, 10.0, 10.0, None, None, None, *COLLISION_KIND_MASK_HIT, *HIT_STATUS_MASK_NORMAL, 1, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIEB, *COLLISION_PART_MASK_BODY_HEAD, false);
+    if !VarModule::is_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK) {
+        if is_excute(fighter) {
+            SEARCH(fighter, 0, 0, Hash40::new("top"), 40.0, 0.0, 10.0, 10.0, None, None, None, *COLLISION_KIND_MASK_HIT, *HIT_STATUS_MASK_NORMAL, 1, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIEB, *COLLISION_PART_MASK_BODY_HEAD, false);
         }
-
+    }
 }
 
 #[acmd_script( agent = "sonic", script = "game_specialnhoming" , category = ACMD_GAME , low_priority)]

--- a/fighters/sonic/src/status.rs
+++ b/fighters/sonic/src/status.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod dash;
+mod special_n;
 mod special_s;
 mod special_s_dash;
 mod special_lw_hold;
@@ -39,6 +40,7 @@ fn sonic_init(fighter: &mut L2CFighterCommon) {
 pub fn install() {
     install_agent_init_callbacks!(sonic_init);
     dash::install();
+    special_n::install();
     special_s::install();
     special_s_dash::install();
     special_lw_hold::install();

--- a/fighters/sonic/src/status/special_n.rs
+++ b/fighters/sonic/src/status/special_n.rs
@@ -1,0 +1,112 @@
+use super::*;
+use globals::*;
+use smashline::*;
+
+
+pub fn install() {
+    install_status_scripts!(
+        main_special_n,
+        pre_special_n_homing_start
+    );
+}
+
+#[status_script(agent = "sonic", status = FIGHTER_STATUS_KIND_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn main_special_n(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let mot = if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        hash40("special_n_start")
+    }
+    else {
+        hash40("special_air_n_start")
+    };
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new_raw(mot),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    fighter.set_situation(SITUATION_KIND_AIR.into());
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_FORCE_LOUPE);
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_SONIC_INSTANCE_WORK_FLAG_SPECIAL_N_FALL);
+    if !StopModule::is_stop(fighter.module_accessor) {
+        special_n_substatus(fighter);
+    }
+    fighter.global_table[SUB_STATUS2].assign(&L2CValue::Ptr(special_n_substatus as *const () as _));
+    fighter.main_shift(special_n_main_loop)
+}
+
+unsafe extern "C" fn special_n_substatus(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let attack_frame_coeff = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_attack_frame_coeff"));
+    let ratio = 1.0 / attack_frame_coeff;
+    let mut advance_counter = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    advance_counter += ratio;
+    WorkModule::set_float(fighter.module_accessor, advance_counter, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    let auto_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_auto_attack_frame"));
+    if auto_attack_frame as f32 <= advance_counter {
+        fighter.global_table[SUB_STATUS2].assign(&L2CValue::I32(0));
+        fighter.global_table[SUB_STATUS].assign(&L2CValue::I32(0));
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if MotionModule::is_end(fighter.module_accessor) {
+        MotionModule::change_motion(
+            fighter.module_accessor,
+            Hash40::new("special_n_spin"),
+            0.0,
+            1.0,
+            false,
+            0.0,
+            false,
+            false
+        );
+        return fighter.main_shift(special_n_main_loop2);
+    }
+    0.into()
+}
+
+unsafe extern "C" fn special_n_main_loop2(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let advance_counter = WorkModule::get_float(fighter.module_accessor, *FIGHTER_SONIC_STATUS_SPECIAL_N_WORK_FLOAT_ADVANCE_COUNTER);
+    let enable_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_enable_attack_frame"));
+    let auto_attack_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_start_auto_attack_frame"));
+    let attack_frame_diff = advance_counter - enable_attack_frame as f32;
+    let mut add_power = 0.0;
+    if 0.0 < attack_frame_diff {
+        let auto_frame_diff = auto_attack_frame - auto_attack_frame;
+        let ratio = attack_frame_diff / auto_frame_diff as f32;
+        add_power = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_add_attack_power"));
+        add_power *= ratio;
+    }
+    WorkModule::set_float(fighter.module_accessor, add_power, *FIGHTER_SONIC_INSTANCE_WORK_ID_FLOAT_SPECIAL_N_ADD_ATTACK_POWER);
+    if auto_attack_frame as f32 <= advance_counter {
+        fighter.change_status(FIGHTER_SONIC_STATUS_KIND_SPECIAL_N_HOMING_START.into(), false.into());
+        return 0.into();
+    }
+    let pad_flag = fighter.global_table[PAD_FLAG].get_i32();
+    if 5.0 <= advance_counter {
+        if pad_flag & *FIGHTER_PAD_FLAG_ATTACK_TRIGGER != 0 {
+            WorkModule::set_float(fighter.module_accessor, 0.0, *FIGHTER_SONIC_INSTANCE_WORK_ID_FLOAT_SPECIAL_N_ADD_ATTACK_POWER);
+            VarModule::on_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK);
+            fighter.change_status(FIGHTER_SONIC_STATUS_KIND_SPECIAL_N_HOMING_START.into(), true.into());
+        }
+    }
+    if enable_attack_frame as f32 <= advance_counter {
+        if pad_flag & *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER != 0 {
+            fighter.change_status(FIGHTER_SONIC_STATUS_KIND_SPECIAL_N_HOMING_START.into(), true.into());
+        }
+    }
+    0.into()
+}
+
+#[status_script(agent = "sonic", status = FIGHTER_SONIC_STATUS_KIND_SPECIAL_N_HOMING_START, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_PRE)]
+pub unsafe fn pre_special_n_homing_start(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let blast_attack = VarModule::is_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK);
+    let ret = original!(fighter);
+    VarModule::set_flag(fighter.battle_object, vars::sonic::status::SPECIAL_N_BLAST_ATTACK, blast_attack);
+    ret
+}

--- a/romfs/source/fighter/sonic/param/vl.prcxml
+++ b/romfs/source/fighter/sonic/param/vl.prcxml
@@ -8,7 +8,12 @@
   </list>
   <list hash="param_special_n">
     <struct index="0">
-      <int hash="special_n_start_enable_attack_frame">18</int>
+      <int hash="special_n_start_enable_attack_frame">21</int>
+	<float hash="special_n_fail_rot">-25</float>
+	<float hash="special_n_fail_speed">3</float>
+	<int hash="special_n_fail_brake_start_frame">6</int>
+	<float hash="special_n_fail_x_brake">0.1</float>
+	<float hash="special_n_fail_y_brake">0.1</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
# Changelog

* Implements PM's Blast Attack. Pressing Attack on frame 5 or later will have Sonic blast downwards without any homing properties.

# Preview

Blast Attack is shown the first and third time Homing Attack is used in this video.

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/5079536f-6482-470f-b5e7-1c667c430883

