### PR TITLE
Mii Swordfighter specials adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1054,10 +1054,9 @@ pub mod vars {
         pub mod status {
             // flags
             pub const WAVE_SPECIAL_N: i32 = 0x1100;
-
-            pub const GALE_STAB_EDGE_CANCEL: i32 = 0x1100;
-
-            pub const SPECIAL_LW1_ATTACK_TRIGGER: i32 = 0x1100;
+            pub const GALE_STAB_EDGE_CANCEL: i32 = 0x1101;
+            pub const SHOCK_SPELL_HOLD: i32 = 0x1102;
+            pub const SPECIAL_LW1_ATTACK_TRIGGER: i32 = 0x1103;
         }
     }
 

--- a/fighters/miiswordsman/src/acmd/other.rs
+++ b/fighters/miiswordsman/src/acmd/other.rs
@@ -242,7 +242,12 @@ unsafe fn miiswordsman_tornadoshot_fly_game(fighter: &mut L2CAgentBase) {
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
     if is_excute(fighter) {
         AREA_WIND_2ND_RAD_arg9(fighter, 0, 2, 0.05, 200, 1, 3, 3, 25, 30);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 85, 38, 0, 100, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -6.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 65, 23, 0, 53, 3.3, 0.0, 5.7, 2.6, Some(0.0), Some(2.8), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -6.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 68, 61, 0, 48, 3.3, 0.0, 5.7, 2.6, Some(0.0), Some(2.8), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -6.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
     }
 
 }

--- a/fighters/miiswordsman/src/acmd/other.rs
+++ b/fighters/miiswordsman/src/acmd/other.rs
@@ -242,21 +242,26 @@ unsafe fn miiswordsman_tornadoshot_fly_game(fighter: &mut L2CAgentBase) {
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
     if is_excute(fighter) {
         AREA_WIND_2ND_RAD_arg9(fighter, 0, 2, 0.05, 200, 1, 3, 3, 25, 30);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 13.0, 86, 100, 150, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -6.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 85, 38, 0, 100, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -6.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
     }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 11.0, 86, 100, 150, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -5.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 86, 100, 150, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
-    }
-    frame(lua_state, 54.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 86, 100, 150, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, -4.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
-    }
+
 }
+
+// #[acmd_script( agent = "miiswordsman_tornadoshot", script = "game_fly" , category = ACMD_GAME , low_priority)]
+// unsafe fn miiswordsman_tornadoshot_fly_game(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     if is_excute(fighter) {
+//         AREA_WIND_2ND_RAD_arg9(fighter, 0, 2, 0.05, 200, 1, 3, 3, 25, 30);
+//         ATTACK(fighter, 0, 0, Hash40::new("top"), 1.0, 366, 100, 30, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(9.5), Some(3.2), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 9, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+//         ATTACK(fighter, 1, 0, Hash40::new("top"), 1.0, 90, 100, 50, 0, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 9, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+//     }
+//     frame(lua_state, 37.0);
+//     if is_excute(fighter) {
+//         AttackModule::clear_all(boma);
+//         ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 80, 40, 0, 100, 4.5, 0.0, 9.5, 3.2, Some(0.0), Some(3.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_ENERGY);
+//     }
+// }
 
 #[acmd_script( agent = "miiswordsman_lightshuriken", script = "game_fly" , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_wave_fly_game(fighter: &mut L2CAgentBase) {
@@ -264,102 +269,103 @@ unsafe fn miiswordsman_wave_fly_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 55, 60, 0, 38, 9.5, 0.0, 3.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -4, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 55, 60, 0, 38, 9.5, 0.0, 3.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -4, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_NONE);
     }
     frame(lua_state, 18.0);
     if is_excute(fighter) {
-       ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 55, 60, 0, 38, 9.5, 0.0, 3.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -4, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_NONE);
+       ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 55, 60, 0, 38, 9.5, 0.0, 3.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -4, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_NONE);
     }
 }
+
 #[acmd_script( agent = "miiswordsman_lightshuriken", script = "effect_fly" , category = ACMD_EFFECT , low_priority)]
 unsafe fn miiswordsman_wave_fly_effect(fighter: &mut L2CAgentBase) {
-        let lua_state = fighter.lua_state_agent;
-        let boma = fighter.boma();
-        let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
-        let mut lead_wave : u32 = std::u32::MAX;
-        let mut old_wave : u32 = std::u32::MAX;
-        let mut wave_2 : u32 = std::u32::MAX;
-        let mut wave_3 : u32 = std::u32::MAX;
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
+    let mut lead_wave : u32 = std::u32::MAX;
+    let mut old_wave : u32 = std::u32::MAX;
+    let mut wave_2 : u32 = std::u32::MAX;
+    let mut wave_3 : u32 = std::u32::MAX;
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_hikari_syuriken"), false, true);
+    }
+    frame(lua_state, 1.0);
+    for _ in 0..i32::MAX {
         if is_excute(fighter) {
-            EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_hikari_syuriken"), false, true);
-        }
-        frame(lua_state, 1.0);
-        for _ in 0..i32::MAX {
-            if is_excute(fighter) {
-                lead_wave = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: 0.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.9, true, 0, 0, 0, 0, 0, false, false) as u32;
-                EffectModule::set_rate(boma, lead_wave, 1.4);
+            lead_wave = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: 0.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.9, true, 0, 0, 0, 0, 0, false, false) as u32;
+            EffectModule::set_rate(boma, lead_wave, 1.4);
 
-                wave_2 = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: -4.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.7, true, 0, 0, 0, 0, 0, false, false) as u32;
-                EffectModule::set_rate(boma, wave_2, 1.4);
-                EffectModule::set_alpha(boma, wave_2, 0.4);
-                //Ray check here is used for checking if you're on the ground. Unfortunately is_touch and is_wall_touch_line didnt work for this. Sorry!
-                if GroundModule::ray_check(
-                    fighter.module_accessor, 
-                    &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
-                    &Vector2f{ x: 0.0, y: -7.0}, true
-                ) == 1 {
-                    FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 3.0, 0, 0, 0, 0, 0, 0, false);
-                    LAST_EFFECT_SET_RATE(fighter, 0.5);
-                    FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
-                }
-            }
-            wait(lua_state, 2.0);
-            if is_excute(fighter) {
-                EffectModule::set_rate(boma, lead_wave, 0.05);
-
-                EffectModule::set_rate(boma, wave_2, 0.2);
-                EffectModule::set_alpha(boma, wave_2, 0.4);
-                wave_3 = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: -8.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.5, true, 0, 0, 0, 0, 0, false, false) as u32;
-                EffectModule::set_rate(boma, wave_3, 1.4);
-                EffectModule::set_alpha(boma, wave_3, 0.4);
-                if GroundModule::ray_check(
-                    fighter.module_accessor, 
-                    &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
-                    &Vector2f{ x: 0.0, y: -7.0}, true
-                ) == 1 {
-                    FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
-                    LAST_EFFECT_SET_RATE(fighter, 0.3);
-                    FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
-                }
-            }
-            wait(lua_state, 2.0);
-            if is_excute(fighter) {
-                if old_wave != std::u32::MAX {
-                    EffectModule::kill(boma, old_wave, false, true);
-                }
-
-                EffectModule::set_rate(boma, wave_3, 0.05);
-                EffectModule::detach(boma, wave_2, 0);
-                if GroundModule::ray_check(
-                    fighter.module_accessor, 
-                    &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
-                    &Vector2f{ x: 0.0, y: -7.0}, true
-                ) == 1 {
-                    FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
-                    LAST_EFFECT_SET_RATE(fighter, 0.3);
-                    FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
-                }
-            }
-            wait(lua_state, 2.0);
-            if is_excute(fighter) {
-                //EffectModule::kill(boma, wave_2, false, true);
-                EffectModule::detach(boma, wave_3, 0);
-                if GroundModule::ray_check(
-                    fighter.module_accessor, 
-                    &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
-                    &Vector2f{ x: 0.0, y: -7.0}, true
-                ) == 1 {
-                    FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
-                    LAST_EFFECT_SET_RATE(fighter, 0.3);
-                    FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
-                }
-            }
-            wait(lua_state, 2.0);
-            if is_excute(fighter) {
-                //EffectModule::kill(boma, wave_3, false, true);
-                old_wave = lead_wave;
+            wave_2 = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: -4.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.7, true, 0, 0, 0, 0, 0, false, false) as u32;
+            EffectModule::set_rate(boma, wave_2, 1.4);
+            EffectModule::set_alpha(boma, wave_2, 0.4);
+            //Ray check here is used for checking if you're on the ground. Unfortunately is_touch and is_wall_touch_line didnt work for this. Sorry!
+            if GroundModule::ray_check(
+                fighter.module_accessor, 
+                &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
+                &Vector2f{ x: 0.0, y: -7.0}, true
+            ) == 1 {
+                FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 3.0, 0, 0, 0, 0, 0, 0, false);
+                LAST_EFFECT_SET_RATE(fighter, 0.5);
+                FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
             }
         }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            EffectModule::set_rate(boma, lead_wave, 0.05);
