### PR TITLE
DACUS rework

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -242,6 +242,7 @@ pub mod vars {
             pub const ECB_CENTER_Y_OFFSET: i32 = 0x0019;
             pub const DASH_HIP_OFFSET_X: i32 = 0x0020;
             pub const RUN_HIP_OFFSET_X: i32 = 0x0021;
+            pub const DACUS_TRANSITION_SPEED: i32 = 0x0022;
         }
         pub mod status {
             // flags

--- a/fighters/common/src/general_statuses/attack/attackdash.rs
+++ b/fighters/common/src/general_statuses/attack/attackdash.rs
@@ -164,10 +164,10 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
             }
         }
     }
-    if (2..9).contains(&fighter.status_frame()) {
-        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("MOTION: {}", speed_x);
-    }
+    // if (2..9).contains(&fighter.status_frame()) {
+    //     let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+    //     println!("MOTION: {}", speed_x);
+    // }
     // This block checks if you want to enable air drift. This code will only run once, and only while in the air,
     // but it enables another flag that will be checked when your situation changes and renable the right kinetic type there.
     if VarModule::is_flag(fighter.battle_object, vars::common::status::ATTACK_DASH_ENABLE_AIR_DRIFT)
@@ -276,20 +276,15 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
     if sub_attack_dash_is_attackhi4_cancel(fighter) {
         VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_DACUS);
         let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("DACUS TRANSITION");
         let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
         let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-        println!("Unadjusted speed: {}", speed_x);
-        println!("speed.abs: {}", speed_x.abs());
-        println!("min: {}, max: {}", min_speed, max_speed);
+        //println!("Unadjusted speed: {}", speed_x);
         let dacus_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacus_mul");
         if !(min_speed..max_speed).contains(&speed_x.abs()) {
             speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-            println!("multiplied speed: {}", speed_x);
         }
         speed_x = speed_x * dacus_mul;
-        println!("Adjusted speed: {}", speed_x);
-        println!();
+        //println!("Adjusted speed: {}", speed_x);
         VarModule::set_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED, speed_x);
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
@@ -300,20 +295,15 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
     if sub_attack_dash_is_attacklw4_cancel(fighter) {
         VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_DACUS);
         let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("DACDS TRANSITION");
         let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
         let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-        println!("Unadjusted speed: {}", speed_x);
-        println!("speed.abs: {}", speed_x.abs());
-        println!("min: {}, max: {}", min_speed, max_speed);
+        //println!("Unadjusted speed: {}", speed_x);
         let dacds_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacds_mul");
         if !(min_speed..max_speed).contains(&speed_x.abs()) {
             speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-            println!("multiplied speed: {}", speed_x);
         }
         speed_x = speed_x * dacds_mul;
-        println!("Adjusted speed: {}", speed_x);
-        println!();
+        //println!("Adjusted speed: {}", speed_x);
         VarModule::set_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED, speed_x);
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_LW4_START),

--- a/fighters/common/src/general_statuses/attack/attackdash.rs
+++ b/fighters/common/src/general_statuses/attack/attackdash.rs
@@ -164,6 +164,10 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
             }
         }
     }
+    if (2..9).contains(&fighter.status_frame()) {
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("MOTION: {}", speed_x);
+    }
     // This block checks if you want to enable air drift. This code will only run once, and only while in the air,
     // but it enables another flag that will be checked when your situation changes and renable the right kinetic type there.
     if VarModule::is_flag(fighter.battle_object, vars::common::status::ATTACK_DASH_ENABLE_AIR_DRIFT)
