### PR TITLE
Fix Ryu and Ken crashing upon trying to grab plat drop params

### DIFF
--- a/romfs/config.json
+++ b/romfs/config.json
@@ -111,6 +111,12 @@
 		],
 		"fighter/falco/cmn": [
 			"fighter/falco/param/hdr.prc"
+		],
+		"fighter/ryu/cmn": [
+			"fighter/ryu/param/hdr.prc"
+		],
+		"fighter/ken/cmn": [
+			"fighter/ken/param/hdr.prc"
 		]
 	}
 }

--- a/utils/agent_params.txt
+++ b/utils/agent_params.txt
@@ -34,3 +34,5 @@ sheik: fighter/sheik/param/hdr.prc
 miigunner: fighter/miigunner/param/hdr.prc
 falco: fighter/falco/param/hdr.prc
 ness: fighter/ness/param/hdr.prc
+ryu: fighter/ryu/param/hdr.prc
+ken: fighter/ken/param/hdr.prc

--- a/utils/rom_watch.txt
+++ b/utils/rom_watch.txt
@@ -36,3 +36,5 @@ fighter/sheik/param/hdr.xml
 fighter/miigunner/param/hdr.xml
 fighter/falco/param/hdr.xml
 fighter/ness/param/hdr.xml
+fighter/ryu/param/hdr.xml
+fighter/ken/param/hdr.xml


### PR DESCRIPTION
Fixes an issue where the game will crash attempting to load Ryu and Ken's hdr.prc to grab their plat drop lockout window params during dash