### PR TITLE
Slow pummel near-reversion

### DIFF
--- a/fighters/bayonetta/src/acmd/other.rs
+++ b/fighters/bayonetta/src/acmd/other.rs
@@ -660,7 +660,7 @@ unsafe fn game_catchattack(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 1.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 1.0, 361, 100, 30, 0, 5.0, 0.0, 12.0, 10.0, None, None, None, 1.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 0.6, 361, 100, 30, 0, 5.0, 0.0, 12.0, 10.0, None, None, None, 2.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
     }
     wait(lua_state, 1.0);
@@ -669,7 +669,7 @@ unsafe fn game_catchattack(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 4.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 1.0, 361, 100, 30, 0, 5.0, 0.0, 12.0, 10.0, None, None, None, 1.25, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 0.7, 361, 100, 30, 0, 5.0, 0.0, 12.0, 10.0, None, None, None, 2.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
         AttackModule::set_catch_only_all(boma, true, false);
     }
     wait(lua_state, 1.0);

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -39,10 +39,8 @@ unsafe fn attack_module_set_attack(module: u64, id: i32, group: i32, data: &mut 
             data.sub_shield = 0;
         }
         if (*boma).is_status(*FIGHTER_STATUS_KIND_CATCH_ATTACK) {
-            // damage
             if !VarModule::is_flag((*boma).object(), vars::common::status::PUMMEL_OVERRIDE_GLOBAL_STATS) {
-                data.power = 2.0;  // damage
-                data.stop_frame = 2.5;  // hitlag mul
+                data.stop_frame = 3.5;  // hitlag mul
             }
         }
     }

--- a/fighters/common/src/general_statuses/catch/catchattack.rs
+++ b/fighters/common/src/general_statuses/catch/catchattack.rs
@@ -17,10 +17,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_CatchAttack_Main)]
 unsafe fn status_CatchAttack_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if StatusModule::is_changing(fighter.module_accessor) {
-        MotionModule::set_rate(fighter.module_accessor, 0.5);
-    }
-    // Your pummel FAF is equal to your animation's length, with a cap at 12f
+    // Your pummel FAF is equal to your animation's length, with a cap at this param's number of frames
     let pummel_max_cancel_frame = ParamModule::get_int(fighter.object(), ParamType::Common, "pummel_max_cancel_frame") as f32;
     if fighter.global_table[CURRENT_FRAME].get_i32() as f32 + 1.0 >= MotionModule::end_frame(fighter.module_accessor).min(pummel_max_cancel_frame)
     || CancelModule::is_enable_cancel(fighter.module_accessor) {

--- a/fighters/packun/src/acmd/other.rs
+++ b/fighters/packun/src/acmd/other.rs
@@ -38,7 +38,7 @@ unsafe fn packun_catch_attack_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         let damage = if stance != 1 { 0.0 } else { 0.3 };
         let effect = if stance != 1 { Hash40::new("collision_attr_normal") } else { Hash40::new("collision_attr_purple") };
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.4 + damage, 361, 100, 30, 0, 5.0, 0.0, 10.0, 10.0, None, None, None, 2.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, effect, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.4 + damage, 361, 100, 30, 0, 5.0, 0.0, 10.0, 10.0, None, None, None, 3.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, effect, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_HEAD);
         AttackModule::set_catch_only_all(boma, true, false);
     }
     wait(lua_state, 1.0);

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -38,5 +38,5 @@
     <int hash="escape_air_slide_fall_frame">28</int>
     <int hash="tether_trump_landing_lag">30</int>
     <float hash="guard_off_motion_start_frame">3</float>
-    <int hash="pummel_max_cancel_frame">12</int>
+    <int hash="pummel_max_cancel_frame">8</int>
 </struct>


### PR DESCRIPTION
Pummel speed has been reverted to basically current beta behavior.

They have instead been given a high global hitlag multiplier to better emulate vanilla's pummel impact.