+
+            EffectModule::set_rate(boma, wave_2, 0.2);
+            EffectModule::set_alpha(boma, wave_2, 0.4);
+            wave_3 = EffectModule::req_follow(boma, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), &Vector3f{x: 0.0, y: 3.0, z: -8.0}, &Vector3f{x: 80.6, y: -69.5, z: 0.0}, 0.5, true, 0, 0, 0, 0, 0, false, false) as u32;
+            EffectModule::set_rate(boma, wave_3, 1.4);
+            EffectModule::set_alpha(boma, wave_3, 0.4);
+            if GroundModule::ray_check(
+                fighter.module_accessor, 
+                &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
+                &Vector2f{ x: 0.0, y: -7.0}, true
+            ) == 1 {
+                FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
+                LAST_EFFECT_SET_RATE(fighter, 0.3);
+                FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
+            }
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            if old_wave != std::u32::MAX {
+                EffectModule::kill(boma, old_wave, false, true);
+            }
+
+            EffectModule::set_rate(boma, wave_3, 0.05);
+            EffectModule::detach(boma, wave_2, 0);
+            if GroundModule::ray_check(
+                fighter.module_accessor, 
+                &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
+                &Vector2f{ x: 0.0, y: -7.0}, true
+            ) == 1 {
+                FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
+                LAST_EFFECT_SET_RATE(fighter, 0.3);
+                FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
+            }
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            //EffectModule::kill(boma, wave_2, false, true);
+            EffectModule::detach(boma, wave_3, 0);
+            if GroundModule::ray_check(
+                fighter.module_accessor, 
+                &smash::phx::Vector2f{ x: PostureModule::pos_x(fighter.module_accessor), y: PostureModule::pos_y(fighter.module_accessor)}, 
+                &Vector2f{ x: 0.0, y: -7.0}, true
+            ) == 1 {
+                FOOT_EFFECT(fighter, Hash40::new("sys_magicball_aura"), Hash40::new("top"), 4, -3.5, 0, 0, 0, 0, 4.5, 0, 0, 0, 0, 0, 0, false);
+                LAST_EFFECT_SET_RATE(fighter, 0.3);
+                FOOT_EFFECT(fighter, Hash40::new("sys_quake"), Hash40::new("top"), 4, -4, 0, 0, 0, 0, 0.4, 0, 0, 0, 0, 0, 0, false);
+            }
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            //EffectModule::kill(boma, wave_3, false, true);
+            old_wave = lead_wave;
+        }
+    }
 }
 
 #[acmd_script( agent = "miiswordsman_chakram", script = "game_fly" , category = ACMD_GAME , low_priority)]

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -4,6 +4,7 @@ use super::*;
 unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
     }

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -1520,10 +1520,15 @@ unsafe fn miiswordsman_special_lw2_sound(fighter: &mut L2CAgentBase) {
         PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c2_l01"));
         PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c2_l01"));
     }
-    frame(lua_state, 12.0);
+    frame(lua_state, 10.5);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_common_electric_hit_m"));
     }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_electric_hit_s"));
+    }
+
 }
 
 

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -1,207 +1,41 @@
-
 use super::*;
 
-#[acmd_script( agent = "miiswordsman", script = "game_specialn1" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["game_specialn1", "game_specialairn1"] , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
     }
-
     frame(lua_state, 17.0);
     if is_excute(fighter) {
         ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, false, 0);
     }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.85);
-    }  
+    frame(lua_state, 20.0);
+    FT_MOTION_RATE_RANGE(fighter, 20.0, 48.0, 19.0);
+    frame(lua_state, 48.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
 
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn1" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n1_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-    }
-
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, false, 0);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.8);
-    }  
-}
-
-//Will need to be looked at in the future when rebalancing tornado
-/*
-#[acmd_script( agent = "miiswordsman", script = "game_specialn1" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    if is_excute(fighter) {
-        VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 0); // Timer used to track time until Gale Strike is available again
-        //VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-        VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-        ArticleModule::remove(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
-     }
-     frame(lua_state, 10.0);
-     if is_excute(fighter) {
-         if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW){
-             //VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-             VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-             FT_MOTION_RATE(fighter, 3.0);
-         }
-         else{
-            FT_MOTION_RATE(fighter, 1.25);
-         }
-     }
-     frame(lua_state, 17.0);
-     if is_excute(fighter) {
-         ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, false, 0);
-         //if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-            VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 120);
-         }
-         else{
-            VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 52);
-         }
-     }
-     frame(lua_state, 18.0);
-     if is_excute(fighter) {
-         //if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-             FT_MOTION_RATE(fighter, 1.2);
-         }
-         else{
-             FT_MOTION_RATE(fighter, 0.85);
-         }  
-     }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn1" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_n1_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);   
-    frame(lua_state, 4.0);
-    if is_excute(fighter) {
-        FOOT_EFFECT(fighter, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0.0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-        }
-        else{
-            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.25, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-            EFFECT(fighter, Hash40::new("miiswordsman_counter_flash"), Hash40::new("top"), 0, 9, 7.5, 0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-        }
-        else{
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn1" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n1_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    if is_excute(fighter) {
-        VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 0); // Timer used to track time until Gale Strike is available again
-        //VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-        VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-        ArticleModule::remove(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
-     }
-     frame(lua_state, 10.0);
-     if is_excute(fighter) {
-         if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW){
-             //VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-             VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-             FT_MOTION_RATE(fighter, 3.0);
-         }
-     }
-     frame(lua_state, 17.0);
-     if is_excute(fighter) {
-         ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, false, 0);
-         //if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){             
-            VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 120);
-         }
-         else{
-            VarModule::set_int(fighter.battle_object, vars::common::instance::GIMMICK_TIMER, 52);
-         }
-     }
-     frame(lua_state, 18.0);
-     if is_excute(fighter) {
-         //if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-             FT_MOTION_RATE(fighter, 1.2);
-         }
-         else{
-             FT_MOTION_RATE(fighter, 0.8);
-         }  
-     }
-    
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn1" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n1_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);   
-    frame(lua_state, 4.0);
-    if is_excute(fighter) {
-        FOOT_EFFECT(fighter, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0.0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-        }
-        else{
-            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK){
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.25, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-            EFFECT(fighter, Hash40::new("miiswordsman_counter_flash"), Hash40::new("top"), 0, 9, 7.5, 0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, true);
-            LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-        }
-        else{
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, true);
-        }
-    }
-}
-*/
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialn2" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["game_specialn2", "game_specialairn2"] , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-
     if is_excute(fighter) {
-        KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION);
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            KineticModule::change_kinetic(boma, *FIGHTER_KINETIC_TYPE_MOTION);
+        }
+        else {
+            let x_vel = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+            fighter.clear_lua_stack();
+            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST, x_vel * 0.6, 0.0, 0.0, 0.0, 0.0);
+            app::sv_kinetic_energy::reset_energy(fighter.lua_state_agent);
+            let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
+            fighter.clear_lua_stack();
+            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, air_speed_x_stable * 0.5, 100.0);
+            app::sv_kinetic_energy::set_stable_speed(fighter.lua_state_agent);
+        }
     }
     frame(lua_state, 14.0);
     if is_excute(fighter) {
@@ -217,18 +51,25 @@ unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 17.0);
     if is_excute(fighter) {
         MotionModule::set_rate(boma, 1.0);
+        if fighter.is_situation(*SITUATION_KIND_AIR) {
+            if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
+                fighter.clear_lua_stack();
+                lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY, 0.8);
+                app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+            }
+        }
         // light
         if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
             MotionModule::set_rate(boma, 1.0);
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 10.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 0, 0, Hash40::new("haver"), 11.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
             ATTACK(fighter, 1, 0, Hash40::new("haver"), 11.0, 361, 100, 0, 39, 3.5, 0.0, 6.75, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
             ATTACK(fighter, 2, 0, Hash40::new("haver"), 12.0, 361, 100, 0, 39, 3.5, 0.0, 11.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         }
         // heavy
         else {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 12.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 13.0, 361, 100, 0, 39, 3.5, 0.0, 6.75, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 2, 0, Hash40::new("haver"), 14.0, 361, 100, 0, 39, 3.5, 0.0, 11.5, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 0, 0, Hash40::new("haver"), 13.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 1, 0, Hash40::new("haver"), 13.0, 361, 100, 0, 39, 3.5, 0.0, 6.75, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 2, 0, Hash40::new("haver"), 14.0, 361, 100, 0, 39, 3.5, 0.0, 11.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         }
     }
     frame(lua_state, 20.0);
