### PR TITLE
Steve - Victory Screen Fixes

### DIFF
--- a/fighters/pickel/src/opff.rs
+++ b/fighters/pickel/src/opff.rs
@@ -126,7 +126,7 @@ unsafe fn pickel_table_recreate(fighter: &mut L2CFighterCommon, boma: &mut Battl
     }
     if VarModule::is_flag(boma.object(), vars::pickel::instance::CAN_RESPAWN_TABLE)
     && status_kind == *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_WAIT // if steve is in stationary mining status
-    && MotionModule::frame(boma) <= 5.0 //during first 5 frames of animation
+    && MotionModule::frame(boma) <= 5.0 // during first 5 frames of animation
     && ![*FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_WALK, *FIGHTER_PICKEL_STATUS_KIND_SPECIAL_N1_WALK_BACK].contains(&prev_status)  // and is not returning to still from a walking mine
     && ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_GUARD) { 
         StatusModule::change_status_force(boma, *FIGHTER_PICKEL_STATUS_KIND_RECREATE_TABLE, true); 


### PR DESCRIPTION
Assets for this PR:  [assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/12491943/assets.zip)

___

This is a small PR to adjust the camera on a couple of Steve's victory animations to account for his increased size in HDR. Before, his new size would cause him to awkwardly stick out of frame.

# Before:
 
![Screenshot 2023-08-31 200951](https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/36df96d3-05e8-404b-a300-2d0b7a483207) 
![Screenshot 2023-08-31 200847](https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/2047df3b-569a-4123-b6bc-93ae387bd55b)

# After:

![Screenshot 2023-08-31 200333](https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/1501e362-5702-4529-beb9-5d052c6bdef4)
![Screenshot 2023-08-31 200440](https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/b9e7ff79-9e80-46b5-9bf5-edf8699dae92)


