### PR TITLE
Fixes Inkling being able to cancel Splattershot in the air

### DIFF
--- a/fighters/inkling/src/opff.rs
+++ b/fighters/inkling/src/opff.rs
@@ -95,6 +95,7 @@ unsafe fn roller_jump_cancel(boma: &mut BattleObjectModuleAccessor) {
 unsafe fn ink_charge_cancel(boma: &mut BattleObjectModuleAccessor) {
     if (boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_INKLING_STATUS_KIND_SPECIAL_N_SHOOT])
     && boma.is_button_on(Buttons::Guard))
+    && boma.is_situation(*SITUATION_KIND_GROUND)
     {
         boma.change_status_req(*FIGHTER_INKLING_STATUS_KIND_CHARGE_INK_START, false);
     }


### PR DESCRIPTION
Inkling was able to cancel Splattershot in the air, which put her immediately into Fall, allowing her to airdodge directly out of it.