@@ -255,11 +96,10 @@ unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn2" , category = ACMD_EFFECT , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["effect_specialn2", "effect_specialairn2"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn miiswordsman_special_n2_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-
     frame(lua_state, 12.0);
     if is_excute(fighter) {
         AFTER_IMAGE4_ON_arg29(fighter, Hash40::new("tex_miiswordsman_sword03"), Hash40::new("tex_miiswordsman_sword04"), 8, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 10.5, 0.0, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.2);
@@ -268,17 +108,12 @@ unsafe fn miiswordsman_special_n2_effect(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
             EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0.0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-            //LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
         }
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        //EFFECT_FOLLOW_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
         FOOT_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), -5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), -1, 10, 6, -10.6, -159.5, 90.0, 1.3, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), -1, 10, 2, -10.6, -140, 90.0, 1.3, true);
 	    LAST_EFFECT_SET_RATE(fighter, 1.4);
     }
     frame(lua_state, 29.0);
@@ -287,11 +122,10 @@ unsafe fn miiswordsman_special_n2_effect(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "miiswordsman", script = "sound_specialn2" , category = ACMD_SOUND , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["sound_specialn2", "sound_specialairn2"] , category = ACMD_SOUND , low_priority)]
 unsafe fn miiswordsman_special_n2_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-
     frame(lua_state, 16.0);
     if is_excute(fighter) {
         PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c2_l01"));
@@ -299,136 +133,26 @@ unsafe fn miiswordsman_special_n2_sound(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn2" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n2_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-
-    if is_excute(fighter) {
-        let x_vel = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, ENERGY_CONTROLLER_RESET_TYPE_FALL_ADJUST, x_vel * 0.6, 0.0, 0.0, 0.0, 0.0);
-        app::sv_kinetic_energy::reset_energy(fighter.lua_state_agent);
-        let air_speed_x_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_x_stable"), 0);
-        fighter.clear_lua_stack();
-        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_CONTROL, air_speed_x_stable * 0.5, 100.0);
-        app::sv_kinetic_energy::set_stable_speed(fighter.lua_state_agent);
-        VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW) {
-            VarModule::on_flag(fighter.battle_object, vars::miiswordsman::status::WAVE_SPECIAL_N);
-            VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-            MotionModule::set_rate(boma, 0.3);
-        }
-        else {
-            MotionModule::set_rate(boma, 1.0/(1.0/(17.0-14.0)));
-        }
-    }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            fighter.clear_lua_stack();
-            lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY, 0.8);
-            app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
-        }
-        // light
-        if !VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            MotionModule::set_rate(boma, 1.0);
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 10.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 11.0, 361, 100, 0, 39, 3.5, 0.0, 6.75, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 2, 0, Hash40::new("haver"), 12.0, 361, 100, 0, 39, 3.5, 0.0, 11.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        // heavy
-        else {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 12.0, 361, 100, 0, 39, 3.5, 0.0, 2.0, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 13.0, 361, 100, 0, 39, 3.5, 0.0, 6.75, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 2, 0, Hash40::new("haver"), 14.0, 361, 100, 0, 39, 3.5, 0.0, 11.5, 0.0, None, None, None, 1.4, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            //WorkModule::set_float(boma, 0.0, *FIGHTER_MIISWORDSMAN_STATUS_FINAL_WORK_ID_FLOAT_WAVE_ANGLE);
-            ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_LIGHTSHURIKEN, false, 0);
-            ArticleModule::shoot_exist(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_LIGHTSHURIKEN, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            MotionModule::set_rate(boma, 0.333);
-        }
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn2" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n2_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_arg29(fighter, Hash40::new("tex_miiswordsman_sword03"), Hash40::new("tex_miiswordsman_sword04"), 8, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 10.5, 0.0, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.2);
-    }
-    frame(lua_state, 15.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0.0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-            //LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-        }
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        //EFFECT_FOLLOW_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_counter_arc"), Hash40::new("top"), -1, 10, 6, -10.6, -159.5,  90.0, 1.3, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.4);
-    }
-    frame(lua_state, 29.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 4.0);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialairn2" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_air_n2_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c2_l01"));
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_l03"));
-    }
-}
 
 // ================================================================================================
 // ======================================== BLURRING BLADE ========================================
 // ================================================================================================
 
-#[acmd_script( agent = "miiswordsman", script = "game_specialn3end" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["game_specialn3end", "game_specialn3endturn", "game_specialn3endmax", "game_specialn3endmaxturn"] , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_special_n3_end_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
+    let turn = fighter.is_motion_one_of(&[Hash40::new("special_n3_end_turn"), Hash40::new("special_n3_end_max_turn")]);
     frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        if turn {
+            REVERSE_LR(fighter);
+        }
+    }
     for _ in 0..4 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 180, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 92, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 0, 0, Hash40::new("haver"), 1.0, 180, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 1, 0, Hash40::new("haver"), 1.0, 92, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
@@ -437,641 +161,47 @@ unsafe fn miiswordsman_special_n3_end_game(fighter: &mut L2CAgentBase) {
         wait(lua_state, 2.0);
     }
     if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("haver"), 1.0, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
     }
     wait(lua_state, 2.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 40.0);
+    frame(lua_state, 33.0);
     if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 8.5, 0.0, 8.0, 12.5, Some(0.0), Some(8.5), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn3end" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_n3_end_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, 12, 0, 0, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
+        let sfx = if fighter.is_motion_one_of(&[Hash40::new("special_n3_end_max"), Hash40::new("special_n3_end_max_turn")]) { *COLLISION_SOUND_ATTR_FIRE } else { *COLLISION_SOUND_ATTR_KICK };
+        let offset = if turn { -10.0 } else { 9.5 };
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 70, 65, 0, 80, 10.0, 0.0, 10.0, offset, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, sfx, *ATTACK_REGION_SWORD);
     }
     frame(lua_state, 36.0);
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), 3, 8, 3, 70, -80, 190, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_b"), Hash40::new("top"), 0, 0, 13, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialn3end" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_n3_end_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_h03_win02"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialn3endturn" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_n3_end_turn_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        REVERSE_LR(fighter);
-    }
-    for _ in 0..4 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 180, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 92, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 8.5, 0.0, 8.0, -12.5, Some(0.0), Some(8.5), Some(-13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
+    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 20.0);
+    frame(lua_state, 80.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
 
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn3endturn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_n3_end_turn_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_arg29(fighter, Hash40::new_raw(WorkModule::get_int64(boma, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD)), Hash40::new_raw(WorkModule::get_int64(boma, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD)), 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, Hash40::new_raw(WorkModule::get_int64(boma, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE)), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, -12, 0, 180, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), -3, 8, -3, 250, 80, 10, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_b"), Hash40::new("top"), 0, 0, -13, 0, 180, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialn3endturn" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_n3_end_turn_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_h03_win02"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialn3endmax" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 6.0);
-    for _ in 0..4 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 180, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 92, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 9.0, 15.0, Some(0.0), Some(8.5), Some(15.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn3endmax" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, 12, 0, 0, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), 3, 8, 3, 70, -80, 190, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        //LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_c"), Hash40::new("top"), 0, 0, 13, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialn3endmax" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_ll"));
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_h03_win02"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialn3endmaxturn" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_turn_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        REVERSE_LR(fighter);
-    }
-    for _ in 0..4 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 180, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-            ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 92, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 9.0, -15.0, Some(0.0), Some(8.5), Some(-15.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialn3endmaxturn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_turn_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, -12, 0, 180, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 44.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), -3, 8, -3, 250, 80, 10, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        //LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_c"), Hash40::new("top"), 0, 0, -13, 0, 180, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialn3endmaxturn" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_n3_end_max_turn_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_ll"));
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_h03_win02"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn3end" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["game_specialairn3end", "game_specialairn3endturn", "game_specialairn3endmax", "game_specialairn3endmaxturn"] , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
+    let turn = fighter.is_motion_one_of(&[Hash40::new("special_air_n3_end_turn"), Hash40::new("special_air_n3_end_max_turn")]);
     if is_excute(fighter) {
-        SET_SPEED_EX(fighter, 0.5, 1.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        let flip = if turn { -1.0 } else { 1.0 };
+        SET_SPEED_EX(fighter, 0.5 * flip, 1.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
     }
     frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        if turn {
+            REVERSE_LR(fighter);
+        }
+    }
     for _ in 0..2 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 90, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 0, 0, Hash40::new("haver"), 1.0, 90, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
@@ -1079,7 +209,7 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 285, 100, 10, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+            ATTACK(fighter, 0, 0, Hash40::new("haver"), 1.0, 285, 100, 10, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
@@ -1088,8 +218,8 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
         wait(lua_state, 2.0);
     }
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 0, 0, Hash40::new("haver"), 1.0, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("haver"), 1.0, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         AttackModule::set_add_reaction_frame(boma, 0, 10.0, false);
         AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
     }
@@ -1099,647 +229,23 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 25.0);
     if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
