### PR TITLE
Use heavy landing animations for jumpsquat

### DIFF
--- a/fighters/common/src/function_hooks/change_motion.rs
+++ b/fighters/common/src/function_hooks/change_motion.rs
@@ -16,8 +16,7 @@ unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash:
     if boma.is_fighter() {
         // Starts landing animations on frame 2
         // This is a purely aesthetic change, makes for snappier landings
-        if [Hash40::new("landing_heavy"),
-            Hash40::new("landing_air_n"),
+        if [Hash40::new("landing_air_n"),
             Hash40::new("landing_air_f"),
             Hash40::new("landing_air_b"),
             Hash40::new("landing_air_hi"),
@@ -25,6 +24,9 @@ unsafe fn change_motion_hook(boma: &mut BattleObjectModuleAccessor, motion_hash:
             Hash40::new("landing_fall_special")].contains(&motion_hash)
         {
             start_frame = 1.0;
+        }
+        else if motion_hash == Hash40::new("landing_heavy") {
+            start_frame = 3.0;
         }
 
         // Allows a frame-perfect edge canceled waveland to still generate landing smoke GFX

--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -997,6 +997,14 @@ unsafe fn reset_flick_y(boma: &mut BattleObjectModuleAccessor) {
     call_original!(boma);
 }
 
+#[skyline::hook(replace=ControlModule::set_rumble)]
+unsafe fn set_rumble_hook(boma: &mut BattleObjectModuleAccessor, kind: smash::phx::Hash40, arg3: i32, arg4: bool, arg5: u32) {
+    if boma.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        return;
+    }
+    call_original!(boma, kind, arg3, arg4, arg5);
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hook!(is_throw_stick);
@@ -1036,6 +1044,7 @@ pub fn install() {
         exec_command_reset_attack_air_kind_hook,
         reset_flick_x,
         reset_flick_y,
+        set_rumble_hook,
     );
     skyline::nro::add_hook(nro_hook);
 }

--- a/fighters/common/src/function_hooks/effect.rs
+++ b/fighters/common/src/function_hooks/effect.rs
@@ -231,6 +231,11 @@ unsafe fn FOOT_EFFECT_FLIP_hook(lua_state: u64) {
 
 #[skyline::hook(replace=smash::app::sv_animcmd::LANDING_EFFECT)]
 unsafe fn LANDING_EFFECT_hook(lua_state: u64) {
+    let boma = smash::app::sv_system::battle_object_module_accessor(lua_state);
+    if boma.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        return;
+    }
+
     let mut l2c_agent: L2CAgent = L2CAgent::new(lua_state);
 
     let mut hitbox_params: [L2CValue ; 16] = [L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void()];
@@ -262,6 +267,11 @@ unsafe fn LANDING_EFFECT_hook(lua_state: u64) {
 
 #[skyline::hook(replace=smash::app::sv_animcmd::LANDING_EFFECT_FLIP)]
 unsafe fn LANDING_EFFECT_FLIP_hook(lua_state: u64) {
+    let boma = smash::app::sv_system::battle_object_module_accessor(lua_state);
+    if boma.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        return;
+    }
+
     let mut l2c_agent: L2CAgent = L2CAgent::new(lua_state);
 
     let mut hitbox_params: [L2CValue ; 18] = [L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void(), L2CValue::new_void()];

--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -149,7 +149,7 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
         // Coupled with "landing_heavy" change in change_motion hook
         // Because we start heavy landing anims on f2 rather than f1, we need to push back the heavy landing FAF by 1 frame so it is accurate to the defined per-character param
         if x1 == hash40("landing_frame") {
-            return original!()(x0, hash40("landing_frame"), 0) + 1.0;
+            return original!()(x0, hash40("landing_frame"), 0) + 3.0;
         }
 
         // Ken aerial hadouken modified offsets for aerial version

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -23,6 +23,7 @@ pub mod collision;
 pub mod camera;
 pub mod shotos;
 pub mod aura;
+pub mod sound;
 
 #[repr(C)]
 pub struct TempModule {
@@ -754,6 +755,7 @@ pub fn install() {
     camera::install();
     shotos::install();
     aura::install();
+    sound::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/common/src/function_hooks/sound.rs
+++ b/fighters/common/src/function_hooks/sound.rs
@@ -1,0 +1,29 @@
+use super::*;
+use globals::*;
+
+#[skyline::hook(replace=smash::app::sv_animcmd::PLAY_LANDING_SE)]
+unsafe fn PLAY_LANDING_SE_hook(lua_state: u64) {
+    let boma = smash::app::sv_system::battle_object_module_accessor(lua_state);
+    if boma.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        return;
+    }
+
+    original!()(lua_state);
+}
+
+#[skyline::hook(replace=smash::app::sv_animcmd::PLAY_SE)]
+unsafe fn PLAY_SE_hook(lua_state: u64) {
+    let boma = smash::app::sv_system::battle_object_module_accessor(lua_state);
+    if boma.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        return;
+    }
+
+    original!()(lua_state);
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        PLAY_LANDING_SE_hook,
+        PLAY_SE_hook,
+    );
+}

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -445,5 +445,5 @@ unsafe fn sub_jump_squat_uniq_process_init_param(fighter: &mut L2CFighterCommon,
     if motion_rate < 1.0 {
         motion_rate += 0.001;
     }
-    MotionModule::change_motion(fighter.module_accessor, Hash40::new("landing_heavy"), 1.0, motion_rate, false, 0.0, false, false);
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("landing_heavy"), 3.0, motion_rate, false, 0.0, false, false);
 }

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -438,40 +438,12 @@ unsafe fn sub_jump_squat_uniq_process_init_param(fighter: &mut L2CFighterCommon,
     let jump_squat_frame = WorkModule::get_param_int(fighter.module_accessor, hash40("jump_squat_frame"), 0) as f32;
     // This cuts a single frame off of the end of the specified characters' jumpsquat animations
     // This is a purely aesthetic change, makes for snappier jumps
-    let end_frame = if [*FIGHTER_KIND_SAMUS,
-        *FIGHTER_KIND_FOX,
-        *FIGHTER_KIND_PIKACHU,
-        *FIGHTER_KIND_LUIGI,
-        *FIGHTER_KIND_NESS,
-        *FIGHTER_KIND_FALCO,
-        *FIGHTER_KIND_POPO,
-        *FIGHTER_KIND_NANA,
-        *FIGHTER_KIND_PICHU,
-        *FIGHTER_KIND_YOUNGLINK,
-        *FIGHTER_KIND_PZENIGAME,
-        *FIGHTER_KIND_DIDDY,
-        *FIGHTER_KIND_LUCAS,
-        *FIGHTER_KIND_WOLF,
-        *FIGHTER_KIND_LITTLEMAC,
-        *FIGHTER_KIND_DUCKHUNT,
-        *FIGHTER_KIND_RYU,
-        *FIGHTER_KIND_KEN,
-        *FIGHTER_KIND_CLOUD,
-        *FIGHTER_KIND_SIMON,
-        *FIGHTER_KIND_RICHTER,
-        *FIGHTER_KIND_DOLLY,
-        *FIGHTER_KIND_EDGE,].contains(&fighter.kind())
-    {
-        MotionModule::end_frame_from_hash(fighter.module_accessor, motion_hash.get_hash()) - 1.0
-    }
-    else {
-        MotionModule::end_frame_from_hash(fighter.module_accessor, motion_hash.get_hash())
-    };
+    let end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, Hash40::new("landing_heavy")) * 0.25;
 
     // vanilla logic
     let mut motion_rate = end_frame / jump_squat_frame;
     if motion_rate < 1.0 {
         motion_rate += 0.001;
     }
-    MotionModule::change_motion(fighter.module_accessor, motion_hash.get_hash(), 0.0, motion_rate, false, 0.0, false, false);
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("landing_heavy"), 1.0, motion_rate, false, 0.0, false, false);
 }

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -128,7 +128,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 

