### PR TITLE
Corrin followup adjustments

### DIFF
--- a/fighters/kamui/src/acmd/specials.rs
+++ b/fighters/kamui/src/acmd/specials.rs
@@ -395,12 +395,12 @@ unsafe fn kamui_special_hi_game (fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 2, Hash40::new("rot"), 3.0, 65, 170, 0, 70, 6.5, 0.0, 3.5, -7.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
 		ATTACK(fighter, 1, 2, Hash40::new("rot"), 3.0, 65, 170, 0, 70, 6.5, 0.0, 3.5, 7.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
     }
-	wait(lua_state, 2.0);
+	frame(lua_state, 34.0);
 	if is_excute(fighter) {
 		AttackModule::clear_all(fighter.module_accessor);
 		notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
 	}
-	frame(lua_state, 38.0);
+	frame(lua_state, 36.0);
 	if is_excute(fighter) {
 		WorkModule::off_flag(fighter.module_accessor, *FIGHTER_KAMUI_STATUS_SPECIAL_HI_FLAG_TILT_BODY_ON);
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_KAMUI_STATUS_SPECIAL_HI_FLAG_AIR_CONTROL);

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -2086,13 +2086,14 @@
     <!-- CORRIN -->
     <struct index="59">
       <float hash="walk_speed_max">1.228</float>
-      <float hash="ground_brake">0.0625</float>
+      <float hash="ground_brake">0.0825</float>
       <float hash="dash_speed">1.763</float>
       <float hash="run_accel_mul">0.04238</float>
       <float hash="run_accel_add">0.02</float>
       <float hash="run_speed_max">1.68</float>
       <int hash="jump_squat_frame">4</int>
       <float hash="jump_speed_x">1</float>
+      <float hash="jump_speed_x_mul">0.75</float>
       <float hash="jump_speed_x_max">1.3</float>
       <float hash="jump_initial_y">10.6071</float>
       <float hash="air_accel_x_mul">0.027</float>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -2087,10 +2087,10 @@
     <struct index="59">
       <float hash="walk_speed_max">1.228</float>
       <float hash="ground_brake">0.0825</float>
-      <float hash="dash_speed">1.763</float>
+      <float hash="dash_speed">1.7215</float>
       <float hash="run_accel_mul">0.04238</float>
       <float hash="run_accel_add">0.02</float>
-      <float hash="run_speed_max">1.68</float>
+      <float hash="run_speed_max">1.7215</float>
       <int hash="jump_squat_frame">4</int>
       <float hash="jump_speed_x">1</float>
       <float hash="jump_speed_x_mul">0.75</float>

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -72,7 +72,7 @@ special_s_wall_jump:
 special_air_hi:
   extra:
     intangible_start_frame: 10
-    intangible_end_frame: 17
+    intangible_end_frame: 18
 special_lw_hit:
   extra:
     intangible_start_frame: 0

--- a/romfs/source/fighter/kamui/param/vl.prcxml
+++ b/romfs/source/fighter/kamui/param/vl.prcxml
@@ -18,11 +18,11 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="dir_mul">23</float>
-      <float hash="special_hi_pass_mul">1.35</float>
-      <float hash="special_air_hi_pass_mul">1.35</float>
+      <float hash="special_hi_pass_mul">1.4</float>
+      <float hash="special_air_hi_pass_mul">1.4</float>
       <float hash="fall_x_mul">0.8</float>
       <float hash="end_air_brake_x">0.01</float>
-      <float hash="end_air_accel_y">0.1</float>
+      <float hash="end_air_accel_y">0.075</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
## Changelog

### General:
 - [-] Initial Dash Speed: 1.763 -> 1.7215
 - [+] Run Speed: 1.68 -> 1.7215
 - [/] Ground Friction: 0.0625 -> 0.0825
 - [/] Ground to Air Multiplier: 0.9x -> 0.75x
 
### Dragon Ascent:
 - [+] Can drift 2 frames sooner after reaching the peak
 - [+] Height Multiplier: 1.35x -> 1.4x
 - [/] Gravity: 0.1 -> 0.075
 - [+] Intangibility Duration (air): F10-17 -> F10-18
 - [+] Hitbox Duration (launcher): F29-30 -> F29-33