### PR TITLE
Dedede followup changes: Tennis edition

### DIFF
--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -309,11 +309,7 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
         if StopModule::is_hit(boma){ 
             for i in 0..num_players{
                 let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
-                //Preventing gordo for staying out for a long time
-                if opponent_boma == owner_module_accessor
-                && (WorkModule::get_int(boma, *WEAPON_DEDEDE_GORDO_STATUS_WORK_INT_BOUND_COUNT) - VarModule::get_int(owner_module_accessor.object(), vars::dedede::instance::RECATCH_COUNTER)) > 1{
-                    VarModule::inc_int(owner_module_accessor.object(), vars::dedede::instance::RECATCH_COUNTER);
-                }
+
                 if AttackModule::is_infliction(opponent_boma, *COLLISION_KIND_MASK_HIT){
                     let data = AttackModule::attack_data(opponent_boma, 0, false);
                     let mut angle = (*data).vector as f32;

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -299,14 +299,44 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
 
     //Disables vanilla regrab searchbox, this ALWAYS needs to be on due to new regrab
     WorkModule::on_flag(owner_module_accessor, *FIGHTER_DEDEDE_INSTANCE_WORK_ID_FLAG_PERSONAL); 
+    let mut speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+    let mut speed_y = KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
 
     if is_excute(fighter) {
-        let damage = DamageModule::damage(boma, 0);
-        if (damage - 5.0) > 7.0{
-            KineticModule::mul_speed(boma, &Vector3f{x: 0.7, y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
-        } 
-        else{
-            KineticModule::mul_speed(boma, &Vector3f{x: 0.10 * (damage - 5.0), y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+        WorkModule::set_int(boma, 300, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
+        let num_players = Fighter::get_fighter_entry_count();
+        if StopModule::is_hit(boma){
+            for i in 0..num_players{
+                let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
+                if AttackModule::is_infliction(opponent_boma, *COLLISION_KIND_MASK_HIT){
+                    let data = AttackModule::attack_data(opponent_boma, 0, false);
+                    let mut angle = (*data).vector as f32;
+                    let mut damage = (*data).power;
+
+                    if angle > 360.0{
+                        angle = 38.0;
+                    }
+                    if damage > 14.0{
+                        damage = 14.0;
+                    }
+
+                    let radians = angle.to_radians();
+                    let cos = radians.cos();
+                    let sin = radians.sin();
+
+                    KineticModule::mul_speed(boma, &Vector3f{x: cos, y: sin  *  (damage / 3.0) / speed_y, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL); 
+                }
+            }
+        if speed_x == KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) &&  speed_y == KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL){
+            let damage = DamageModule::damage(boma, 0);
+            if damage > 11.0{
+                KineticModule::mul_speed(boma, &Vector3f{x: 0.8, y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+            }
+            else{
+                KineticModule::mul_speed(boma, &Vector3f{x: 0.4 + 0.05 * (damage - 5.0), y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+            }
+                println!{"NON DIRECT HIT!!!!!"};
+        }
         }
     }
     for _ in 0..181{
@@ -314,12 +344,19 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
             if !boma.is_status(*WEAPON_DEDEDE_GORDO_STATUS_KIND_HOP) {
                 /* Reduces damage on every bounce, by 12.5% of its last damage in this case */
                 let bounce_dmg_multiplier = ((WorkModule::get_int(boma, *WEAPON_DEDEDE_GORDO_STATUS_WORK_INT_BOUND_COUNT) as f32 + 5.0) * 0.125);
-                ATTACK(fighter, 0, 0, Hash40::new("hip"), 7.5 * bounce_dmg_multiplier, 60, 110, 60, 0, 6.2, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
+                if !StopModule::is_stop(boma){
+                    speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL).abs();
+                    speed_y = KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL).abs();
+                }
+                let mut speed = speed_x.max(speed_y);
+                let mut damage = (7.5 * (speed/2.0));
+                damage = damage.max(7.5);
+
+                ATTACK(fighter, 0, 0, Hash40::new("hip"), damage * bounce_dmg_multiplier, 60, 110, 60, 0, 6.2, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
             }
         }
         wait(lua_state, 1.0);
     }
- 
 }
 
 #[acmd_script( agent = "dedede_gordo", script = "effect_specialsattack" , category = ACMD_EFFECT , low_priority)]

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -304,18 +304,21 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
 
     if is_excute(fighter) {
         WorkModule::set_int(boma, 300, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
-        let num_players = Fighter::get_fighter_entry_count();
-        if StopModule::is_hit(boma){
+        /* below grabs the boma of the opponent hitting gordo, the attack data of that hit, and adjusts the speed accordingly */
+        let num_players = Fighter::get_fighter_entry_count(); 
+        if StopModule::is_hit(boma){ 
             for i in 0..num_players{
                 let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
                 if AttackModule::is_infliction(opponent_boma, *COLLISION_KIND_MASK_HIT){
                     let data = AttackModule::attack_data(opponent_boma, 0, false);
                     let mut angle = (*data).vector as f32;
                     let mut damage = (*data).power;
-
-                    if angle > 360.0{
-                        angle = 38.0;
+                    
+                    //Covering sakurai angle and other funky angles
+                    if angle > 360.0{ 
+                        angle = 32.0;
                     }
+                    //Damage cap, gordo goes to the moon otherwise
                     if damage > 14.0{
                         damage = 14.0;
                     }
@@ -327,6 +330,7 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
                     KineticModule::mul_speed(boma, &Vector3f{x: cos, y: sin  *  (damage / 3.0) / speed_y, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL); 
                 }
             }
+        /* Seeing the speed is still the same. This only occurs if the above did not run, which happens on projectiles or non-direct hits (Bayo smash attacks) */
         if speed_x == KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) &&  speed_y == KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL){
             let damage = DamageModule::damage(boma, 0);
             if damage > 11.0{
@@ -335,7 +339,6 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
             else{
                 KineticModule::mul_speed(boma, &Vector3f{x: 0.4 + 0.05 * (damage - 5.0), y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
             }
-                println!{"NON DIRECT HIT!!!!!"};
         }
         }
     }

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -219,6 +219,7 @@ unsafe fn dedede_gordo_special_s_throw_game(fighter: &mut L2CAgentBase) {
     let gordo_speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);    
     
     if is_excute(fighter){
+        HitModule::set_no_team(boma, true); //allows gordo to be hit by anyone
         if VarModule::is_flag(owner_module_accessor.object(), vars::dedede::instance::IS_DASH_GORDO){
             PostureModule::reverse_rot_y_lr(boma);
             PostureModule::reverse_lr(boma);
@@ -309,25 +310,36 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
         if StopModule::is_hit(boma){ 
             for i in 0..num_players{
                 let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
+                //Preventing gordo for staying out for a long time
+                if opponent_boma == owner_module_accessor
+                && (WorkModule::get_int(boma, *WEAPON_DEDEDE_GORDO_STATUS_WORK_INT_BOUND_COUNT) - VarModule::get_int(owner_module_accessor.object(), vars::dedede::instance::RECATCH_COUNTER)) > 1{
+                    VarModule::inc_int(owner_module_accessor.object(), vars::dedede::instance::RECATCH_COUNTER);
+                }
                 if AttackModule::is_infliction(opponent_boma, *COLLISION_KIND_MASK_HIT){
                     let data = AttackModule::attack_data(opponent_boma, 0, false);
                     let mut angle = (*data).vector as f32;
                     let mut damage = (*data).power;
+                    let kbg = (*data).r_eff as f32;
+                    let bkb = (*data).r_add as f32;
                     
                     //Covering sakurai angle and other funky angles
                     if angle > 360.0{ 
                         angle = 32.0;
                     }
                     //Damage cap, gordo goes to the moon otherwise
-                    if damage > 14.0{
-                        damage = 14.0;
+                    if damage > 25.0{
+                        damage = 25.0;
                     }
 
                     let radians = angle.to_radians();
                     let cos = radians.cos();
                     let sin = radians.sin();
 
-                    KineticModule::mul_speed(boma, &Vector3f{x: cos, y: sin  *  (damage / 3.0) / speed_y, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL); 
+                    //formulas for the speed multipliers
+                    let x_speed_mul = cos * ((kbg * 0.3718) + bkb / 100.0) * (damage / 8.0) / 70.0;
+                    let y_speed_mul =  sin  *  (damage / 2.5) * ((kbg * 0.3718) + bkb / 100.0) / 60.0 / speed_y;
+
+                    KineticModule::mul_speed(boma, &Vector3f{x: x_speed_mul, y: y_speed_mul , z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL); 
                 }
             }
         /* Seeing the speed is still the same. This only occurs if the above did not run, which happens on projectiles or non-direct hits (Bayo smash attacks) */
@@ -341,8 +353,9 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
             }
         }
         }
+        HitModule::set_no_team(boma, true); //allows gordo to be hit by anyone
     }
-    for _ in 0..181{
+    for _ in 0..301{
         if is_excute(fighter) {
             if !boma.is_status(*WEAPON_DEDEDE_GORDO_STATUS_KIND_HOP) {
                 /* Reduces damage on every bounce, by 12.5% of its last damage in this case */
@@ -352,7 +365,7 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
                     speed_y = KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL).abs();
                 }
                 let mut speed = speed_x.max(speed_y);
-                let mut damage = (7.5 * (speed/2.0));
+                let mut damage = (7.5 * (speed * 0.6));
                 damage = damage.max(7.5);
 
                 ATTACK(fighter, 0, 0, Hash40::new("hip"), damage * bounce_dmg_multiplier, 60, 110, 60, 0, 6.2, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, -5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -219,7 +219,6 @@ unsafe fn dedede_gordo_special_s_throw_game(fighter: &mut L2CAgentBase) {
     let gordo_speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);    
     
     if is_excute(fighter){
-        HitModule::set_no_team(boma, true); //allows gordo to be hit by anyone
         if VarModule::is_flag(owner_module_accessor.object(), vars::dedede::instance::IS_DASH_GORDO){
             PostureModule::reverse_rot_y_lr(boma);
             PostureModule::reverse_lr(boma);
@@ -353,7 +352,6 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
             }
         }
         }
-        HitModule::set_no_team(boma, true); //allows gordo to be hit by anyone
     }
     for _ in 0..301{
         if is_excute(fighter) {

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -301,7 +301,13 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
     WorkModule::on_flag(owner_module_accessor, *FIGHTER_DEDEDE_INSTANCE_WORK_ID_FLAG_PERSONAL); 
 
     if is_excute(fighter) {
-        KineticModule::mul_speed(boma, &Vector3f{x: 0.7, y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+        let damage = DamageModule::damage(boma, 0);
+        if (damage - 5.0) > 7.0{
+            KineticModule::mul_speed(boma, &Vector3f{x: 0.7, y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+        } 
+        else{
+            KineticModule::mul_speed(boma, &Vector3f{x: 0.10 * (damage - 5.0), y: 1.0, z: 1.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+        }
     }
     for _ in 0..181{
         if is_excute(fighter) {

--- a/fighters/dedede/src/acmd/specials.rs
+++ b/fighters/dedede/src/acmd/specials.rs
@@ -558,7 +558,7 @@ unsafe fn dedede_special_hi_turn_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     FT_MOTION_RATE(fighter, 13.0 / (20.0 - 1.0));
     if is_excute(fighter) {
-        SET_SPEED_EX(fighter, 0, 0.2, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        SET_SPEED_EX(fighter, 0, 0.5, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
         damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_NORMAL, 0);
     }
     if is_excute(fighter) {

--- a/fighters/dedede/src/opff.rs
+++ b/fighters/dedede/src/opff.rs
@@ -64,9 +64,9 @@ unsafe fn gordo_recatch(boma: &mut BattleObjectModuleAccessor, frame: f32, fight
         let char_pos = *PostureModule::pos(boma); //position of dedede
         let gordo_pos = *PostureModule::pos(article_boma); //position of gordo
         let char_lr = PostureModule::lr(boma); // LR value before we check everything
-        let offset = Vector3f::new(6.0 * char_lr, 9.0, 0.0); //offset, if we need to move the area
+        let offset = Vector3f::new(5.0 * char_lr, 9.0, 0.0); //offset, if we need to move the area
 
-        if ((gordo_pos.x - (char_pos.x + offset.x)).abs() < 18.0 && (gordo_pos.y - (char_pos.y + offset.y)).abs() < 15.0){
+        if ((gordo_pos.x - (char_pos.x + offset.x)).abs() < 19.0 && (gordo_pos.y - (char_pos.y + offset.y)).abs() < 15.0){
             if ((StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_ESCAPE_AIR) 
             || ((StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_LANDING) && StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_ESCAPE_AIR)) 
             && VarModule::is_flag(fighter.battle_object, vars::dedede::instance::CAN_WADDLE_DASH_FLAG){

--- a/fighters/dedede/src/opff.rs
+++ b/fighters/dedede/src/opff.rs
@@ -109,7 +109,8 @@ unsafe fn gordo_recatch(boma: &mut BattleObjectModuleAccessor, frame: f32, fight
         // Re enables gordo dash if d3 has either done a gordodash, has landed, or is in jump squat
         if StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_SPECIAL_S 
         || StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_LANDING 
-        || StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_JUMP_SQUAT{
+        || StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_JUMP_SQUAT
+        || WorkModule::is_flag(boma, *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_JUST_SHIELD){
             VarModule::set_flag(fighter.battle_object, vars::dedede::instance::CAN_WADDLE_DASH_FLAG, true);
         }
         //Prevents B reversing when we are in the dash

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1384,9 +1384,9 @@
       <float hash="air_accel_x_add">0.02</float>
       <float hash="air_speed_x_stable">0.915</float>
       <float hash="air_brake_x">0.005</float>
-      <float hash="air_accel_y">0.095</float>
+      <float hash="air_accel_y">0.124</float>
       <float hash="air_speed_y_stable">2.25</float>
-      <float hash="damage_fly_top_air_accel_y">0.095</float>
+      <float hash="damage_fly_top_air_accel_y">0.124</float>
       <float hash="damage_fly_top_speed_y_stable">2.25</float>
       <float hash="dive_speed_y">3.3</float>
       <float hash="weight">113</float>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1384,9 +1384,9 @@
       <float hash="air_accel_x_add">0.02</float>
       <float hash="air_speed_x_stable">0.915</float>
       <float hash="air_brake_x">0.005</float>
-      <float hash="air_accel_y">0.124</float>
+      <float hash="air_accel_y">0.095</float>
       <float hash="air_speed_y_stable">2.25</float>
-      <float hash="damage_fly_top_air_accel_y">0.124</float>
+      <float hash="damage_fly_top_air_accel_y">0.095</float>
       <float hash="damage_fly_top_speed_y_stable">2.25</float>
       <float hash="dive_speed_y">3.3</float>
       <float hash="weight">113</float>

--- a/romfs/source/fighter/dedede/param/vl.prcxml
+++ b/romfs/source/fighter/dedede/param/vl.prcxml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
+  <list hash="fly_data">
+    <struct index="0">
+      <list hash="speed_y_table">
+        <float index="0">2.55</float>
+        <float index="1">2.17</float>
+        <float index="2">1.80</float>
+        <float index="3">1.54</float>
+      </list>
+    </struct>
+  </list>
   <list hash="param_special_n">
     <struct index="0">
       <int hash="hold_count">25</int>

--- a/romfs/source/fighter/dedede/param/vl.prcxml
+++ b/romfs/source/fighter/dedede/param/vl.prcxml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <struct>
-  <list hash="fly_data">
-    <struct index="0">
-      <list hash="speed_y_table">
-        <float index="0">2.55</float>
-        <float index="1">2.17</float>
-        <float index="2">1.80</float>
-        <float index="3">1.54</float>
-      </list>
-    </struct>
-  </list>
   <list hash="param_special_n">
     <struct index="0">
       <int hash="hold_count">25</int>

--- a/romfs/source/fighter/dedede/param/vl.prcxml
+++ b/romfs/source/fighter/dedede/param/vl.prcxml
@@ -27,6 +27,7 @@
       <float hash="search_radius">0</float>
       <float hash="search_offset_x">0</float>
       <float hash="search_offset_2x">0</float>
+      <float hash="search_offset_y">0</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/dedede/param/vl.prcxml
+++ b/romfs/source/fighter/dedede/param/vl.prcxml
@@ -38,9 +38,12 @@
       <int hash="life">180</int>
       <float hash="accel_y">0.15</float>
       <float hash="0x1f6c5eefa5">5</float>
-      <float hash="turn_speed_min">4</float>
       <int hash="remove_bound_num">2</int>
-      <int hash="remove_turn_num">2</int>
+      <int hash="remove_turn_num">3</int>
+      <float hash="turn_attack_power_max">110</float>
+      <float hash="turn_attack_power_min">35</float>
+      <float hash="turn_speed_max">6</float>
+      <float hash="turn_speed_min">3</float>
       <float hash="hop_speed_x">0.5</float>
       <float hash="hop_speed_y">1.55</float>
       <int hash="hop_life">40</int>


### PR DESCRIPTION
Some followup changes and a design change for hitting gordo back. 

# Changelog

### Gordo
- [R] For most attacks with a direct hitbox, the angle and speed of gordo will change based off of the angle and strength of the attack that hit it
    - This means that gordo can be hit upwards, spiked downwards, etc. This behavior is intended to be similar to DK's barrel item or Pac Man's hydrant 
    - The attack's damage, KBG, and BKB affect how the gordo is sent.
- [R] Projectiles and other outlier cases (stuff like Bayo's smash attacks) will instead change the speed of gordo based off of it's damage, the angle it is sent at will not be changed.




https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/42ca35a2-366a-4be0-883c-0ae722204a10

- [R] Life of gordo when hit back: 180 frames -> 300 frames
    - This is only when hitting gordo back, not thrown or spit gordo
- [R] Base Damage of gordo when hit back: 7.5 Reduced by bounces -> Speed dependent and still reduced by bounces
    - This base damage is always a minimum of 7.5, but the total damage can be lower due to the bounce multiplier
- [/] Times gordo can be hit until despawned: 2 -> 3 
- [+] Absolute maximum speed: 7 -> 6
- [/] Attack power needed to reach this maximum speed is reduced 

### Gordo Regrab
- [+] Offset shifted inwards by 1 unit
- [+] Searchbox shifted outwards by 1 unit
- (*) Fixed a bug where parrying gordo and trying to dash out of it would result in a bugged gordo dash

### Up B
- [+] Extra vertical speed during flip animation: 0.2 -> 0.5




