### PR TITLE
Mythra Hair Animation Bug Fix

### DIFF
--- a/fighters/elight/src/status/special_hi_jump.rs
+++ b/fighters/elight/src/status/special_hi_jump.rs
@@ -14,7 +14,7 @@ unsafe fn special_hi_jump_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
         *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_FLOAT,
         0
     );
-
+ 
     FighterStatusModuleImpl::set_fighter_status_data(
         fighter.module_accessor,
         false,


### PR DESCRIPTION
Assets for this PR:

[hdr-pr-mythra-anim-fixes](https://github.com/HDR-Development/HewDraw-Remix/files/12641400/hdr-pr-mythra-anim-fixes.zip)

A rework / polishing up of all of Mythra's animations that previously caused her swing bones to become scrunched up. These animations in question included her Initial Dash, and the 3 Up b animations (which includes the initial jump for Up b-1 and the variations for Ray of Punishment and Chroma Dust.) Comparison gifs are below for quick visuals on these differences.

**Example Still Render**
**Before:**
![Up b bugged](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/b98c0ca0-f2c4-4fd2-b5d0-628a1450b0f4)
**After:**
![Up b fixed](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/01b90153-b8e2-47f6-9174-a0b34923b8cb)

**Initial Dash**
**Before:**
![Bugged Dash](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/ad2b3a0d-ad30-4063-87eb-6a93242a56b7)
**After:**
![Fixed Dash](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/81f0d2b7-0f19-483a-b4ee-1b7c2b5a2653)

**Up b-1**
**Before:**
![Jump Bugged](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/f3f3799f-5c20-4a5e-b8e1-130846527963)
**After:**
![Jump Fixed](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/ab24c353-1208-45ab-9a0d-6c3682015ea1)

**Ray of Punishment**
**Before:**
![Ray of Punishment Bugged](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/0f5b55a5-24d9-4dd8-b3fc-3a5851db62c3)
**After:**
![Ray of Punishment Fixed](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/822cd82b-8c39-4b7a-892f-d8b3d45b3809)

**Chroma Dust**
**Before:**
![Chroma Dust Bugged](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/c7aef18f-a499-4c15-8b57-f8643a36e60e)
**After:**
![Chroma Dust Fixed](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/bfbc0c36-1a48-4f82-aa48-0a5e0e6a0d50)
