### PR TITLE
Fix grounded knockback freezing bug

### DIFF
--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -555,7 +555,8 @@ pub unsafe fn end_pass_ground(fighter: &mut L2CFighterCommon) -> L2CValue {
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_virtual_ftStatusUniqProcessDamage_exec_common)]
 pub unsafe fn virtual_ftStatusUniqProcessDamage_exec_common(fighter: &mut L2CFighterCommon) {
     // Adding FIGHTER_STATUS_KIND_DAMAGE_AIR to this check allows for DI on non-tumble knockback
-    if [*FIGHTER_STATUS_KIND_DAMAGE_AIR,
+    if [*FIGHTER_STATUS_KIND_DAMAGE,
+        *FIGHTER_STATUS_KIND_DAMAGE_AIR,
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL,
         *FIGHTER_STATUS_KIND_DAMAGE_FLY,
         *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR,


### PR DESCRIPTION
Fixes an issue where moves that dealt only enough knockback to leave you in the `FIGHTER_STATUS_KIND_DAMAGE` status (any hitstun that didn't lift you into the air) would cause you to freeze after the damage animation was over.

Footage of bug in action:

https://github.com/HDR-Development/HewDraw-Remix/assets/52509873/5ba26d6d-bfa5-405b-8c83-ccf62760a2c8



Fixed:

https://github.com/HDR-Development/HewDraw-Remix/assets/52509873/b5547cff-c2c3-4d47-bfd5-5decafaca7b2


