### PR TITLE
Steve Down Tilt Fire Effect Fix

### DIFF
--- a/fighters/pickel/src/acmd/other.rs
+++ b/fighters/pickel/src/acmd/other.rs
@@ -253,11 +253,12 @@ unsafe fn pickel_fire_attack_lw3_effect(fighter: &mut L2CAgentBase) {
         if VarModule::is_flag(owner_module_accessor.object(), vars::pickel::instance::IS_CURRENT_ATTACK_LW3_SOUL_FIRE){
             EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
             EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
-            LAST_EFFECT_SET_COLOR(fighter, 0.0, 0.25, 1.0);
+            LAST_EFFECT_SET_COLOR(fighter, 0.29, 0.941, 0.957);
         }
         else {
             EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire_soot"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
             EFFECT_FOLLOW(fighter, Hash40::new("pickel_fire"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, false);
+            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.568, 0.0);
         }
     }
     frame(lua_state, 30.0);


### PR DESCRIPTION
Asset Changes:
[hdr_pr_steve_fire_fix.zip](https://github.com/HDR-Development/HewDraw-Remix/files/12722286/hdr_pr_steve_fire_fix.zip)

This PR adjusts the effect of Steve's down tilt so that the Soul Fire variant more closely resembles the actual appearance of Soul Fire in Minecraft. Due to the limitations of effect editing however the regular fire variant looks different than normal. Below are visuals to see these changes in action.

**Before:**
![My Great Capture Screenshot 2023-09-26 00-56-36](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/8257ff6f-c5cc-4415-a8a9-8e8dc15482f2)
![My Great Capture Screenshot 2023-09-26 00-56-48](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/731b3473-734b-418f-b56c-0c09c48260cd)

**After:**
![My Great Capture Screenshot 2023-09-26 00-39-39](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/673aacb9-45a3-4737-8c1d-ef891dfaaab8)
![My Great Capture Screenshot 2023-09-26 00-45-03](https://github.com/HDR-Development/HewDraw-Remix/assets/109394370/2b3fd419-220f-4dbc-9d6e-b80bb998ac32)
