### PR TITLE
Intangibility Corrections/Adjustments

### DIFF
--- a/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
@@ -48,6 +48,8 @@ appeal_s_r:
 special_lw:
   blend_frames: 3
   extra:
+    xlu_start: 0
+    xlu_end: 0
     intangible_end_frame: 15
     cancel_frame: 66
 attack_hi3:

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -27,6 +27,13 @@ attack_lw3:
 special_lw:
   flags:
     move: false
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 attack_hi3:
   extra:
     cancel_frame: 34

--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -52,6 +52,14 @@ special_s_end:
 attack_air_hi:
   extra:
     cancel_frame: 33
+special_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 special_s_hit_end:
   extra:
     cancel_frame: 23

--- a/romfs/source/fighter/fox/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/fox/motion/body/motion_patch.yaml
@@ -47,6 +47,14 @@ special_air_lw_start:
   extra:
     intangible_start_frame: 0
     intangible_end_frame: 0
+special_lw_start_l:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw_start_l:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 catch_attack:
   extra:
     cancel_frame: 0

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -57,3 +57,11 @@ landing_fall_special:
 catch_attack:
   extra:
     cancel_frame: 0
+special_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0

--- a/romfs/source/fighter/ike/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ike/motion/body/motion_patch.yaml
@@ -74,6 +74,14 @@ attack_air_hi:
 attack_s4_hold:
 attack_hi4_hold:
 attack_lw4_hold:
+special_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 special_air_s_attack:
   extra:
     cancel_frame: 38

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -50,6 +50,14 @@ attack_air_f:
 attack_air_n:
   extra:
     cancel_frame: 51
+special_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 special_hi2_f:
   extra:
     intangible_start_frame: 0

--- a/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
@@ -44,6 +44,12 @@ special_lw:
     move: false
   extra:
     cancel_frame: 64
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 attack_hi3:
   extra:
     cancel_frame: 28

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -39,6 +39,13 @@ attack_lw4:
 special_lw:
   flags:
     move: false
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 attack_hi3:
 attack_dash:
   extra:

--- a/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
@@ -57,6 +57,22 @@ attack_100_end:
   extra:
     cancel_frame: 37
 attack_lw4_hold:
+special_lw2_start:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw2_start:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_lw3:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw3:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 special_lw2_landing:
   extra:
     cancel_frame: 16

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -35,9 +35,6 @@ attack_hi3:
 attack_s4_s:
   extra:
     cancel_frame: 55
-special_lw1:
-  extra:
-    intangible_start_frame: 5
 attack_air_f:
   extra:
     cancel_frame: 41
@@ -62,12 +59,17 @@ attack_s4_hold:
 special_s3_1_hi:
   extra:
     cancel_frame: 41
-special_air_lw1:
-  extra:
-    intangible_start_frame: 5
 special_s3_1_lw:
   extra:
     cancel_frame: 41
+special_lw1:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw1:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 special_lw1_hit:
   extra:
     cancel_frame: 50

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -62,3 +62,11 @@ attack_s4_hold:
 catch_attack:
   extra:
     cancel_frame: 0
+special_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -30,3 +30,12 @@ attack_air_hi:
 catch_attack:
   extra:
     cancel_frame: 0
+special_lw:
+  extra:
+    xlu_start: 1
+    xlu_end: 2
+special_air_lw:
+  extra:
+    xlu_start: 1
+    xlu_end: 2
+

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -54,3 +54,11 @@ special_air_n_cancel:
 catch_attack:
   extra:
     cancel_frame: 0
+special_lw_start:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw_start:
+  extra:
+    xlu_start: 0
+    xlu_end: 0

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -33,6 +33,13 @@ attack_lw3:
 special_lw:
   flags:
     move: false
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 attack_hi3:
   extra:
     cancel_frame: 34

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -38,6 +38,14 @@ attack_s3_s:
 attack_air_f:
   extra:
     cancel_frame: 36
+special_n:
+  extra:
+    xlu_start: 5
+    xlu_end: 8
+special_air_n:
+  extra:
+    xlu_start: 5
+    xlu_end: 8
 special_s_throw_lw:
   extra:
     cancel_frame: 31

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -61,3 +61,11 @@ attack_s4_lw:
 catch_attack:
   extra:
     cancel_frame: 0
+special_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0

--- a/romfs/source/fighter/trail/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/trail/motion/body/motion_patch.yaml
@@ -45,3 +45,11 @@ throw_lw:
 catch_attack:
   extra:
     cancel_frame: 0
+special_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw:
+  extra:
+    xlu_start: 0
+    xlu_end: 0

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -79,6 +79,14 @@ special_air_lw_start:
   extra:
     intangible_start_frame: 0
     intangible_end_frame: 0
+special_lw_start_l:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+special_air_lw_start_l:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 catch_attack:
   extra:
     cancel_frame: 0


### PR DESCRIPTION
Intangibility corrections to the cast that were previously removed with recent motion list changes. Along with that, some characters have had their intangibility off of certain special moves removed, namely counters.
Characters included are:
- Fox
- Wolf
- Jigglypuff
- Isabelle
- Bayonetta
- Roy
- Marth
- Ike
- Chrom
- Greninja
- Joker
- Little Mac
- Mii Swordsman
- Mii Brawler
- Robin
- Shulk
- Sora