+        KineticModule::add_speed(boma, &Vector3f::new(0.0, 2.0, 0.0));
     }
-    frame(lua_state, 38.0);
+    frame(lua_state, 33.0);
     if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
+        let sfx = if fighter.is_motion_one_of(&[Hash40::new("special_air_n3_end_max"), Hash40::new("special_air_n3_end_max_turn")]) { *COLLISION_SOUND_ATTR_FIRE } else { *COLLISION_SOUND_ATTR_KICK };
+        let offset = if turn { -9.5 } else { 9.5 };
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 70, 65, 0, 80, 10.0, 0.0, 10.0, offset, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, sfx, *ATTACK_REGION_SWORD);
     }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 8.5, 0.0, 8.0, 12.5, Some(0.0), Some(8.5), Some(13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
+    frame(lua_state, 36.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
+    frame(lua_state, 40.0);
+    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 20.0);
+    frame(lua_state, 80.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn3end" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, 12, 0, 0, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), 3, 8, 3, 70, -80, 190, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_b"), Hash40::new("top"), 0, 0, 13, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialairn3end" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn3endturn" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_turn_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    if is_excute(fighter) {
-        SET_SPEED_EX(fighter, -0.5, 1.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-    }
-    frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        REVERSE_LR(fighter);
-    }
-    for _ in 0..2 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 90, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 285, 100, 10, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        AttackModule::set_add_reaction_frame(boma, 0, 10.0, false);
-        AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-    }
-    frame(lua_state, 38.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 8.5, 0.0, 8.0, -12.5, Some(0.0), Some(8.5), Some(-13.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn3endturn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_turn_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, -12, 0, 180, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), -3, 8, -3, 250, 80, 10, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_b"), Hash40::new("top"), 0, 0, -13, 0, 180, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialairn3endturn" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_turn_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn3endmax" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    if is_excute(fighter) {
-        SET_SPEED_EX(fighter, 0.5, 1.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-    }
-    frame(lua_state, 6.0);
-    for _ in 0..2 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 90, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 285, 100, 10, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        AttackModule::set_add_reaction_frame(boma, 0, 10.0, false);
-        AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-    }
-    frame(lua_state, 38.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 9.0, 15.0, Some(0.0), Some(8.5), Some(15.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn3endmax" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, 12, 0, 0, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), 3, 8, 3, 70, -80, 190, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_c"), Hash40::new("top"), 0, 0, 13, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialairn3endmax" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_ll"));
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairn3endmaxturn" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_turn_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    if is_excute(fighter) {
-        SET_SPEED_EX(fighter, -0.5, 1.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
-    }
-    frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        REVERSE_LR(fighter);
-    }
-    for _ in 0..2 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 90, 100, 1, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 285, 100, 10, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 0.8, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 1, 0, Hash40::new("haver"), 0.8, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
-        AttackModule::set_add_reaction_frame(boma, 0, 10.0, false);
-        AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-    }
-    frame(lua_state, 38.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 4.0);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        //ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 10.0, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 40, 110, 0, 58, 4.0, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        let addSpeed = smash::phx::Vector3f { x: 0.0, y: 2.0, z: 0.0 };
-        KineticModule::add_speed(boma, &addSpeed);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 40, 110, 0, 58, 13.0, 0.0, 9.0, -15.0, Some(0.0), Some(8.5), Some(-15.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-    }
-    wait(lua_state, 4.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairn3endmaxturn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_turn_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1.0, true);
-    }
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE4_ON_WORK_arg29(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_TEX_SWORD_ADD, 3, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 0.2, 0.0, true, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 2.0, 0.2);
-    }
-    frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), Hash40::new("top"), -0.0, 5.5, -12, 0, 180, 0, 1, true);
-	    EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 22.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_wind_s"), false, false);
-    }
-    frame(lua_state, 25.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), Hash40::new("haver"), 0, -0.5, 0, 0, 0, 0, 1, true);
-    }
-    frame(lua_state, 43.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_rapid_slash_arc"), Hash40::new("top"), -3, 8, -3, 250, 80, 10, 1.2, true);
-	    LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-	    //EFFECT(fighter, Hash40::new("sys_sp_flash"), Hash40::new("haver"), -0.0, 12, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        EFFECT(fighter, Hash40::new("sys_bomb_c"), Hash40::new("top"), 0, 0, -13, 0, 180, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
-    }
-    frame(lua_state, 55.0);
-    if is_excute(fighter) {
-        AFTER_IMAGE_OFF(fighter, 2);
-    }
-    frame(lua_state, 74.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_rapid_slash_sword"), false, true);
-    }
-}
-
-#[acmd_script( agent = "miiswordsman", script = "sound_specialairn3endmaxturn" , category = ACMD_SOUND , low_priority)]
-unsafe fn miiswordsman_special_air_n3_end_max_turn_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    let end_frame = MotionModule::end_frame(boma);
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        STOP_SE(fighter, Hash40::new("se_miiswordsman_special_s01"));
-        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c3_n01"));
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n01"));
-    }
-    frame(lua_state, 45.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c3_n02"));
-    }
-    frame(lua_state, 47.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_bomb_ll"));
-    }
-}
-
 
 
 // ==================================================================================================
@@ -2895,25 +1401,23 @@ unsafe fn miiswordsman_special_air_lw1_hit_lv2_game(fighter: &mut L2CAgentBase) 
 // ======================================== DEFLECTING DRAFT / SHOCK SPELL ========================================
 // ================================================================================================================
 
-#[acmd_script( agent = "miiswordsman", script = "game_speciallw2" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["game_speciallw2", "game_specialairlw2"] , category = ACMD_GAME , low_priority)]
 unsafe fn miiswordsman_special_lw2_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 1.3);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.3);
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
     frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 3.0);
-    }
+    FT_MOTION_RATE(fighter, 3.0);
     frame(lua_state, 12.0);
+    FT_MOTION_RATE(fighter, 1.2);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
-    FT_MOTION_RATE(fighter, 1.2);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 25.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 4.0, 0.0, 9.0, 24.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 25.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 2.0, 0.0, 2.0, 25.0, Some(0.0), Some(25.0), Some(25.0), 0.9, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
@@ -2927,119 +1431,86 @@ unsafe fn miiswordsman_special_lw2_game(fighter: &mut L2CAgentBase) {
     
 }
 
-#[acmd_script( agent = "miiswordsman", script = "effect_speciallw2" , category = ACMD_EFFECT , low_priority)]
+#[acmd_script( agent = "miiswordsman", scripts = ["effect_speciallw2", "effect_specialairlw2"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), -1.5, 0, 2, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.2);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), -1.5, 0, 2, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
+            LAST_EFFECT_SET_RATE(fighter, 1.2);
+        }
         EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_reflect_sword"), Hash40::new("haver"), 0, 0, 0, 0, 0.0, 0, 1, true);
-        //EFFECT_FOLLOW_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
         LAST_EFFECT_SET_ALPHA(fighter, 0.65);
-    }
-    frame(lua_state, 10.5);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("arml"), 4.0, 0, 0.0, 0, 0.0, 0, 0.1, true);
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder_flash"), Hash40::new("arml"), 4.0, 0, 0.0, 0, 0.0, 0, 0.3, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.2);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0.5, 0, 0, 0, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, false);
-    EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8.0, 25.0, 0, 0.0, 0, 0.4, true);
-        LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_reflect_sword"), false, true);
-    }
-    frame(lua_state, 23.0);
-    if is_excute(fighter) {
-        //EFFECT_OFF_KIND_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, false, false);
-    }
-    frame(lua_state, 26.0);
-    if is_excute(fighter) {
-        EFFECT_DETACH_KIND(fighter, Hash40::new("miiswordsman_reflect1"), -1);
-    }
-    
-}
-
-#[acmd_script( agent = "miiswordsman", script = "game_specialairlw2" , category = ACMD_GAME , low_priority)]
-unsafe fn miiswordsman_special_air_lw2_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-
-    frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.3);
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
     frame(lua_state, 6.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 3.0);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.4, true);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 21, 0, 0.0, 0, 0.4, true);
+            LAST_EFFECT_SET_SCALE_W(fighter, 0.4, 0.25, 0.4);
+            LAST_EFFECT_SET_COLOR(fighter, 0.1, 0.1, 0.1);
+            LAST_EFFECT_SET_RATE(fighter, 1.1);
+        }
     }