--- a/fighters/donkey/src/acmd/other.rs
+++ b/fighters/donkey/src/acmd/other.rs
@@ -128,7 +128,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 

--- a/fighters/koopa/src/acmd/other.rs
+++ b/fighters/koopa/src/acmd/other.rs
@@ -127,7 +127,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 

--- a/fighters/krool/src/acmd/other.rs
+++ b/fighters/krool/src/acmd/other.rs
@@ -128,7 +128,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 

--- a/fighters/plizardon/src/acmd/other.rs
+++ b/fighters/plizardon/src/acmd/other.rs
@@ -266,7 +266,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 

--- a/fighters/ridley/src/acmd/other.rs
+++ b/fighters/ridley/src/acmd/other.rs
@@ -128,7 +128,8 @@ unsafe fn expression_landingheavy(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_landl"), 0, false, 0x50000000 /* default value */);
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR) {
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
         }
     } 


### PR DESCRIPTION
Jumpsquat animations have been globally replaced with the character's heavy landing animation (much like what Melee does). This makes wavedashing appear much more smooth and readable. Also makes jumping a bit snappier.


https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/c6dbe15b-2920-4b13-b4a7-b30b5b24eb6b


https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/acbea943-6a7b-46fd-8a01-c6bcd23a635e


https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/09a19af7-718b-4d3d-a7b8-df99989a0627


https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/7462a16f-9d4b-4fb6-bed0-dbc7743df986


https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/7e59f6eb-8403-4958-90d5-f5d8b07b0f56

