### PR TITLE
Peanut Popgun Charge Cancel + Kirby Offense Up Bugfix

### DIFF
--- a/fighters/common/src/function_hooks/set_fighter_status_data.rs
+++ b/fighters/common/src/function_hooks/set_fighter_status_data.rs
@@ -23,7 +23,7 @@ unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, ar
         || (boma.kind() == *FIGHTER_KIND_IKE
             && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S]))
         || (boma.kind() == *FIGHTER_KIND_KIRBY
-            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S]))
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_S, *FIGHTER_KIRBY_STATUS_KIND_CAPTAIN_SPECIAL_N, *FIGHTER_KIRBY_STATUS_KIND_DONKEY_SPECIAL_N, *FIGHTER_KIRBY_STATUS_KIND_LITTLEMAC_SPECIAL_N, *FIGHTER_LITTLEMAC_STATUS_KIND_SPECIAL_N_START, *FIGHTER_KIRBY_STATUS_KIND_PACMAN_SPECIAL_N]))
         || (boma.kind() == *FIGHTER_KIND_KROOL
             && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_HI, *FIGHTER_KROOL_STATUS_KIND_SPECIAL_HI_START, *FIGHTER_STATUS_KIND_SPECIAL_LW]))
         || (boma.kind() == *FIGHTER_KIND_LINK

--- a/fighters/diddy/src/opff.rs
+++ b/fighters/diddy/src/opff.rs
@@ -17,36 +17,36 @@ unsafe fn nspecial_cancels(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma:
     if status_kind == *FIGHTER_DIDDY_STATUS_KIND_SPECIAL_N_CHARGE {
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
             if fighter.is_cat_flag(Cat2::StickEscape) {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_ESCAPE);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_ESCAPE);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
             else if fighter.is_cat_flag(Cat2::StickEscapeF) {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_ESCAPE_F);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_ESCAPE_F);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
             else if fighter.is_cat_flag(Cat2::StickEscapeB) {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_ESCAPE_B);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_ESCAPE_B);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
             else if (fighter.is_cat_flag(Cat1::JumpButton) || (ControlModule::is_enable_flick_jump(fighter.module_accessor) && fighter.is_cat_flag(Cat1::Jump) && fighter.sub_check_button_frick().get_bool())) {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_GROUND_JUMP);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_GROUND_JUMP);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
             if fighter.sub_check_command_guard().get_bool() {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_GUARD);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_GUARD);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
         }
         else {
             if fighter.is_cat_flag(Cat1::AirEscape)  {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_ESCAPE_AIR);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_ESCAPE_AIR);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL, true, false);
             }
             else if (fighter.is_cat_flag(Cat1::JumpButton) || (ControlModule::is_enable_flick_jump(fighter.module_accessor) && fighter.is_cat_flag(Cat1::Jump)))
             && fighter.get_num_used_jumps() < fighter.get_jump_count_max()
             {
-                VarModule::set_int(fighter.battle_object, vars::littlemac::status::SPECIAL_N_CANCEL_TYPE, vars::littlemac::SPECIAL_N_CANCEL_TYPE_JUMP_AERIAL);
-                fighter.change_to_custom_status(statuses::littlemac::SPECIAL_N_CANCEL_JUMP, true, false);
+                VarModule::set_int(fighter.battle_object, vars::diddy::status::SPECIAL_N_CANCEL_TYPE, vars::diddy::SPECIAL_N_CANCEL_TYPE_JUMP_AERIAL);
+                fighter.change_to_custom_status(statuses::diddy::SPECIAL_N_CANCEL_JUMP, true, false);
             }
         }
     }

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -268,6 +268,9 @@ littlemac_special_air_n_cancel:
 lucas_special_n_end:
   extra:
     cancel_frame: 20
+lucas_special_air_n_end:
+  extra:
+    cancel_frame: 20
 tantan_special_air_n_end:
   extra:
     cancel_frame: 40


### PR DESCRIPTION
Fixes bugs that originated from the Copy Ability Adjustments PR.

Diddy Kong - Variables changed to own instead of using Little Mac's, restoring the ability to cancel the move again.

Kirby - Offense Up Charge Cancel in the air is matched to Lucas and is now FAF: 20.

Also adds statuses to hopefully allow some copy abilities to b-reverse like they should soon.