-    frame(lua_state, 12.0);
+    frame(lua_state, 9.0);
     if is_excute(fighter) {
-        WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
-    FT_MOTION_RATE(fighter, 1.2);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 25.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 4.0, 0.0, 9.0, 24.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
-    }
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 15.0);
-    if is_excute(fighter) {
-        notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
-    }
-    frame(lua_state, 23.0);
-    if is_excute(fighter) {
-        WorkModule::off_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
-    }
-    
-}
-
-#[acmd_script( agent = "miiswordsman", script = "effect_specialairlw2" , category = ACMD_EFFECT , low_priority)]
-unsafe fn miiswordsman_special_air_lw2_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), -1.5, 0, 2, 0, 0, 0, 0.7, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.2);
-        EFFECT_FOLLOW(fighter, Hash40::new("miiswordsman_reflect_sword"), Hash40::new("haver"), 0, 0, 0, 0, 0.0, 0, 1, true);
-        //EFFECT_FOLLOW_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_ALPHA(fighter, 0.65);
+        if fighter.is_situation(*SITUATION_KIND_AIR) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 21, 0, 0.0, 0, 0.4, true);
+            LAST_EFFECT_SET_SCALE_W(fighter, 0.4, 0.25, 0.4);
+            LAST_EFFECT_SET_COLOR(fighter, 0.1, 0.1, 0.1);
+            LAST_EFFECT_SET_RATE(fighter, 1.1);
+        }
     }
     frame(lua_state, 10.5);
     if is_excute(fighter) {
-    EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("arml"), 4.0, 0, 0.0, 0, 0.0, 0, 0.1, true);
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder_flash"), Hash40::new("arml"), 4.0, 0, 0.0, 0, 0.0, 0, 0.3, true);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0.5, 0, 0, 0, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, false);
+        }
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder_flash"), Hash40::new("top"), 0, 15, 21, 0, 0, 180, 0.15, true);
         LAST_EFFECT_SET_RATE(fighter, 1.2);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0.5, 0, 0, 0, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, false);
-    EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8.0, 25.0, 0, 0.0, 0, 0.4, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_damage_paralysis"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.35, true);
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_smokescreen"), false, false);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8.0, 21.0, 0, 0.0, 0, 0.4, true);
         LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_damage_paralysis"), true, true);
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder_flash"), true, true);
+        EFFECT_DETACH_KIND(fighter, Hash40::new("sys_hit_elec"), -1);
     }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("miiswordsman_reflect_sword"), false, true);
     }
-    frame(lua_state, 23.0);
-    if is_excute(fighter) {
-        //EFFECT_OFF_KIND_WORK(fighter, *FIGHTER_MIISWORDSMAN_INSTANCE_WORK_ID_INT_EFT_ID_SWORD_FLARE, false, false);
-    }
     frame(lua_state, 26.0);
     if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder"), false, true);
         EFFECT_DETACH_KIND(fighter, Hash40::new("miiswordsman_reflect1"), -1);
     }
     
 }
+
+#[acmd_script( agent = "miiswordsman", scripts = ["sound_speciallw2", "sound_specialairlw2"], category = ACMD_SOUND, low_priority )]
+unsafe fn miiswordsman_special_lw2_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_miiswordsman_special_c2_l01"));
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_miiswordsman_rnd_special_c2_l01"));
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_electric_hit_m"));
+    }
+}
+
 
 // ================================================================================================================
 // ======================================== HURRICANE HEAVE =======================================================
@@ -3260,39 +1731,11 @@ unsafe fn miiswordsman_special_air_lw3_end_air_game(fighter: &mut L2CAgentBase) 
 pub fn install() {
     install_acmd_scripts!(
         miiswordsman_special_n1_game,
-        //miiswordsman_special_n1_effect,
-        miiswordsman_special_air_n1_game,
-        //miiswordsman_special_air_n1_effect,
         miiswordsman_special_n2_game,
         miiswordsman_special_n2_effect,
         miiswordsman_special_n2_sound,
-        miiswordsman_special_air_n2_game,
-        miiswordsman_special_air_n2_effect,
-        miiswordsman_special_air_n2_sound,
-        //miiswordsman_special_n3_end_game,
-        //miiswordsman_special_n3_end_effect,
-        //miiswordsman_special_n3_end_sound,
-        //miiswordsman_special_n3_end_turn_game,
-        //miiswordsman_special_n3_end_turn_effect,
-        //miiswordsman_special_n3_end_turn_sound,
-        //miiswordsman_special_n3_end_max_game,
-        //miiswordsman_special_n3_end_max_effect,
-        //miiswordsman_special_n3_end_max_sound,
-        //miiswordsman_special_n3_end_max_turn_game,
-        //miiswordsman_special_n3_end_max_turn_effect,
-        //miiswordsman_special_n3_end_max_turn_sound,
-        //miiswordsman_special_air_n3_end_game,
-        //miiswordsman_special_air_n3_end_effect,
-        //miiswordsman_special_air_n3_end_sound,
-        //miiswordsman_special_air_n3_end_turn_game,
-        //miiswordsman_special_air_n3_end_turn_effect,
-        //miiswordsman_special_air_n3_end_turn_sound,
-        //miiswordsman_special_air_n3_end_max_game,
-        //miiswordsman_special_air_n3_end_max_effect,
-        //miiswordsman_special_air_n3_end_max_sound,
-        //miiswordsman_special_air_n3_end_max_turn_game,
-        //miiswordsman_special_air_n3_end_max_turn_effect,
-        //miiswordsman_special_air_n3_end_max_turn_sound,
+        miiswordsman_special_n3_end_game,
+        miiswordsman_special_air_n3_end_game,
 
         miiswordsman_special_s1_start_game,
         miiswordsman_special_air_s1_start_game,
@@ -3333,9 +1776,7 @@ pub fn install() {
         //miiswordsman_special_air_lw1_hit_lv2_game,
         miiswordsman_special_lw2_game,
         miiswordsman_special_lw2_effect,
-        miiswordsman_special_air_lw2_game,
-        miiswordsman_special_air_lw2_effect,
-        miiswordsman_special_air_lw2_game,
+        miiswordsman_special_lw2_sound,
         miiswordsman_special_lw3_game,
         //miiswordsman_special_lw3_end_game,
         miiswordsman_special_air_lw3_game,
@@ -3343,4 +1784,3 @@ pub fn install() {
         //miiswordsman_special_air_lw3_end_air_game,
     );
 }
-

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -1412,12 +1412,18 @@ unsafe fn miiswordsman_special_lw2_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 6.0);
     FT_MOTION_RATE(fighter, 3.0);
+    if is_excute(fighter) {
+        if boma.is_button_on(Buttons::Special) {
+            VarModule::on_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD);
+        }
+    }
     frame(lua_state, 12.0);
     FT_MOTION_RATE(fighter, 1.2);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 25.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 2.0, 0.0, 2.0, 25.0, Some(0.0), Some(25.0), Some(25.0), 0.9, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_OBJECT);
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 10.0 } else { 0.0 };
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 15.0 + hold, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 2.0, 0.0, 2.0, 15.0 + hold, Some(0.0), Some(25.0), Some(15.0 + hold), 0.9, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
@@ -1446,9 +1452,14 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 6.0);
     if is_excute(fighter) {
+        let mut offset = 0;
         EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.4, true);
+        if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) {
+            offset = 8;
+            EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("top"), 0, 15.0, 8.0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
+        }
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 21, 0, 0.0, 0, 0.4, true);
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 13 + offset, 0, 0.0, 0, 0.4, true);
             LAST_EFFECT_SET_SCALE_W(fighter, 0.4, 0.25, 0.4);
             LAST_EFFECT_SET_COLOR(fighter, 0.1, 0.1, 0.1);
             LAST_EFFECT_SET_RATE(fighter, 1.1);
@@ -1457,7 +1468,8 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     frame(lua_state, 9.0);
     if is_excute(fighter) {
         if fighter.is_situation(*SITUATION_KIND_AIR) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 21, 0, 0.0, 0, 0.4, true);
+            let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 13 + hold, 0, 0.0, 0, 0.4, true);
             LAST_EFFECT_SET_SCALE_W(fighter, 0.4, 0.25, 0.4);
             LAST_EFFECT_SET_COLOR(fighter, 0.1, 0.1, 0.1);
             LAST_EFFECT_SET_RATE(fighter, 1.1);
@@ -1465,17 +1477,19 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 10.5);
     if is_excute(fighter) {
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
             LANDING_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0.5, 0, 0, 0, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, false);
         }
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder_flash"), Hash40::new("top"), 0, 15, 21, 0, 0, 180, 0.15, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder_flash"), Hash40::new("top"), 0, 15, 13 + hold, 0, 0, 180, 0.15, true);
         LAST_EFFECT_SET_RATE(fighter, 1.2);
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
         EFFECT_FOLLOW(fighter, Hash40::new("sys_damage_paralysis"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.35, true);
         EFFECT_OFF_KIND(fighter, Hash40::new("sys_smokescreen"), false, false);
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8.0, 21.0, 0, 0.0, 0, 0.4, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8, 13 + hold, 0, 0, 0, 0.4, true);
         LAST_EFFECT_SET_COLOR(fighter, 1.0, 0.84, 0.17);
     }
     frame(lua_state, 16.0);

