### PR TITLE
Sonic Touchups

### DIFF
--- a/fighters/kirby/src/status/sonic.rs
+++ b/fighters/kirby/src/status/sonic.rs
@@ -77,7 +77,7 @@ unsafe extern "C" fn special_n_main_loop2(fighter: &mut L2CFighterCommon) -> L2C
     let attack_frame_diff = advance_counter - enable_attack_frame as f32;
     let mut add_power = 0.0;
     if 0.0 < attack_frame_diff {
-        let auto_frame_diff = auto_attack_frame - auto_attack_frame;
+        let auto_frame_diff = auto_attack_frame - enable_attack_frame;
         let ratio = attack_frame_diff / auto_frame_diff as f32;
         add_power = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("special_n_add_attack_power"));
         add_power *= ratio;

--- a/fighters/sonic/src/acmd/other.rs
+++ b/fighters/sonic/src/acmd/other.rs
@@ -213,6 +213,13 @@ unsafe fn escape_air_slide_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "sonic", script = "expression_wait4", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn expression_wait4(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        slope!(agent, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         escape_air_game,
@@ -224,7 +231,8 @@ pub fn install() {
         damageflylw_sound,
         damageflyn_sound,
         damageflyroll_sound,
-        damageflytop_sound
+        damageflytop_sound,
+        expression_wait4
     );
 }
 

--- a/fighters/sonic/src/status.rs
+++ b/fighters/sonic/src/status.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod wait;
 mod dash;
 mod special_n;
 mod special_s;
@@ -50,6 +51,7 @@ fn sonic_init(fighter: &mut L2CFighterCommon) {
 
 pub fn install() {
     install_agent_init_callbacks!(sonic_init);
+    wait::install();
     dash::install();
     special_n::install();
     special_s::install();

--- a/fighters/sonic/src/status/wait.rs
+++ b/fighters/sonic/src/status/wait.rs
@@ -1,0 +1,25 @@
+use super::*;
+use globals::*;
+use smashline::*;
+
+pub fn install() {
+  install_status_scripts!(
+    wait_main
+  );
+}
+
+#[status_script(agent = "sonic", status = FIGHTER_STATUS_KIND_WAIT, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn wait_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.sub_wait_common();
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("wait_4"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+    fighter.sub_shift_status_main(L2CValue::Ptr(L2CFighterCommon_status_Wait_Main as *const () as _))
+}

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -178,3 +178,32 @@ special_air_s_boost_end:
 catch_attack:
   extra:
     cancel_frame: 0
+wait_4:
+  game_script: game_wait4
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: a00wait4.nuanmb
+  scripts:
+  - expression_wait4
+  - sound_wait4
+  - effect_wait4
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 0
+    freeze_during_hitstop: false


### PR DESCRIPTION
# Changelog

## Idle

Uses a new idle animation by Gryz.

## Homing Attack

Fixes a bug where Kirby's version of Homing Attack would deal infinite damage and glitch the game.

## Spin Boost

Sonic now retains momentum during a ledge cancel.

[sonic_assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/12694109/sonic_assets.zip)