@@ -271,6 +275,22 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
     let cat1 = fighter.global_table[CMD_CAT1].get_i32();
     if sub_attack_dash_is_attackhi4_cancel(fighter) {
         VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_DACUS);
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("DACUS TRANSITION");
+        let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
+        let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
+        println!("Unadjusted speed: {}", speed_x);
+        println!("speed.abs: {}", speed_x.abs());
+        println!("min: {}, max: {}", min_speed, max_speed);
+        let dacus_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacus_mul");
+        if !(min_speed..max_speed).contains(&speed_x.abs()) {
+            speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
+            println!("multiplied speed: {}", speed_x);
+        }
+        speed_x = speed_x * dacus_mul;
+        println!("Adjusted speed: {}", speed_x);
+        println!();
+        VarModule::set_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED, speed_x);
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_HI4_START),
             L2CValue::Bool(true)
@@ -279,6 +299,22 @@ unsafe extern "C" fn status_AttackDash_Main(fighter: &mut L2CFighterCommon) -> L
     }
     if sub_attack_dash_is_attacklw4_cancel(fighter) {
         VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_DACUS);
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("DACDS TRANSITION");
+        let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
+        let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
+        println!("Unadjusted speed: {}", speed_x);
+        println!("speed.abs: {}", speed_x.abs());
+        println!("min: {}, max: {}", min_speed, max_speed);
+        let dacds_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacds_mul");
+        if !(min_speed..max_speed).contains(&speed_x.abs()) {
+            speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
+            println!("multiplied speed: {}", speed_x);
+        }
+        speed_x = speed_x * dacds_mul;
+        println!("Adjusted speed: {}", speed_x);
+        println!();
+        VarModule::set_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED, speed_x);
         fighter.change_status(
             L2CValue::I32(*FIGHTER_STATUS_KIND_ATTACK_LW4_START),
             L2CValue::Bool(true)

--- a/fighters/common/src/general_statuses/attack/attackdash.rs
+++ b/fighters/common/src/general_statuses/attack/attackdash.rs
@@ -108,8 +108,8 @@ unsafe extern "C" fn sub_attack_dash_uniq(fighter: &mut L2CFighterCommon, arg: L
 
         // Add one because it is 0 based
         let current_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_DASH_WORK_INT_FRAME) + 1;
-        let start_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "dacus_enable.start_frame");
-        let end_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "dacus_enable.end_frame");
+        let start_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "dacus.start_frame");
+        let end_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "dacus.end_frame");
         if start_frame <= current_frame && current_frame < end_frame {
             VarModule::off_flag(fighter.battle_object, vars::common::status::ATTACK_DASH_CANCEL_DISABLE);
             WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_HI4_START);

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -153,11 +153,11 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     else {
         // This should only reduce the highest speed the dacds will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
         if StatusModule::is_changing(fighter.module_accessor) {
-            let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            //let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
             //println!("old motion speed: {}", spdx);
             let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
             sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, speed_x, 0.0);
-            let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            //let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
             //println!("new motion speed: {}", spx);
         }
         // Account for added STOP energy (only if the dacds has a non-default multiplier)

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -54,10 +54,6 @@ unsafe fn status_AttackHi4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
 
     if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_DACUS) {
         if sha_frame > 0 && !StopModule::is_stop(fighter.module_accessor) {
-            let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-            println!("UP SMASH MOTION: {}", speed_x);
-            speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-            println!("UP SMASH STOP: {}", speed_x);
             if fighter.sub_check_button_jump().get_bool() {
                 let script_name = fighter.status_attack()[0xf40d7b92u64]["attack_hi4"].get_hash();
                 MotionAnimcmdModule::call_script_single(fighter.module_accessor, *FIGHTER_ANIMCMD_EXPRESSION, script_name, -1);
@@ -70,35 +66,15 @@ unsafe fn status_AttackHi4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     else {
         // This should only reduce the highest speed the dacus will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
         if StatusModule::is_changing(fighter.module_accessor) {
-            println!();
-            println!("UP SMASH");
             let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-            println!("old stop speed: {}", spdx);
             let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
             sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, speed_x, 0.0);
             let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-            println!("new stop speed: {}", spx);
         }
-        // Account for added MOTION energy (only if the dacus has a non-default multiplier)
-        let dacus_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacus_mul");
-        if dacus_mul != 1.0 {
-            let mut motion = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-            if motion.abs() > 0.0 {
-                println!("extra motion energy found: {}", motion);
-                let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
-                let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-                if !(min_speed..max_speed).contains(&motion.abs()) {
-                    motion = motion.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-                    println!("multiplied motion: {}", motion);
-                }
-                motion = motion * dacus_mul;
-                sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, motion, 0.0);
-            }
-        }
-        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("DACUS MOTION: {}", speed_x);
-        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-        println!("DACUS STOP: {}", speed_x);
+        // let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        // println!("DACUS MOTION: {}", speed_x);
+        // speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+        // println!("DACUS STOP: {}", speed_x);
     }
     let log_attack_kind = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
     if sha_frame == 1 && !fighter.global_table[8].get_bool() && log_attack_kind > 0 {
@@ -164,10 +140,6 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     }
 
     if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_DACUS) {
-        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("DOWN SMASH MOTION: {}", speed_x);
-        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-        println!("DOWN SMASH STOP: {}", speed_x);
         if sha_frame > 0 && !StopModule::is_stop(fighter.module_accessor) {
             if fighter.sub_check_button_jump().get_bool() {
                 let script_name = fighter.status_attack()[0xf40d7b92u64]["attack_lw4"].get_hash();
@@ -181,36 +153,32 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     else {
         // This should only reduce the highest speed the dacds will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
         if StatusModule::is_changing(fighter.module_accessor) {
-            println!();
-            println!("DOWN SMASH");
             let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-            println!("old motion speed: {}", spdx);
+            //println!("old motion speed: {}", spdx);
             let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
             sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, speed_x, 0.0);
             let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-            println!("new motion speed: {}", spx);
+            //println!("new motion speed: {}", spx);
         }
         // Account for added STOP energy (only if the dacds has a non-default multiplier)
         let dacds_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacds_mul");
         if dacds_mul != 1.0 {
             let mut stop = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
             if stop.abs() > 0.0 {
-                println!("extra stop energy found: {}", stop);
+                //println!("extra stop energy: {}", stop);
                 let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
                 let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-                
                 if !(min_speed..max_speed).contains(&stop.abs()) {
                     stop = stop.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-                    println!("multiplied stop: {}", stop);
                 }
                 stop = stop * dacds_mul;
                 sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, stop, 0.0);
             }
         }
-        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
-        println!("DACDS MOTION: {}", speed_x);
-        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-        println!("DACDS STOP: {}", speed_x);
+        // let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        // println!("DACDS MOTION: {}", speed_x);
+        // speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+        // println!("DACDS STOP: {}", speed_x);
     }
     let log_attack_kind = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
     if sha_frame == 1 && !fighter.global_table[8].get_bool() && log_attack_kind > 0 {

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -54,6 +54,10 @@ unsafe fn status_AttackHi4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
 
     if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_DACUS) {
         if sha_frame > 0 && !StopModule::is_stop(fighter.module_accessor) {
+            let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            println!("UP SMASH MOTION: {}", speed_x);
+            speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+            println!("UP SMASH STOP: {}", speed_x);
             if fighter.sub_check_button_jump().get_bool() {
                 let script_name = fighter.status_attack()[0xf40d7b92u64]["attack_hi4"].get_hash();
                 MotionAnimcmdModule::call_script_single(fighter.module_accessor, *FIGHTER_ANIMCMD_EXPRESSION, script_name, -1);
@@ -65,21 +69,36 @@ unsafe fn status_AttackHi4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     }
     else {
         // This should only reduce the highest speed the dacus will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
-        if fighter.status_frame() == 1 {
-            let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-            let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
-            let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-            println!("Unadjusted speed: {}", speed_x);
-            println!("speed.abs: {}", speed_x.abs());
-            println!("min: {}, max: {}", min_speed, max_speed);
-            if !(min_speed..max_speed).contains(&speed_x.abs()) {
-                speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-                let dacus_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacus_mul");
-                println!("Adjusted speed: {}", speed_x * dacus_mul);
-                println!();
-                sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, speed_x * dacus_mul, 0.0);
+        if StatusModule::is_changing(fighter.module_accessor) {
+            println!();
+            println!("UP SMASH");
+            let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+            println!("old stop speed: {}", spdx);
+            let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
+            sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, speed_x, 0.0);
+            let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+            println!("new stop speed: {}", spx);
+        }
+        // Account for added MOTION energy (only if the dacus has a non-default multiplier)
+        let dacus_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacus_mul");
+        if dacus_mul != 1.0 {
+            let mut motion = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            if motion.abs() > 0.0 {
+                println!("extra motion energy found: {}", motion);
+                let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
+                let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
+                if !(min_speed..max_speed).contains(&motion.abs()) {
+                    motion = motion.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
+                    println!("multiplied motion: {}", motion);
+                }
+                motion = motion * dacus_mul;
+                sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, motion, 0.0);
             }
         }
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("DACUS MOTION: {}", speed_x);
+        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+        println!("DACUS STOP: {}", speed_x);
     }
     let log_attack_kind = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
     if sha_frame == 1 && !fighter.global_table[8].get_bool() && log_attack_kind > 0 {
@@ -145,6 +164,10 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     }
 
     if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_DACUS) {
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("DOWN SMASH MOTION: {}", speed_x);
+        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+        println!("DOWN SMASH STOP: {}", speed_x);
         if sha_frame > 0 && !StopModule::is_stop(fighter.module_accessor) {
             if fighter.sub_check_button_jump().get_bool() {
                 let script_name = fighter.status_attack()[0xf40d7b92u64]["attack_lw4"].get_hash();
@@ -156,22 +179,38 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
         }
     }
     else {
-        // This should only reduce the highest speed the dacus will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
-        if fighter.status_frame() == 1 {
-            let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
-            let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
-            let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
-            println!("Unadjusted speed: {}", speed_x);
-            println!("speed.abs: {}", speed_x.abs());
-            println!("min: {}, max: {}", min_speed, max_speed);
-            if !(min_speed..max_speed).contains(&speed_x.abs()) {
-                speed_x = speed_x.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
-                let dacds_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacds_mul");
-                println!("Adjusted speed: {}", speed_x * dacds_mul);
-                println!();
-                sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, speed_x * dacds_mul, 0.0);
+        // This should only reduce the highest speed the dacds will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
+        if StatusModule::is_changing(fighter.module_accessor) {
+            println!();
+            println!("DOWN SMASH");
+            let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            println!("old motion speed: {}", spdx);
+            let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
+            sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, speed_x, 0.0);
+            let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            println!("new motion speed: {}", spx);
+        }
+        // Account for added STOP energy (only if the dacds has a non-default multiplier)
+        let dacds_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "dacds_mul");
+        if dacds_mul != 1.0 {
+            let mut stop = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+            if stop.abs() > 0.0 {
+                println!("extra stop energy found: {}", stop);
+                let min_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.min_speed");
+                let max_speed = ParamModule::get_float(fighter.battle_object, ParamType::Common, "dacus.max_speed");
+                
+                if !(min_speed..max_speed).contains(&stop.abs()) {
+                    stop = stop.abs().clamp(min_speed, max_speed) * PostureModule::lr(fighter.module_accessor);
+                    println!("multiplied stop: {}", stop);
+                }
+                stop = stop * dacds_mul;
+                sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, stop, 0.0);
             }
         }
+        let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+        println!("DACDS MOTION: {}", speed_x);
+        speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
+        println!("DACDS STOP: {}", speed_x);
     }
     let log_attack_kind = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
     if sha_frame == 1 && !fighter.global_table[8].get_bool() && log_attack_kind > 0 {

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -153,7 +153,7 @@ unsafe fn status_AttackLw4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     else {
         // This should only reduce the highest speed the dacds will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
         if StatusModule::is_changing(fighter.module_accessor) {
-            let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
+            //let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
             //println!("old motion speed: {}", spdx);
             let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
             sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_MOTION, speed_x, 0.0);

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -66,10 +66,8 @@ unsafe fn status_AttackHi4Start_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     else {
         // This should only reduce the highest speed the dacus will reach (the first frame); it should still decrease at the same rate as those with a 1.0 mul
         if StatusModule::is_changing(fighter.module_accessor) {
-            let spdx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
             let speed_x = VarModule::get_float(fighter.object(), vars::common::instance::DACUS_TRANSITION_SPEED);
             sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, speed_x, 0.0);
-            let spx = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_STOP);
         }
         // let mut speed_x = fighter.get_speed_x(*FIGHTER_KINETIC_ENERGY_ID_MOTION);
         // println!("DACUS MOTION: {}", speed_x);

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -14,9 +14,11 @@
     <int hash="glide_toss_cancel_frame">5</int>
     <int hash="air_escape_snap_frame">5</int>
     <float hash="waveland_distance_threshold">6</float>
-    <struct hash="dacus_enable">
+    <struct hash="dacus">
         <int hash="start_frame">3</int>
         <int hash="end_frame">10</int>
+        <float hash="min_speed">0.0</float>
+        <float hash="max_speed">3.5</float>
     </struct>
     <int hash="dash_perfect_pivot_window">3</int>
     <float hash="perfect_pivot_speed_mul">-0.75</float>

--- a/romfs/source/fighter/common/hdr/param/fighter_param.xml
+++ b/romfs/source/fighter/common/hdr/param/fighter_param.xml
@@ -28,8 +28,8 @@
     <struct index="4">
       <hash40 hash="fighter_kind">SAMUSD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="5">
       <hash40 hash="fighter_kind">YOSHI</hash40>
@@ -52,8 +52,8 @@
     <struct index="8">
       <hash40 hash="fighter_kind">PIKACHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.85</float>
+      <float hash="dacds_mul">0.85</float>
     </struct>
     <struct index="9">
       <hash40 hash="fighter_kind">LUIGI</hash40>
@@ -88,8 +88,8 @@
     <struct index="14">
       <hash40 hash="fighter_kind">DAISY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.95</float>
+      <float hash="dacds_mul">0.95</float>
     </struct>
     <struct index="15">
       <hash40 hash="fighter_kind">KOOPA</hash40>
@@ -100,8 +100,8 @@
     <struct index="16">
       <hash40 hash="fighter_kind">SHEIK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="17">
       <hash40 hash="fighter_kind">ZELDA</hash40>
@@ -172,8 +172,8 @@
     <struct index="28">
       <hash40 hash="fighter_kind">GAMEWATCH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.8</float>
+      <float hash="dacds_mul">0.8</float>
     </struct>
     <struct index="29">
       <hash40 hash="fighter_kind">METAKNIGHT</hash40>
@@ -184,20 +184,20 @@
     <struct index="30">
       <hash40 hash="fighter_kind">PIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="31">
       <hash40 hash="fighter_kind">PITB</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="32">
       <hash40 hash="fighter_kind">SZEROSUIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacds_mul">0.95</float>
     </struct>
     <struct index="33">
       <hash40 hash="fighter_kind">WARIO</hash40>
@@ -220,8 +220,8 @@
     <struct index="36">
       <hash40 hash="fighter_kind">PZENIGAME</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="37">
       <hash40 hash="fighter_kind">PFUSHIGISOU</hash40>
@@ -244,8 +244,8 @@
     <struct index="40">
       <hash40 hash="fighter_kind">LUCAS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="41">
       <hash40 hash="fighter_kind">SONIC</hash40>
@@ -280,8 +280,8 @@
     <struct index="46">
       <hash40 hash="fighter_kind">TOONLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.95</float>
+      <float hash="dacds_mul">0.95</float>
     </struct>
     <struct index="47">
       <hash40 hash="fighter_kind">WOLF</hash40>
@@ -316,14 +316,14 @@
     <struct index="52">
       <hash40 hash="fighter_kind">LITTLEMAC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.775</float>
+      <float hash="dacds_mul">0.825</float>
     </struct>
     <struct index="53">
       <hash40 hash="fighter_kind">GEKKOUGA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="54">
       <hash40 hash="fighter_kind">PALUTENA</hash40>
@@ -394,14 +394,14 @@
     <struct index="65">
       <hash40 hash="fighter_kind">INKLING</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.875</float>
+      <float hash="dacds_mul">0.875</float>
     </struct>
     <struct index="66">
       <hash40 hash="fighter_kind">RIDLEY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="67">
       <hash40 hash="fighter_kind">SIMON</hash40>
@@ -436,8 +436,8 @@
     <struct index="72">
       <hash40 hash="fighter_kind">MIIFIGHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.75</float>
+      <float hash="dacds_mul">0.75</float>
     </struct>
     <struct index="73">
       <hash40 hash="fighter_kind">MIISWORDSMAN</hash40>
@@ -490,14 +490,14 @@
     <struct index="81">
       <hash40 hash="fighter_kind">PACKUN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.95</float>
+      <float hash="dacds_mul">0.95</float>
     </struct>
     <struct index="82">
       <hash40 hash="fighter_kind">JACK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="83">
       <hash40 hash="fighter_kind">BRAVE</hash40>
@@ -520,14 +520,14 @@
     <struct index="86">
       <hash40 hash="fighter_kind">MASTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.875</float>
+      <float hash="dacds_mul">0.875</float>
     </struct>
     <struct index="87">
       <hash40 hash="fighter_kind">TANTAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="88">
       <hash40 hash="fighter_kind">PICKEL</hash40>
@@ -539,7 +539,7 @@
       <hash40 hash="fighter_kind">EDGE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacds_mul">0.95</float>
     </struct>
     <struct index="90">
       <hash40 hash="fighter_kind">EFLAME</hash40>
@@ -550,20 +550,20 @@
     <struct index="91">
       <hash40 hash="fighter_kind">ELIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.9</float>
+      <float hash="dacds_mul">0.9</float>
     </struct>
     <struct index="92">
       <hash40 hash="fighter_kind">DEMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacds_mul">0.8</float>
     </struct>
     <struct index="93">
       <hash40 hash="fighter_kind">TRAIL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
-      <float hash="dacus_mul">1.0</float>
-      <float hash="dacds_mul">1.0</float>
+      <float hash="dacus_mul">0.925</float>
+      <float hash="dacds_mul">0.925</float>
     </struct>
   </list>
 </struct>

--- a/romfs/source/fighter/common/hdr/param/fighter_param.xml
+++ b/romfs/source/fighter/common/hdr/param/fighter_param.xml
@@ -4,378 +4,566 @@
     <struct index="0">
       <hash40 hash="fighter_kind">MARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="1">
       <hash40 hash="fighter_kind">DONKEY</hash40>
       <float hash="attack_dash_fall_speed_mul">0.25</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="2">
       <hash40 hash="fighter_kind">LINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="3">
       <hash40 hash="fighter_kind">SAMUS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="4">
       <hash40 hash="fighter_kind">SAMUSD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="5">
       <hash40 hash="fighter_kind">YOSHI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="6">
       <hash40 hash="fighter_kind">KIRBY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="7">
       <hash40 hash="fighter_kind">FOX</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="8">
       <hash40 hash="fighter_kind">PIKACHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="9">
       <hash40 hash="fighter_kind">LUIGI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="10">
       <hash40 hash="fighter_kind">NESS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="11">
       <hash40 hash="fighter_kind">CAPTAIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="12">
       <hash40 hash="fighter_kind">PURIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="13">
       <hash40 hash="fighter_kind">PEACH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="14">
       <hash40 hash="fighter_kind">DAISY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="15">
       <hash40 hash="fighter_kind">KOOPA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="16">
       <hash40 hash="fighter_kind">SHEIK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="17">
       <hash40 hash="fighter_kind">ZELDA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="18">
       <hash40 hash="fighter_kind">MARIOD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="19">
       <hash40 hash="fighter_kind">PICHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="20">
       <hash40 hash="fighter_kind">FALCO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="21">
       <hash40 hash="fighter_kind">MARTH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="22">
       <hash40 hash="fighter_kind">LUCINA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="23">
       <hash40 hash="fighter_kind">YOUNGLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="24">
       <hash40 hash="fighter_kind">GANON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="25">
       <hash40 hash="fighter_kind">MEWTWO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="26">
       <hash40 hash="fighter_kind">ROY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="27">
       <hash40 hash="fighter_kind">CHROM</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="28">
       <hash40 hash="fighter_kind">GAMEWATCH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="29">
       <hash40 hash="fighter_kind">METAKNIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="30">
       <hash40 hash="fighter_kind">PIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="31">
       <hash40 hash="fighter_kind">PITB</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="32">
       <hash40 hash="fighter_kind">SZEROSUIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="33">
       <hash40 hash="fighter_kind">WARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="34">
       <hash40 hash="fighter_kind">SNAKE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="35">
       <hash40 hash="fighter_kind">IKE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="36">
       <hash40 hash="fighter_kind">PZENIGAME</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="37">
       <hash40 hash="fighter_kind">PFUSHIGISOU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="38">
       <hash40 hash="fighter_kind">PLIZARDON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="39">
       <hash40 hash="fighter_kind">DIDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="40">
       <hash40 hash="fighter_kind">LUCAS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="41">
       <hash40 hash="fighter_kind">SONIC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="42">
       <hash40 hash="fighter_kind">DEDEDE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="43">
       <hash40 hash="fighter_kind">PIKMIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="44">
       <hash40 hash="fighter_kind">LUCARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="45">
       <hash40 hash="fighter_kind">ROBOT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="46">
       <hash40 hash="fighter_kind">TOONLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="47">
       <hash40 hash="fighter_kind">WOLF</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="48">
       <hash40 hash="fighter_kind">MURABITO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="49">
       <hash40 hash="fighter_kind">ROCKMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="50">
       <hash40 hash="fighter_kind">WIIFIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="51">
       <hash40 hash="fighter_kind">ROSETTA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="52">
       <hash40 hash="fighter_kind">LITTLEMAC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="53">
       <hash40 hash="fighter_kind">GEKKOUGA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="54">
       <hash40 hash="fighter_kind">PALUTENA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="55">
       <hash40 hash="fighter_kind">PACMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="56">
       <hash40 hash="fighter_kind">REFLET</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="57">
       <hash40 hash="fighter_kind">SHULK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="58">
       <hash40 hash="fighter_kind">KOOPAJR</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="59">
       <hash40 hash="fighter_kind">DUCKHUNT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="60">
       <hash40 hash="fighter_kind">RYU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="61">
       <hash40 hash="fighter_kind">KEN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="62">
       <hash40 hash="fighter_kind">CLOUD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="63">
       <hash40 hash="fighter_kind">KAMUI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="64">
       <hash40 hash="fighter_kind">BAYONETTA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="65">
       <hash40 hash="fighter_kind">INKLING</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="66">
       <hash40 hash="fighter_kind">RIDLEY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="67">
       <hash40 hash="fighter_kind">SIMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="68">
       <hash40 hash="fighter_kind">RICHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="69">
       <hash40 hash="fighter_kind">KROOL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="70">
       <hash40 hash="fighter_kind">SHIZUE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="71">
       <hash40 hash="fighter_kind">GAOGAEN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="72">
       <hash40 hash="fighter_kind">MIIFIGHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="73">
       <hash40 hash="fighter_kind">MIISWORDSMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="74">
       <hash40 hash="fighter_kind">MIIGUNNER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="75">
       <hash40 hash="fighter_kind">POPO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="76">
       <hash40 hash="fighter_kind">NANA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="77">
       <hash40 hash="fighter_kind">KOOPAG</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="78">
       <hash40 hash="fighter_kind">MIIENEMYF</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="79">
       <hash40 hash="fighter_kind">MIIENEMYS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="80">
       <hash40 hash="fighter_kind">MIIENEMYG</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="81">
       <hash40 hash="fighter_kind">PACKUN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="82">
       <hash40 hash="fighter_kind">JACK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="83">
       <hash40 hash="fighter_kind">BRAVE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="84">
       <hash40 hash="fighter_kind">BUDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="85">
       <hash40 hash="fighter_kind">DOLLY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="86">
       <hash40 hash="fighter_kind">MASTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="87">
       <hash40 hash="fighter_kind">TANTAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="88">
       <hash40 hash="fighter_kind">PICKEL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="89">
       <hash40 hash="fighter_kind">EDGE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="90">
       <hash40 hash="fighter_kind">EFLAME</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="91">
       <hash40 hash="fighter_kind">ELIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="92">
       <hash40 hash="fighter_kind">DEMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
     <struct index="93">
       <hash40 hash="fighter_kind">TRAIL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
+      <float hash="dacus_mul">1.0</float>
+      <float hash="dacds_mul">1.0</float>
     </struct>
   </list>
 </struct>


### PR DESCRIPTION
Reworks/adds logic for handling DACUS/DACDS speed

## Overview
- Currently, DACUS speed depends entirely on the motion energy of a character's dash attack on the frame the transition occurs. Ergo, the farther a character's animation shifts position during the frame a DACUS is performed, the farther they will slide
- Speed during DACUS is now capped at 3.5. As a reference, many of the more extreme DACUSes reached above 4.0 (max ground speed) when performed perfectly
- All fighters have been given separate multipliers for DACUS and DACDS for higher modularity
- Multipliers only apply on the first frame of the DACUS so that the speed can decrease at the same natural rate

## What these changes mean for actual gameplay and balance
- The vast majority of DACUSes are completely unaffected by these changes. Some that had slightly more motion energy than the new speed cap will travel slightly less, but the more egregious cases have been reduced appropriately in addition to the speed cap and are listed explicitly below
- The addition of multipliers opens the door to more granular balance for DACUSes and dash attacks. Rather than the former being tied to the latter, dash attack lengths can now be adjusted separately while still preserving the same length for their DACUS/DACDS and vice versa
- This PR only contains reductions to DACUSes that were seen as being too long. Expect further adjustments in the future, including buffing underwhelming DACUSes and/or dash attack lengths if warranted

## Technical note
- DACUS uses primarily STOP energy and DACDS uses MOTION to determine the sliding speed. However, certain characters have a bit of additional STOP energy during down smash specifically, resulting in a slightly longer DACDS compared to its DACUS. Said added values are accounted for and are also clamped accordingly and reduced where needed

## Non-default multipliers
The following characters have been given the corresponding multipliers. Any not listed have the default 1.0
- Pikachu: 0.85x
- Sheik: 0.9x
- Mr. Game and Watch: 0.8x
- Pit: 0.9x
- ZSS (dsmash only): 0.95x
- Squirtle: 0.9x
- Lucas: 0.9x
- Toon Link: 0.95x
- Little Mac (up/down smash): 0.775/0.825x
- Greninja: 0.9x
- Mii Brawler: 0.75x
- Dark Pit: 0.9x
- Inkling: 0.875x
- Daisy: 0.95x
- Ridley: 0.9x
- Dark Samus: 0.9x
- Piranha Plant: 0.95x
- Joker: 0.9x
- Byleth: 0.875x
- Min Min: 0.9x
- Sephiroth (dsmash only): 0.95x
- Mythra: 0.9x
- Kazuya (dsmash only): 0.8x
- Sora: 0.925x