### PR TITLE
Add plat drop lockout to initial dash for FGC characters

### DIFF
--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -384,16 +384,18 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
 
     let pass_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("pass_stick_y"));
     let pass_flick_y = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("pass_flick_y"));
-    let fgc_dash_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Common, "fgc_dash_pass_disable_frame");
     if GroundModule::is_passable_ground(fighter.module_accessor)
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
+        // Param-based plat drop lockout window for Ryu, Ken, Terry, and Kazuya
         if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DOLLY || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
-            if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dash_pass_disable_frame {
+            let dash_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Agent, "dash_pass_disable_frame");
+            if fighter.global_table[CURRENT_FRAME].get_i32() >= dash_pass_disable_frame {
                 interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
             }
         }
+        // Normal behavior for all other fighters
         else{
             interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
         }

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -389,7 +389,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
+        if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DOLLY || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
             if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dash_pass_disable_frame {
                 interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
             }

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -384,11 +384,19 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
 
     let pass_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("pass_stick_y"));
     let pass_flick_y = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("pass_flick_y"));
+    let fgc_dash_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Common, "fgc_dash_pass_disable_frame");
     if GroundModule::is_passable_ground(fighter.module_accessor)
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
+        if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
+            if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dash_pass_disable_frame {
+                interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
+            }
+        }
+        else{
+            interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
+        }
     }
 
     if fighter.sub_transition_group_check_ground_attack().get_bool() {

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -389,7 +389,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DOLLY || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
+        if [FIGHTER_KIND_RYU, FIGHTER_KIND_KEN, FIGHTER_KIND_DOLLY, FIGHTER_KIND_DEMON].contains(&fighter.global_table[FIGHTER_KIND]) {
             if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dash_pass_disable_frame {
                 interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
             }

--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -389,7 +389,7 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        if [FIGHTER_KIND_RYU, FIGHTER_KIND_KEN, FIGHTER_KIND_DOLLY, FIGHTER_KIND_DEMON].contains(&fighter.global_table[FIGHTER_KIND]) {
+        if fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_RYU || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_KEN || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DOLLY || fighter.global_table[FIGHTER_KIND] == FIGHTER_KIND_DEMON {
             if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dash_pass_disable_frame {
                 interrupt!(fighter, *FIGHTER_STATUS_KIND_PASS, true);
             }

--- a/fighters/common/src/shoto_status.rs
+++ b/fighters/common/src/shoto_status.rs
@@ -141,12 +141,12 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
 
     let pass_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("pass_stick_y"));
     let pass_flick_y = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("pass_flick_y"));
-    let fgc_dashback_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Common, "fgc_dashback_pass_disable_frame");
+    let dashback_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Agent, "dashback_pass_disable_frame");
     if GroundModule::is_passable_ground(fighter.module_accessor)
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dashback_pass_disable_frame {
+        if fighter.global_table[CURRENT_FRAME].get_i32() >= dashback_pass_disable_frame {
             fighter.change_status(FIGHTER_STATUS_KIND_PASS.into(), true.into());
             return 1.into();
         }

--- a/fighters/common/src/shoto_status.rs
+++ b/fighters/common/src/shoto_status.rs
@@ -141,12 +141,15 @@ unsafe extern "C" fn fgc_dashback_main_loop(fighter: &mut L2CFighterCommon) -> L
 
     let pass_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("pass_stick_y"));
     let pass_flick_y = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("pass_flick_y"));
+    let fgc_dashback_pass_disable_frame = ParamModule::get_int(fighter.object(), ParamType::Common, "fgc_dashback_pass_disable_frame");
     if GroundModule::is_passable_ground(fighter.module_accessor)
     && fighter.global_table[FLICK_Y].get_i32() < pass_flick_y
     && fighter.global_table[STICK_Y].get_f32() < pass_stick_y
     {
-        fighter.change_status(FIGHTER_STATUS_KIND_PASS.into(), true.into());
-        return 1.into();
+        if fighter.global_table[CURRENT_FRAME].get_i32() >= fgc_dashback_pass_disable_frame {
+            fighter.change_status(FIGHTER_STATUS_KIND_PASS.into(), true.into());
+            return 1.into();
+        }
     }
 
     if fighter.sub_transition_group_check_ground_attack().get_bool() {

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -42,4 +42,6 @@
     <float hash="guard_off_motion_start_frame">3</float>
     <int hash="pummel_max_cancel_frame">8</int>
     <int hash="button_walljump_leniency_frame">3</int>
+    <int hash="fgc_dash_pass_disable_frame">10</int>
+    <int hash="fgc_dashback_pass_disable_frame">10</int>
 </struct>

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -42,6 +42,4 @@
     <float hash="guard_off_motion_start_frame">3</float>
     <int hash="pummel_max_cancel_frame">8</int>
     <int hash="button_walljump_leniency_frame">3</int>
-    <int hash="fgc_dash_pass_disable_frame">10</int>
-    <int hash="fgc_dashback_pass_disable_frame">10</int>
 </struct>

--- a/romfs/source/fighter/demon/param/hdr.xml
+++ b/romfs/source/fighter/demon/param/hdr.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
+    <int hash="dash_pass_disable_frame">10</int>
+    <int hash="dashback_pass_disable_frame">10</int>
     <struct hash="cliff_hang_data">
         <struct hash="special_s">
             <float hash="p1_x">16</float>

--- a/romfs/source/fighter/dolly/param/hdr.xml
+++ b/romfs/source/fighter/dolly/param/hdr.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
+    <int hash="dash_pass_disable_frame">10</int>
+    <int hash="dashback_pass_disable_frame">10</int>
     <struct hash="cliff_hang_data">
         <struct hash="special_hi">
             <float hash="p1_x">16</float>

--- a/romfs/source/fighter/ken/param/hdr.xml
+++ b/romfs/source/fighter/ken/param/hdr.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <int hash="dash_pass_disable_frame">10</int>
+    <int hash="dashback_pass_disable_frame">10</int>
+</struct>

--- a/romfs/source/fighter/ryu/param/hdr.xml
+++ b/romfs/source/fighter/ryu/param/hdr.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<struct>
+    <int hash="dash_pass_disable_frame">10</int>
+    <int hash="dashback_pass_disable_frame">10</int>
+</struct>


### PR DESCRIPTION
Edits the `dash` common status script to add a 10F lockout window for plat drop to initial dash for Ryu, Ken, Terry, and Kazuya in order to allow them to input grounded command inputs on droppable platforms. Frame windows are controllable in `hdr/fighter/param/ryu/hdr.prc` (etc. for Ken, Terry, and Kazuya) via the `dash_pass_disable_frame` and `dashback_pass_disable_frame` params for forward and backward dash respectively.