### PR TITLE
DK adjustments

### DIFF
--- a/fighters/common/src/misc.rs
+++ b/fighters/common/src/misc.rs
@@ -137,11 +137,11 @@ unsafe fn set_team_hook(boma: &mut BattleObjectModuleAccessor, arg2: i32, arg3: 
 #[skyline::hook(replace=TeamModule::set_team_second)]
 unsafe fn set_team_second_hook(boma: &mut BattleObjectModuleAccessor, arg2: i32) {
     original!()(boma, arg2);
-    if (boma.is_item()
-    && boma.kind() == *ITEM_KIND_BARREL) {
-        //println!("set team second called for barrel: {:x}", arg2);
-        return;
-    }
+    // if (boma.is_item()
+    // && boma.kind() == *ITEM_KIND_BARREL) {
+    //     //println!("set team second called for barrel: {:x}", arg2);
+    //     return;
+    // }
 }
 
 #[skyline::hook(replace=TeamModule::set_team_owner_id)]

--- a/fighters/donkey/src/acmd/aerials.rs
+++ b/fighters/donkey/src/acmd/aerials.rs
@@ -7,13 +7,9 @@ unsafe fn attack_air_n(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.65);
-    }
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 8.0, 5.0);
     frame(lua_state, 8.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.000);
-    }
+    FT_MOTION_RATE(fighter, 1.0);
     frame(lua_state, 9.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
@@ -21,7 +17,7 @@ unsafe fn attack_air_n(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 1, 0, Hash40::new("handl"), 12.0, 361, 100, 0, 25, 5.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
         ATTACK(fighter, 2, 0, Hash40::new("hip"), 12.0, 361, 100, 0, 25, 8.0, 1.6, 3.1, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
     }
-    wait(lua_state, 4.0);
+    frame(lua_state, 13.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("handr"), 9.0, 50, 100, 0, 10, 5.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
         ATTACK(fighter, 1, 0, Hash40::new("handl"), 9.0, 50, 100, 0, 10, 5.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
@@ -30,13 +26,8 @@ unsafe fn attack_air_n(fighter: &mut L2CAgentBase) {
     frame(lua_state, 28.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
-	frame(lua_state, 28.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-	wait(lua_state, 12.0);
+    frame(lua_state, 31.0);
     if is_excute(fighter) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
     }
@@ -175,7 +166,7 @@ unsafe fn attack_air_hi(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 0.4);
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
-        ATTACK(fighter, 0, 0, Hash40::new("head"), 12.0, 90, 103, 0, 31, 7.25, 1.0, 1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 0, 0, Hash40::new("head"), 12.0, 90, 86, 0, 54, 7.25, 1.0, 1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
     }
     wait(lua_state, 6.0);
     if is_excute(fighter) {

--- a/fighters/donkey/src/acmd/specials.rs
+++ b/fighters/donkey/src/acmd/specials.rs
@@ -334,42 +334,24 @@ unsafe fn special_lw_loop(fighter: &mut L2CAgentBase) {
 unsafe fn special_air_lw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
+    frame(lua_state, 19.0);
     if is_excute(fighter) {
-        MotionModule::set_rate(boma, 0.67);
-    }
-    frame(lua_state, 7.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 1.0);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 0.5);
-    }
-    frame(lua_state, 14.5);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 0.1);
         JostleModule::set_status(boma, false);
-        //VarModule::on_flag(fighter.battle_object, vars::donkey::status::SPECIAL_AIR_LW_STOP);
-        CATCH(fighter, 0, Hash40::new("top"), 6.0, 0.0, 12.0, 9.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
-        CATCH(fighter, 1, Hash40::new("top"), 7.0, 0.0, 10.0, 13.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_G);
+        CATCH(fighter, 0, Hash40::new("top"), 6.0, 0.0, 5.5, 9.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
+        CATCH(fighter, 1, Hash40::new("top"), 7.0, 0.0, 4.0, 13.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_G);
     }
-    wait(lua_state, 0.5);
+    frame(lua_state, 24.0);
     if is_excute(fighter) {
         grab!(fighter, MA_MSC_CMD_GRAB_CLEAR_ALL);
-        MotionModule::set_rate(boma, 6.0);
     }
-    wait(lua_state, 6.0);
-    if is_excute(fighter) {
-        MotionModule::set_rate(boma, 0.9);
-    }
+    
 }
 
 #[acmd_script( agent = "donkey", script = "sound_specialairlw", category = ACMD_SOUND , low_priority)]
 unsafe fn sound_special_air_lw(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 13.0);
+    frame(lua_state, 19.0);
     if is_excute(fighter) {
         PLAY_SEQUENCE(fighter, Hash40::new("seq_donkey_rnd_attack"));
         PLAY_SE(fighter, Hash40::new("se_donkey_attackdash"));
@@ -382,14 +364,12 @@ unsafe fn effect_special_air_lw(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_flash"), Hash40::new("top"), 5, 16, 5, 0, 0, 0, 0.8, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_flash"), Hash40::new("top"), 5, 16, 9, 0, 0, 0, 0.8, true);
     }
-    frame(lua_state,14.5);
+    frame(lua_state, 18.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("donkey_attack_arc"), Hash40::new("top"), 0, /* up/down */ 17, /* forward/back */ 7.0, -30, -2, 180, 1.15, true);
-        LAST_EFFECT_SET_ALPHA(fighter, 0.75);
-        EFFECT_FOLLOW(fighter, Hash40::new("donkey_attack_arc"), Hash40::new("top"), 0, /* up/down */ 13, /* forward/back */ 5.0, 30, -2, 0, 1.15, true);
-        LAST_EFFECT_SET_ALPHA(fighter, 0.75);
+        EFFECT_FOLLOW(fighter, Hash40::new("donkey_attack_arc"), Hash40::new("top"), -1, 10, 5, -27, 0, 180, 1.4, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("donkey_attack_arc"), Hash40::new("top"), -1, 10, 5, 27, 0, 0, 1.4, true);
     }
 }
 

--- a/fighters/donkey/src/acmd/specials.rs
+++ b/fighters/donkey/src/acmd/specials.rs
@@ -342,7 +342,7 @@ unsafe fn special_air_lw(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         MotionModule::set_rate(boma, 1.0);
     }
-    frame(lua_state, 14.0);
+    frame(lua_state, 12.0);
     if is_excute(fighter) {
         MotionModule::set_rate(boma, 0.5);
     }
@@ -351,9 +351,8 @@ unsafe fn special_air_lw(fighter: &mut L2CAgentBase) {
         MotionModule::set_rate(boma, 0.1);
         JostleModule::set_status(boma, false);
         //VarModule::on_flag(fighter.battle_object, vars::donkey::status::SPECIAL_AIR_LW_STOP);
-        CATCH(fighter, 0, Hash40::new("top"), 6.0, 0.0, 14.0, 5.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
+        CATCH(fighter, 0, Hash40::new("top"), 6.0, 0.0, 12.0, 9.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
         CATCH(fighter, 1, Hash40::new("top"), 7.0, 0.0, 10.0, 13.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_G);
-        CATCH(fighter, 2, Hash40::new("top"), 8.0, 0.0, 10.0, 13.0, None, None, None, *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_A);
     }
     wait(lua_state, 0.5);
     if is_excute(fighter) {

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -78,7 +78,7 @@ unsafe fn game_throwff(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 65, 53, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 60, 53, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 14.0);
@@ -99,7 +99,7 @@ unsafe fn game_throwfb(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 65, 52, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 9.0, 60, 52, 0, 65, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 15.0);
@@ -121,6 +121,9 @@ unsafe fn game_throwfb(fighter: &mut L2CAgentBase) {
 unsafe fn game_throwfhi(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    let weight = WorkModule::get_param_float(boma.get_grabbed_opponent_boma(), hash40("weight"), 0);
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 36.0, 35.0 + 26.0 * (weight / 100.0 - 1.0));
     if is_excute(fighter) {
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 90, 30, 0, 90, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
@@ -130,11 +133,13 @@ unsafe fn game_throwfhi(fighter: &mut L2CAgentBase) {
         CHECK_FINISH_CAMERA(fighter, 1, 31);
     }
     frame(lua_state, 15.0);
-    if is_excute(fighter) { 
-		let release_position = Vector3f{x:0.0, y: 16.0, z: 0.0 };
+    if is_excute(fighter) {
+		let release_position = Vector3f{ x:0.0, y: 16.0, z: 0.0 };
 		ModelModule::set_joint_translate(boma, Hash40::new("throw"), &release_position, false, false);
 		ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
 	}
+    frame(lua_state, 36.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
 
 #[acmd_script( agent = "donkey", script = "game_throwflw" , category = ACMD_GAME , low_priority)]

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -123,7 +123,7 @@ unsafe fn game_throwfhi(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     let weight = WorkModule::get_param_float(boma.get_grabbed_opponent_boma(), hash40("weight"), 0);
-    FT_MOTION_RATE_RANGE(fighter, 1.0, 36.0, 35.0 + 26.0 * (weight / 100.0 - 1.0));
+    FT_MOTION_RATE_RANGE(fighter, 1.0, 36.0, 39.0 + 18.0 * (weight / 100.0 - 1.0));
     if is_excute(fighter) {
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 7.0, 90, 30, 0, 90, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);

--- a/fighters/donkey/src/status/special_lw.rs
+++ b/fighters/donkey/src/status/special_lw.rs
@@ -101,9 +101,9 @@ unsafe extern "C" fn special_lw_main_loop(fighter: &mut L2CFighterCommon) -> L2C
         fighter.change_status(status.into(), false.into());
         return 1.into();
     }
-    if MotionModule::is_end(fighter.module_accessor) {
+    if CancelModule::is_enable_cancel(fighter.module_accessor) {
         let status = if is_air {
-            FIGHTER_STATUS_KIND_FALL
+            FIGHTER_STATUS_KIND_FALL_SPECIAL
         }
         else {
             FIGHTER_DONKEY_STATUS_KIND_SPECIAL_LW_LOOP

--- a/fighters/donkey/src/status/special_lw.rs
+++ b/fighters/donkey/src/status/special_lw.rs
@@ -101,7 +101,7 @@ unsafe extern "C" fn special_lw_main_loop(fighter: &mut L2CFighterCommon) -> L2C
         fighter.change_status(status.into(), false.into());
         return 1.into();
     }
-    if CancelModule::is_enable_cancel(fighter.module_accessor) {
+    if MotionModule::is_end(fighter.module_accessor) {
         let status = if is_air {
             FIGHTER_STATUS_KIND_FALL_SPECIAL
         }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -59,7 +59,7 @@
       <float hash="damage_fly_top_speed_y_stable">2.4</float>
       <float hash="dive_speed_y">2.96</float>
       <float hash="weight">110</float>
-      <float hash="landing_attack_air_frame_n">8</float>
+      <float hash="landing_attack_air_frame_n">10</float>
       <float hash="landing_attack_air_frame_f">13</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">11</float>

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -60,6 +60,8 @@ attack_s3_hi:
     cancel_frame: 35
 special_air_lw:
   blend_frames: 2
+  extra:
+    cancel_frame: 0
 special_lw_end:
   extra:
     cancel_frame: 22

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -25,7 +25,7 @@ attack_lw3:
     cancel_frame: 23
 throw_f_hi:
   extra:
-    cancel_frame: 36
+    cancel_frame: 38
 special_hi:
   extra:
     cancel_frame: 111

--- a/romfs/source/item/common/param/param.prcxml
+++ b/romfs/source/item/common/param/param.prcxml
@@ -9,7 +9,7 @@
       <float hash="hp">999</float><!--vanilla is 14-->
       <!-- force barrel to incur hitlag-->
       <hash40 hash="attack_hitstop_kind">item_attack_hitstop_kind_normal</hash40>
-      <float hash="pickup_range_sizew">10.0</float>
+      <float hash="pickup_range_sizew">7.0</float>
       <float hash="pickup_range_sizeh">12.0</float>
     </struct>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
Assets: [assets-dk.zip](https://github.com/HDR-Development/HewDraw-Remix/files/12787367/assets-dk.zip)

## Changelog
### Neutral Air:
 - [-] Autocancel: F1-6/F26 -> F1-6/F29
 - [-] Landing Lag: 8F -> 10F

### Up Air:
 - [/] BKB: 31 -> 54
 - [/] KBG: 103 -> 86

### Barrel
 - (*) [Hopefully] fixed issues with inconsistent hitbox detection when being launched
 - [$] Given a new model based on barrels from the DK series courtesy of Silent
 - [R] Pickup Radius: 10.0u -> 7.0u
 - [-] Shield Damage: 2.0% -> -2.0%
 - [+] Hitbox Size: 4.8u -> 5.3u
![image](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/c84e1687-cf04-44df-ba44-10088a072a04)
![image](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/a7142fa5-12ac-40ac-b49d-44e745eb4b6a)


### Air Cargo:
 - (!) Given new animation courtesy of mokl
 - [-] Transitions into special fall on whiff
 - [-] Removed outer air-only grab box
 - [/] Grab boxes repositioned
 - [-] Hitbox Duration: F18-22 -> F19-23
![2023091220352600-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/0a881307-58fb-4aa3-be86-36564ee65d71)
![Screenshot 2023-10-02 19-44-24](https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/c0d1bdf6-a271-490a-b027-7947dc887be8)

### Cargo Forward Throw:
 - [/] Angle: 65 -> 60

### Cargo Back Throw:
 - [/] Angle: 65 -> 60

### Cargo Up Throw:
 - (!) Made weight-dependent
 - [R] FAF (min weight/max weight): 36 -> 36/46