--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -5,6 +5,7 @@ unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 17.0, 14.0);
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
     }
@@ -13,7 +14,7 @@ unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
         ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_TORNADOSHOT, false, 0);
     }
     frame(lua_state, 20.0);
-    FT_MOTION_RATE_RANGE(fighter, 20.0, 48.0, 19.0);
+    FT_MOTION_RATE_RANGE(fighter, 20.0, 48.0, 17.0);
     frame(lua_state, 48.0);
     FT_MOTION_RATE(fighter, 1.0);
 }
@@ -22,6 +23,8 @@ unsafe fn miiswordsman_special_n1_game(fighter: &mut L2CAgentBase) {
 unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 14.0, 9.0);
     if is_excute(fighter) {
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
@@ -39,19 +42,21 @@ unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
         }
     }
     frame(lua_state, 14.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    if boma.is_button_on(Buttons::Special) {
+        FT_MOTION_RATE_RANGE(fighter, 14.0, 17.0, 13.0);
+    }
+    else {
+        FT_MOTION_RATE(fighter, 1.0);
+    }
     if is_excute(fighter) {
-        if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW) {
-            VarModule::on_flag(fighter.battle_object, vars::miiswordsman::status::WAVE_SPECIAL_N);
+        if boma.is_button_on(Buttons::Special) {
             VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
-            MotionModule::set_rate(boma, 0.3);
-        }
-        else {
-            MotionModule::set_rate(boma, 1.0/(1.0/(17.0-14.0)));
         }
     }
     frame(lua_state, 17.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
         if fighter.is_situation(*SITUATION_KIND_AIR) {
             if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
                 fighter.clear_lua_stack();
@@ -76,7 +81,6 @@ unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 20.0);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            //WorkModule::set_float(boma, 0.0, *FIGHTER_MIISWORDSMAN_STATUS_FINAL_WORK_ID_FLOAT_WAVE_ANGLE);
             ArticleModule::generate_article(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_LIGHTSHURIKEN, false, 0);
             ArticleModule::shoot_exist(boma, *FIGHTER_MIISWORDSMAN_GENERATE_ARTICLE_LIGHTSHURIKEN, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
         }
@@ -86,15 +90,12 @@ unsafe fn miiswordsman_special_n2_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            MotionModule::set_rate(boma, 0.333);
-        }
+    if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
+        FT_MOTION_RATE_RANGE(fighter, 33.0, 36.0, 10.0);
     }
     frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
+    FT_MOTION_RATE(fighter, 1.0);
+
 }
 
 #[acmd_script( agent = "miiswordsman", scripts = ["effect_specialn2", "effect_specialairn2"] , category = ACMD_EFFECT , low_priority)]
@@ -105,7 +106,7 @@ unsafe fn miiswordsman_special_n2_effect(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         AFTER_IMAGE4_ON_arg29(fighter, Hash40::new("tex_miiswordsman_sword03"), Hash40::new("tex_miiswordsman_sword04"), 8, Hash40::new("haver"), 0.0, 0.2, 0.0, Hash40::new("haver"), -0.0, 10.5, 0.0, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_Y, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.2);
     }
-    frame(lua_state, 15.0);
+    frame(lua_state, 14.2);
     if is_excute(fighter) {
         if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
             EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("haver"), 0, 7.5, 0.0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
@@ -163,13 +164,16 @@ unsafe fn miiswordsman_special_n3_end_game(fighter: &mut L2CAgentBase) {
     }
     if is_excute(fighter) {
         ATTACK(fighter, 1, 0, Hash40::new("haver"), 1.0, 91, 100, 21, 0, 3.5, 0.0, -2.0, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 1, 2.0);
         AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
     }
-    wait(lua_state, 2.0);
+    frame(lua_state, 24.0);
+    FT_MOTION_RATE_RANGE(fighter, 24.0, 33.0, 5.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 33.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         let sfx = if fighter.is_motion_one_of(&[Hash40::new("special_n3_end_max"), Hash40::new("special_n3_end_max_turn")]) { *COLLISION_SOUND_ATTR_FIRE } else { *COLLISION_SOUND_ATTR_KICK };
         let offset = if turn { -10.0 } else { 9.5 };
@@ -180,7 +184,7 @@ unsafe fn miiswordsman_special_n3_end_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 40.0);
-    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 20.0);
+    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 26.0);
     frame(lua_state, 80.0);
     FT_MOTION_RATE(fighter, 1.0);
 }
@@ -221,10 +225,12 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("haver"), 1.0, 120, 100, 20, 0, 4.0, 0.0, 8.2, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 1, 0, Hash40::new("haver"), 1.0, 45, 100, 25, 0, 4.0, 0.0, -1.2, 0.0, Some(0.0), Some(12.0), Some(0.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 1, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.0);
         AttackModule::set_add_reaction_frame(boma, 0, 10.0, false);
         AttackModule::set_add_reaction_frame(boma, 1, 10.0, false);
     }
-    wait(lua_state, 2.0);
+    frame(lua_state, 24.0);
+    FT_MOTION_RATE_RANGE(fighter, 24.0, 33.0, 5.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -233,6 +239,7 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
         KineticModule::add_speed(boma, &Vector3f::new(0.0, 2.0, 0.0));
     }
     frame(lua_state, 33.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         let sfx = if fighter.is_motion_one_of(&[Hash40::new("special_air_n3_end_max"), Hash40::new("special_air_n3_end_max_turn")]) { *COLLISION_SOUND_ATTR_FIRE } else { *COLLISION_SOUND_ATTR_KICK };
         let offset = if turn { -9.5 } else { 9.5 };
@@ -243,7 +250,7 @@ unsafe fn miiswordsman_special_air_n3_end_game(fighter: &mut L2CAgentBase) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 40.0);
-    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 20.0);
+    FT_MOTION_RATE_RANGE(fighter, 40.0, 80.0, 26.0);
     frame(lua_state, 80.0);
     FT_MOTION_RATE(fighter, 1.0);
 }
@@ -1121,7 +1128,7 @@ unsafe fn miiswordsman_special_air_hi3_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 22.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 85, 100, 75, 0, 6.0, 0.0, 8.0, 9.0, Some(0.0), Some(6.0), Some(14.0), 0.75, 0.3, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 367, 100, 75, 0, 6.0, 0.0, 8.0, 9.0, Some(0.0), Some(6.0), Some(14.0), 0.75, 0.3, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
     }
     wait(lua_state, 1.0);
@@ -1139,7 +1146,7 @@ unsafe fn miiswordsman_special_air_hi3_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 31.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 75, 95, 60, 0, 6.3, 0.0, 9.0, 9.0, Some(0.0), Some(9.0), Some(15.0), 0.75, 0.3, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 80, 100, 60, 0, 6.3, 0.0, 9.0, 9.0, Some(0.0), Some(9.0), Some(15.0), 0.75, 0.3, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
     }
     wait(lua_state, 1.0);
@@ -1153,10 +1160,12 @@ unsafe fn miiswordsman_special_air_hi3_game(fighter: &mut L2CAgentBase) {
         AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
     }
     wait(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 39.0, 47.0, 6.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 47.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 361, 208, 0, 30, 7.5, 0.0, 14.0, 4.0, Some(0.0), Some(18.0), Some(11.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
     }
@@ -1177,78 +1186,128 @@ unsafe fn miiswordsman_special_air_hi3_game(fighter: &mut L2CAgentBase) {
 // ======================================== KINESIS BLADE ========================================
 // ===============================================================================================
 
-// Kinesis Blade - Charge Storage
-#[acmd_script( agent = "miiswordsman", script = "game_speciallw1hit" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", script = "game_speciallw1hit", category = ACMD_GAME, low_priority )]
 unsafe fn miiswordsman_special_lw1_hit_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 21.0, 15.0);
     if is_excute(fighter) {
-        let current_level = VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL);
-        // Attack transition
-        if VarModule::is_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER) {
-            VarModule::off_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER);
-            if current_level > 0{
-                if current_level == 1 {
-                    // println!("Changing to level 1");
-                    MotionModule::change_motion(boma, Hash40::new("special_lw1_hit_lv1"), 0.0, 1.0, false, 0.0, false, false);
-                }
-                else{
-                    // println!("Changing to level 2");
-                    MotionModule::change_motion(boma, Hash40::new("special_lw1_hit_lv2"), 0.0, 1.0, false, 0.0, false, false);
-                }
-            }
-        }
-        else{
-            // Increment the level
-            if current_level < 2 {
-                VarModule::set_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL, current_level + 1); // Add a charge level
-                // println!("Kinesis increment");
-            }
-            // println!("Kinesis Level: {}", VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL));
-        }
+        WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_OFF);
     }
