### PR TITLE
Fixes the emulator check for Ryujinx

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -52,11 +52,11 @@ pub fn is_on_ryujinx() -> bool {
     unsafe {
         // Ryujinx skip based on text addr
         let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
-        if text_addr == 0x8004000 {
-            println!("we are on Ryujinx");
+        if text_addr == 0x8504000 || text_addr == 0x80004000 {
+            println!("we are on Emulator");
             return true;
         } else {
-            println!("we are not on Ryujinx");
+            println!("we are not on Emulator");
             return false;
         }
     }


### PR DESCRIPTION
HDR now recognizes if you're on Ryujinx and will not install the one frame latency codes.