### PR TITLE
Kirby - Sora Specials & Wavedash Effect fix

### DIFF
--- a/fighters/kirby/src/acmd/other.rs
+++ b/fighters/kirby/src/acmd/other.rs
@@ -192,8 +192,7 @@ unsafe fn landingheavy_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     if is_excute(fighter) {
         LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
-        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
-        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+        if !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             EFFECT(fighter, Hash40::new("kirby_star"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
         }
     }

--- a/fighters/kirby/src/acmd/other.rs
+++ b/fighters/kirby/src/acmd/other.rs
@@ -186,10 +186,24 @@ unsafe fn escape_air_slide_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "kirby", script = "effect_landingheavy", category = ACMD_EFFECT, low_priority )]
+unsafe fn landingheavy_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
+        if !fighter.is_prev_status(*FIGHTER_STATUS_KIND_ESCAPE_AIR)
+        && !fighter.is_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
+            EFFECT(fighter, Hash40::new("kirby_star"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        }
+    }
+}
+
 pub fn install() {
     install_acmd_scripts!(
         escape_air_game,
         escape_air_slide_game,
+        landingheavy_effect,
         dash_sound,
         kirby_turn_dash_game,
         damageflyhi_sound,

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -361,8 +361,9 @@ unsafe fn max_water_shuriken_dc(boma: &mut BattleObjectModuleAccessor, status_ki
     }
 }
 
-// Firaga Airdodge Cancel
+// Sora Magic Cancels
 unsafe fn magic_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+    // Firaga Airdodge Cancel
     if status_kind == *FIGHTER_KIRBY_STATUS_KIND_TRAIL_SPECIAL_N1_SHOOT {
         if frame > 2.0 {
             boma.check_airdodge_cancel();
@@ -1060,12 +1061,10 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
             *FIGHTER_KIRBY_STATUS_KIND_SPECIAL_S_FALL,
             *FIGHTER_KIRBY_STATUS_KIND_SPECIAL_S_JUMP,
             *FIGHTER_KIRBY_STATUS_KIND_SPECIAL_S_ATTACK,
-            *FIGHTER_KIRBY_STATUS_KIND_LUCAS_SPECIAL_N,
-            *FIGHTER_KIRBY_STATUS_KIND_LUCAS_SPECIAL_N_HOLD,
-            *FIGHTER_KIRBY_STATUS_KIND_LUCAS_SPECIAL_N_END,
-            *FIGHTER_KIRBY_STATUS_KIND_LUCAS_SPECIAL_N_FIRE
+            *FIGHTER_KIRBY_STATUS_KIND_TRAIL_SPECIAL_N2,
+            *FIGHTER_KIRBY_STATUS_KIND_TRAIL_SPECIAL_N3
             ])
-        || (0x206..0x37c).contains(&copystatus) {
+        || (0x206..0x377).contains(&copystatus) {
             fighter.sub_air_check_dive();
             if fighter.is_flag(*FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_DIVE) {
                 if [*FIGHTER_KINETIC_TYPE_MOTION_AIR, *FIGHTER_KINETIC_TYPE_MOTION_AIR_ANGLE].contains(&KineticModule::get_kinetic_type(fighter.module_accessor)) {
@@ -1108,7 +1107,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     // Water Shuriken Max Dash Cancel
     max_water_shuriken_dc(boma, status_kind, situation_kind, cat[0], frame);
 
-    // Firaga and Thundaga Cancels
+    // Sora Magic Cancels
     magic_cancels(boma, status_kind, situation_kind, cat[0], frame);
 
     // Bite Early Throw and Turnaround

--- a/fighters/trail/src/acmd/specials.rs
+++ b/fighters/trail/src/acmd/specials.rs
@@ -66,57 +66,128 @@ unsafe fn game_specialairn3(fighter: &mut L2CAgentBase) {
 unsafe fn game_specialn2(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        WorkModule::on_flag(boma,  *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
-        ArticleModule::remove_exist(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER, app::ArticleOperationTarget(0));
-        ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER, false, 0);
-        ArticleModule::change_motion(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER,  Hash40::new("special_n2"), false, 0.0);
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 78, 60, 0, 70, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 20.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
-    }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 50.0);
-    if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
-    }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 90.0);
-    if is_excute(fighter) {
-        WorkModule::off_flag(boma,  *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
-        WorkModule::on_flag(boma,  *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLAG_CHANGE_MAGIC);
+    if fighter.kind() == *FIGHTER_KIND_KIRBY {
+        if is_excute(fighter) {
+            WorkModule::on_flag(boma, *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
+        }
+        frame(lua_state, 1.0);
+        FT_MOTION_RATE(fighter, 0.5);
+        frame(lua_state, 19.0);
+        FT_MOTION_RATE(fighter, 1.0);
+        frame(lua_state, 22.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 100, 40, 0, 3.2, 0.0, 6.4, 2.2, Some(0.0), Some(6.4), Some(5.2), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 2, false, false, true, true, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_MAGIC);
+        }
+        frame(lua_state, 24.0);
+        FT_MOTION_RATE(fighter, 1.25);
+        if is_excute(fighter) {
+            AttackModule::clear(boma, 0, false);
+            WorkModule::set_float(boma, 4.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+            WorkModule::on_flag(boma, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLAG_CHANGE_MAGIC);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, 16.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, -8.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, 24.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, -2.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, 12.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::set_float(boma, -14.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        if is_excute(fighter) {
+            WorkModule::on_flag(boma, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLAG_LAST_SHOOT);
+            WorkModule::set_float(boma, 0.0, *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLOAT_ANGLE);
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_ICE, false, -1);
+        }
+        wait(lua_state, 2.0);
+        FT_MOTION_RATE(fighter, 1.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.8, 42, 64, 0, 52, 3.2, 0.0, 6.4, 2.2, Some(0.0), Some(6.4), Some(6.4), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_MAGIC);
+        }
+        wait(lua_state, 2.0);
+        FT_MOTION_RATE(fighter, 0.8);
+        if is_excute(fighter) {
+            AttackModule::clear(boma, 0, false);
+            WorkModule::off_flag(boma, *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
+        }
+        frame(lua_state, 57.0);
+        FT_START_ADJUST_MOTION_FRAME_arg1(fighter, 1.0);
+    } else {
+        if is_excute(fighter) {
+            WorkModule::on_flag(boma,  *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
+            ArticleModule::remove_exist(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER, app::ArticleOperationTarget(0));
+            ArticleModule::generate_article(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER, false, 0);
+            ArticleModule::change_motion(boma, *FIGHTER_TRAIL_GENERATE_ARTICLE_FLOWER,  Hash40::new("special_n2"), false, 0.0);
+        }
+        frame(lua_state, 10.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 78, 60, 0, 70, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_LL, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        }
+        wait(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        frame(lua_state, 20.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        }
+        wait(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        frame(lua_state, 30.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        }
+        wait(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        frame(lua_state, 40.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
+        }
+        wait(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        frame(lua_state, 50.0);
+        if is_excute(fighter) {
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 4.5, 361, 60, 0, 30, 7.0, 0.0, 6.0, 12.0, Some(0.0), Some(6.0), Some(-12.0), 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FREEZE, *ATTACK_REGION_SWORD);
+        }
+        wait(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+        }
+        frame(lua_state, 90.0);
+        if is_excute(fighter) {
+            WorkModule::off_flag(boma,  *FIGHTER_TRAIL_INSTANCE_WORK_ID_FLAG_MAGIC_SELECT_FORBID);
+            WorkModule::on_flag(boma,  *FIGHTER_TRAIL_STATUS_SPECIAL_N2_FLAG_CHANGE_MAGIC);
+        }
     }
 }
 


### PR DESCRIPTION
Restores Kirby's ability to use Blizzaga and switch to the next magic spell. Since Kirby's Blizzaga is different from Sora's, this one can fastfall.

Also previously, Firaga could fastfall and Thundaga could not. This behavior has been flipped, and now Firaga cannot fastfall while Thundaga can, matching the original character.

Lastly, changing jumpsquat animation to heavylanding caused an extra star particle to appear when jumping, or 2 stars when wavedashing, causing clutter. A check was added to prevent the extra star from spawning when performing a jump.