### PR TITLE
Disable double traction during knockdown/Amsah tech

### DIFF
--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -347,7 +347,18 @@ unsafe fn before_collision(object: *mut BattleObject) {
                 let damage_speed_y = app::lua_bind::KineticEnergy::get_speed_y(damage_energy);
                 if damage_speed_x != 0.0
                 && StatusModule::status_kind(boma) <= 0x1DB  // only affects common statuses
-                && (*boma).is_situation(*SITUATION_KIND_GROUND) {
+                && (*boma).is_situation(*SITUATION_KIND_GROUND)
+                && !(*boma).is_status_one_of(&[
+                    *FIGHTER_STATUS_KIND_PASSIVE,
+                    *FIGHTER_STATUS_KIND_PASSIVE_FB,
+                    *FIGHTER_STATUS_KIND_DOWN,
+                    *FIGHTER_STATUS_KIND_DOWN_CONTINUE,
+                    *FIGHTER_STATUS_KIND_DOWN_WAIT,
+                    *FIGHTER_STATUS_KIND_DOWN_WAIT_CONTINUE,
+                    *FIGHTER_STATUS_KIND_DOWN_SPOT,
+                    *FIGHTER_STATUS_KIND_DOWN_STAND,
+                    *FIGHTER_STATUS_KIND_DOWN_STAND_ATTACK,
+                    *FIGHTER_STATUS_KIND_DOWN_STAND_FB]) {
                     let speed_x = KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) - KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_GROUND) - KineticModule::get_sum_speed_x(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_EXTERN);
                     let max_walk = WorkModule::get_param_float(boma, hash40("walk_speed_max"), 0);
                     let ground_brake = WorkModule::get_param_float(boma, hash40("ground_brake"), 0);


### PR DESCRIPTION
You will now slide further along the ground when knocked down/teching from an ASDI down'd attack.