-    frame(lua_state, 23.0);
+    frame(lua_state, 21.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 80, 60, 0, 85, 8.8, 0.0, 8.0, 15.0, Some(0.0), Some(8.0), Some(3.0), 1.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        AttackModule::set_force_reaction(boma, 0, true, false);
+    }
+    frame(lua_state, 24.0);
+    FT_MOTION_RATE_RANGE(fighter, 24.0, 47.0, 19.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_ON);
-        //FT_MOTION_RATE(fighter, 0.65);
     }
+    frame(lua_state, 47.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
 
-#[acmd_script( agent = "miiswordsman", script = "game_specialairlw1hit" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "miiswordsman", script = "game_specialairlw1hit", category = ACMD_GAME, low_priority )]
 unsafe fn miiswordsman_special_air_lw1_hit_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 21.0, 15.0);
     if is_excute(fighter) {
-        let current_level = VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL);
-        // Attack transition
-        if VarModule::is_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER) {
-            VarModule::off_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER);
-            if current_level > 0{
-                if current_level == 1 {
-                    // println!("Changing to level 1");
-                    MotionModule::change_motion(boma, Hash40::new("special_air_lw1_hit_lv1"), 0.0, 1.0, false, 0.0, false, false);
-                }
-                else{
-                    // println!("Changing to level 2");
-                    MotionModule::change_motion(boma, Hash40::new("special_air_lw1_hit_lv2"), 0.0, 1.0, false, 0.0, false, false);
-                }
-            }
-        }
-        else{
-            // Increment the level
-            if current_level < 2 {
-                VarModule::set_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL, current_level + 1); // Add a charge level
-                // println!("Kinesis increment");
-            }
-            // println!("Kinesis Level: {}", VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL));
-        }
+        WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_OFF);
     }
-    frame(lua_state, 23.0);
+    frame(lua_state, 21.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 73, 60, 0, 85, 10.5, 0.0, 7.0, 14.0, Some(0.0), Some(7.0), Some(4.0), 1.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        AttackModule::set_force_reaction(boma, 0, true, false);
+    }
+    frame(lua_state, 24.0);
+    FT_MOTION_RATE_RANGE(fighter, 24.0, 47.0, 19.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_ON);
-        //FT_MOTION_RATE(fighter, 0.65);
     }
+    frame(lua_state, 47.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
+
+// Kinesis Blade - Charge Storage
+// #[acmd_script( agent = "miiswordsman", script = "game_speciallw1hit" , category = ACMD_GAME , low_priority)]
+// unsafe fn miiswordsman_special_lw1_hit_game(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     if is_excute(fighter) {
+//         let current_level = VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL);
+//         // Attack transition
+//         if VarModule::is_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER) {
+//             VarModule::off_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER);
+//             if current_level > 0{
+//                 if current_level == 1 {
+//                     // println!("Changing to level 1");
+//                     MotionModule::change_motion(boma, Hash40::new("special_lw1_hit_lv1"), 0.0, 1.0, false, 0.0, false, false);
+//                 }
+//                 else{
+//                     // println!("Changing to level 2");
+//                     MotionModule::change_motion(boma, Hash40::new("special_lw1_hit_lv2"), 0.0, 1.0, false, 0.0, false, false);
+//                 }
+//             }
+//         }
+//         else{
+//             // Increment the level
+//             if current_level < 2 {
+//                 VarModule::set_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL, current_level + 1); // Add a charge level
+//                 // println!("Kinesis increment");
+//             }
+//             // println!("Kinesis Level: {}", VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL));
+//         }
+//     }
+//     frame(lua_state, 23.0);
+//     if is_excute(fighter) {
+//         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_ON);
+//         //FT_MOTION_RATE(fighter, 0.65);
+//     }
+// }
+
+// #[acmd_script( agent = "miiswordsman", script = "game_specialairlw1hit" , category = ACMD_GAME , low_priority)]
+// unsafe fn miiswordsman_special_air_lw1_hit_game(fighter: &mut L2CAgentBase) {
+//     let lua_state = fighter.lua_state_agent;
+//     let boma = fighter.boma();
+//     if is_excute(fighter) {
+//         let current_level = VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL);
+//         // Attack transition
+//         if VarModule::is_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER) {
+//             VarModule::off_flag(fighter.battle_object, vars::miiswordsman::status::SPECIAL_LW1_ATTACK_TRIGGER);
+//             if current_level > 0{
+//                 if current_level == 1 {
+//                     // println!("Changing to level 1");
+//                     MotionModule::change_motion(boma, Hash40::new("special_air_lw1_hit_lv1"), 0.0, 1.0, false, 0.0, false, false);
+//                 }
+//                 else{
+//                     // println!("Changing to level 2");
+//                     MotionModule::change_motion(boma, Hash40::new("special_air_lw1_hit_lv2"), 0.0, 1.0, false, 0.0, false, false);
+//                 }
+//             }
+//         }
+//         else{
+//             // Increment the level
+//             if current_level < 2 {
+//                 VarModule::set_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL, current_level + 1); // Add a charge level
+//                 // println!("Kinesis increment");
+//             }
+//             // println!("Kinesis Level: {}", VarModule::get_int(fighter.battle_object, vars::miiswordsman::instance::SPECIAL_LW1_CHARGE_LEVEL));
+//         }
+//     }
+//     frame(lua_state, 23.0);
+//     if is_excute(fighter) {
+//         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_COUNTER_FLAG_GRAVITY_ON);
+//         //FT_MOTION_RATE(fighter, 0.65);
+//     }
+// }
 
 
 // Kinesis Blade - 1 Charge
@@ -1407,31 +1466,33 @@ unsafe fn miiswordsman_special_lw2_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    FT_MOTION_RATE(fighter, 1.3);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 6.0, 7.0);
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS);
     }
     frame(lua_state, 6.0);
-    FT_MOTION_RATE(fighter, 3.0);
+    FT_MOTION_RATE_RANGE(fighter, 6.0, 12.0, 16.0);
     if is_excute(fighter) {
         if boma.is_button_on(Buttons::Special) {
             VarModule::on_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD);
         }
     }
     frame(lua_state, 12.0);
-    FT_MOTION_RATE(fighter, 1.2);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
-        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 10.0 } else { 0.0 };
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 15.0 + hold, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 2.0, 0.0, 2.0, 15.0 + hold, Some(0.0), Some(25.0), Some(15.0 + hold), 0.9, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_OBJECT);
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 15.0 } else { 0.0 };
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 60, 55, 0, 40, 5.0, 0.0, 9.0, 15.0 + hold, None, None, None, 1.0, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 15, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 60, 55, 0, 40, 2.0, 0.0, 2.0, 15.0 + hold, Some(0.0), Some(25.0), Some(15.0 + hold), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 16.0);
+    FT_MOTION_RATE_RANGE(fighter, 16.0, 23.0, 10.0);
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES);
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 23.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_MIISWORDSMAN_STATUS_REVERSE_SLASH_FLAG_SPECIAL_FALL);
     }
@@ -1456,7 +1517,7 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
         let mut offset = 0;
         EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.4, true);
         if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) {
-            offset = 8;
+            offset = 13;
             EFFECT(fighter, Hash40::new("sys_smash_flash"), Hash40::new("top"), 0, 15.0, 8.0, 0, 0, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
         }
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
@@ -1469,7 +1530,7 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     frame(lua_state, 9.0);
     if is_excute(fighter) {
         if fighter.is_situation(*SITUATION_KIND_AIR) {
-            let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
+            let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 13 } else { 0 };
             EFFECT_FOLLOW(fighter, Hash40::new("sys_smokescreen"), Hash40::new("top"), 0, 25, 13 + hold, 0, 0.0, 0, 0.4, true);
             LAST_EFFECT_SET_SCALE_W(fighter, 0.4, 0.25, 0.4);
             LAST_EFFECT_SET_COLOR(fighter, 0.1, 0.1, 0.1);
@@ -1478,7 +1539,7 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 10.5);
     if is_excute(fighter) {
-        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 13 } else { 0 };
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
             LANDING_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0.5, 0, 0, 0, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, false);
         }
@@ -1487,7 +1548,7 @@ unsafe fn miiswordsman_special_lw2_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 12.0);
     if is_excute(fighter) {
-        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 8 } else { 0 };
+        let hold = if VarModule::is_flag(fighter.object(), vars::miiswordsman::status::SHOCK_SPELL_HOLD) { 13 } else { 0 };
         EFFECT_FOLLOW(fighter, Hash40::new("sys_damage_paralysis"), Hash40::new("arml"), 4, 0, 0, 0, 0, 0, 0.35, true);
         EFFECT_OFF_KIND(fighter, Hash40::new("sys_smokescreen"), false, false);
         EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec"), Hash40::new("top"), 0, 8, 13 + hold, 0, 0, 0, 0.4, true);
