### PR TITLE
Rivals Wall Jump followup

### DIFF
--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -41,4 +41,5 @@
     <int hash="tether_trump_landing_lag">30</int>
     <float hash="guard_off_motion_start_frame">3</float>
     <int hash="pummel_max_cancel_frame">8</int>
+    <int hash="button_walljump_leniency_frame">2</int>
 </struct>

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -41,5 +41,5 @@
     <int hash="tether_trump_landing_lag">30</int>
     <float hash="guard_off_motion_start_frame">3</float>
     <int hash="pummel_max_cancel_frame">8</int>
-    <int hash="button_walljump_leniency_frame">2</int>
+    <int hash="button_walljump_leniency_frame">3</int>
 </struct>

--- a/utils/src/modules/input.rs
+++ b/utils/src/modules/input.rs
@@ -549,18 +549,12 @@ fn exec_internal(input_module: &mut InputModule, control_module: u64, call_origi
         && triggered_buttons.intersects(Buttons::Jump) {
             if ControlModule::get_stick_x((*input_module.owner).module_accessor) > 0.0 {
                 if input_module.hdr_cat.valid_frames[walljump_right_offset] == 0 {
-                    input_module.hdr_cat.valid_frames[walljump_right_offset] = unsafe {
-                        ControlModule::get_command_life_count_max((*input_module.owner).module_accessor)
-                            as u8
-                    };
+                    input_module.hdr_cat.valid_frames[walljump_right_offset] = 2;
                 }
             }
             else if ControlModule::get_stick_x((*input_module.owner).module_accessor) < 0.0 {
                 if input_module.hdr_cat.valid_frames[walljump_left_offset] == 0 {
-                    input_module.hdr_cat.valid_frames[walljump_left_offset] = unsafe {
-                        ControlModule::get_command_life_count_max((*input_module.owner).module_accessor)
-                            as u8
-                    };
+                    input_module.hdr_cat.valid_frames[walljump_left_offset] = 2;
                 }
             }
         }

--- a/utils/src/modules/input.rs
+++ b/utils/src/modules/input.rs
@@ -549,12 +549,18 @@ fn exec_internal(input_module: &mut InputModule, control_module: u64, call_origi
         && triggered_buttons.intersects(Buttons::Jump) {
             if ControlModule::get_stick_x((*input_module.owner).module_accessor) > 0.0 {
                 if input_module.hdr_cat.valid_frames[walljump_right_offset] == 0 {
-                    input_module.hdr_cat.valid_frames[walljump_right_offset] = 2;
+                    input_module.hdr_cat.valid_frames[walljump_right_offset] = unsafe {
+                        ParamModule::get_int(&mut (*input_module.owner), ParamType::Common, "button_walljump_leniency_frame")
+                        as u8
+                    };
                 }
             }
             else if ControlModule::get_stick_x((*input_module.owner).module_accessor) < 0.0 {
                 if input_module.hdr_cat.valid_frames[walljump_left_offset] == 0 {
-                    input_module.hdr_cat.valid_frames[walljump_left_offset] = 2;
+                    input_module.hdr_cat.valid_frames[walljump_left_offset] = unsafe {
+                        ParamModule::get_int(&mut (*input_module.owner), ParamType::Common, "button_walljump_leniency_frame")
+                        as u8
+                    };
                 }
             }
         }


### PR DESCRIPTION
Shortens the input window for a valid wall jump to 3 frames, making button wall jumps more difficult to hold buffer. This should mitigate accidentally performing a wall jump when performing actions such as rising aerials from ledge