@@ -1788,8 +1849,8 @@ pub fn install() {
         miiswordsman_special_hi3_game,
         miiswordsman_special_air_hi3_game,
 
-        //miiswordsman_special_lw1_hit_game,
-        //miiswordsman_special_air_lw1_hit_game,
+        miiswordsman_special_lw1_hit_game,
+        miiswordsman_special_air_lw1_hit_game,
         //miiswordsman_special_lw1_hit_lv1_game,
         //miiswordsman_special_air_lw1_hit_lv1_game,
         //miiswordsman_special_lw1_hit_lv2_game,

--- a/fighters/miiswordsman/src/lib.rs
+++ b/fighters/miiswordsman/src/lib.rs
@@ -43,4 +43,6 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frames!(tornadoshot_frame);
 }

--- a/fighters/miiswordsman/src/opff.rs
+++ b/fighters/miiswordsman/src/opff.rs
@@ -293,3 +293,10 @@ pub unsafe fn miiswordsman_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon)
         moveset(fighter, &mut *info.boma, info.id, info.cat, info.status_kind, info.situation_kind, info.motion_kind.hash, info.stick_x, info.stick_y, info.facing, info.frame);
     }
 }
+
+#[weapon_frame( agent = WEAPON_KIND_MIISWORDSMAN_TORNADOSHOT )]
+pub fn tornadoshot_frame(weapon: &mut L2CFighterBase) {
+    unsafe {
+        ModelModule::set_joint_scale(weapon.module_accessor, Hash40::new("top"), &Vector3f::new(0.6, 0.6, 0.6));
+    }
+}

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -96,7 +96,7 @@ special_air_lw1:
     xlu_end: 0
 special_lw1_hit:
   extra:
-    cancel_frame: 50
+    cancel_frame: 47
 special_air_s3_1:
   extra:
     cancel_frame: 41

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -26,6 +26,30 @@ special_n2:
     move: true
   extra:
     cancel_frame: 47
+special_n3_end:
+  extra:
+    cancel_frame: 80
+special_n3_end_turn:
+  extra:
+    cancel_frame: 80
+special_n3_end_max:
+  extra:
+    cancel_frame: 80
+special_n3_end_max_turn:
+  extra:
+    cancel_frame: 80
+special_air_n3_end:
+  extra:
+    cancel_frame: 80
+special_air_n3_end_turn:
+  extra:
+    cancel_frame: 80
+special_air_n3_end_max:
+  extra:
+    cancel_frame: 80
+special_air_n3_end_max_turn:
+  extra:
+    cancel_frame: 80
 attack_lw4:
   extra:
     cancel_frame: 50

--- a/romfs/source/fighter/miiswordsman/param/vl.prcxml
+++ b/romfs/source/fighter/miiswordsman/param/vl.prcxml
@@ -10,7 +10,7 @@
   <list hash="param_special_n">
     <struct index="0">
       <float hash="n1_offset_ground_x">9.0</float>
-      <float hash="n1_offset_ground_y">5.0</float>
+      <float hash="n1_offset_ground_y">2.0</float>
       <float hash="n1_offset_air_x">9.0</float>
       <float hash="n1_offset_air_y">2.0</float>
     </struct>
@@ -39,9 +39,12 @@
   </list>
   <list hash="param_tornadoshot">
     <struct index="0">
-      <float hash="life">40</float>
-      <float hash="speed_x">0.0</float>
-      <float hash="limit_speed_x">0.4</float>
+      <float hash="life">50</float>
+      <float hash="speed_x">0.3</float>
+      <float hash="limit_speed_x">2.0</float>
+      <float hash="speed_y">0.05</float>
+      <float hash="accel_y">-0.025</float>
+      <float hash="limit_speed_y">-1.8</float>
     </struct>
   </list>
   <list hash="param_lightshuriken">

--- a/romfs/source/fighter/miiswordsman/param/vl.prcxml
+++ b/romfs/source/fighter/miiswordsman/param/vl.prcxml
@@ -7,14 +7,18 @@
       <float hash="p2_x">-11.6</float>
     </struct>
   </list>
-  <list hash="param_lightshuriken">
+  <list hash="param_special_n">
     <struct index="0">
-      <int hash="life">240</int>
-      <float hash="speed">2</float>
-      <float hash="accel">0</float>
-      <float hash="rot_speed">0</float>
-      <int hash="is_penetration">1</int>
+      <float hash="n1_offset_ground_x">9.0</float>
+      <float hash="n1_offset_ground_y">5.0</float>
+      <float hash="n1_offset_air_x">9.0</float>
+      <float hash="n1_offset_air_y">2.0</float>
     </struct>
+    <hash40 index="1">dummy</hash40>
+    <struct index="2">
+      <float hash="n3_attack_power_mul_max">2.0</float>
+    </struct>
+    <hash40 index="3">dummy</hash40>
   </list>
   <list hash="param_special_s">
     <struct index="0">
@@ -32,6 +36,22 @@
       <float hash="s3_chakram_angle_max">30</float>
     </struct>
     <hash40 index="3">dummy</hash40>
+  </list>
+  <list hash="param_tornadoshot">
+    <struct index="0">
+      <float hash="life">40</float>
+      <float hash="speed_x">0.0</float>
+      <float hash="limit_speed_x">0.4</float>
+    </struct>
+  </list>
+  <list hash="param_lightshuriken">
+    <struct index="0">
+      <int hash="life">50</int>
+      <float hash="speed">2</float>
+      <float hash="accel">0</float>
+      <float hash="rot_speed">0</float>
+      <int hash="is_penetration">1</int>
+    </struct>
   </list>
   <list hash="param_chakram">
     <struct index="0">


### PR DESCRIPTION
Contains some QoL/reworks for certain specials

## Changelog
### Gale Strike -> Soaring Zephyr (Neutral Special 1):
 - [R] Changed to a small tornado that rises into the air
 - Hit 1
   - Hitbox Duration: F15-31
   - Damage: 7.0%
   - Angle: 65
   - BKB: 53
   - KBG: 23
   - Hitbox Size: 3.3u
 - Hit 2
   - Hitbox Duration: F32-63
   - Damage: 6.0%
   - Angle: 68
   - BKB: 48
   - KBG: 61
   - Hitbox Size: 3.3u
 - FAF: 52

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/d4d6f55c-f747-4ff3-8d77-e3f1346ad12b

### Warrior Wave (Neutral Special 2):
 - [$] Adjusted vfx
 - Uncharged
   - [+] Hitbox Duration: F15-18 -> F13-16
   - [+] Damage (blade/tip): 10.0/11.0/12.0% -> 11.0/12.0%
   - [+] FAF: 45 -> 43
 - Charged
   - Sword
     - [+] Hitbox Duration: F24-27 -> F23-26
     - [+] Damage (blade/tip): 12.0/13.0/14.0% -> 13.0/14.0%
     - [/] Hitlag Multiplier: 1.4x -> 1.0x
   - Wave
     - [-] Lifetime: 240F -> 50F
     - [+] Damage (early/late): 8.0/6.0% -> 9.0/7.0%
     - [+] Hitlag Multiplier: 0.5x -> 1.0x
   - [+] FAF: 61 -> 60
### Blurring Blade (Neutral Special 3):
 - [-] Damage Multiplier (max charge): 2.4x -> 2.0x
 - Multihits
   - [+] Damage: 0.8% -> 1.0%
   - [+] Shieldstun Multiplier (final hit): 1.0x -> 2.0x
   - [+] Shield Damage: 0.0/1.0% -> 1.0%
 - Launcher
   - [+] Hitbox Duration: F44-45 -> F40-42
   - [+] Damage: 8.0% -> 10.0%
   - [R] Angle: 40 -> 70
   - [R] BKB: 58 -> 80
   - [R] KBG: 105 -> 65
   - [+] Shield Damage: 0.0% -> 2.0%
 - [+] FAF: 85 -> 70

### Hero's Spin (Up Special 3):
 - Multihits
   - [+] Improved linking consistency of the front hits
 - Launcher
   - [+] Hitbox Duration: F47-48 -> F45-46

### Blade Counter (Down Special 1):
 - Success
   - [+] Hitbox Duration: F21-22 -> F16-18
   - [/] Hitlag Multiplier: 1.5x -> 1.3x
   - [+] FAF (ground/air): 41/44 -> 41

### Shock Spell (Down Special 2):
 - [$] Given complete visual overhaul
 - (!) Holding Special during startup will make the attack spawn further away
 - [+] Added a sourspot along the bolt
 - [+] Hitbox Duration: F25-29 -> F24-28
 - Sweetspot
   - [+] SDI Multiplier: 1.0x -> 0.5x
   - [+] Shield Damage: 0.0% -> 15.0%
 - Sourspot
   - Damage: 12.0%
   - Angle: 60
   - BKB: 40
   - KBG: 55
   - Hitbox Size: 2.0u
 - [+] FAF: 57 -> 53

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/b0ea4060-68c8-465d-b024-6984f8585e20

![Screenshot 2023-09-29 22-47-55](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/98ab595e-a4fe-416c-9b66-6149c74d7145)