### PR TITLE
ECB Bugfix for certain projectiles and Jigglypuff

### DIFF
--- a/fighters/buddy/src/acmd/other.rs
+++ b/fighters/buddy/src/acmd/other.rs
@@ -223,6 +223,27 @@ unsafe fn buddy_bullet_bakyun_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "buddy_bullet", script = "game_missile", category = ACMD_GAME, low_priority )]
+unsafe fn buddy_bullet_missile_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        GroundModule::set_offset_y(boma, -1.0);
+
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.4, 361, 20, 0, 52, 3.6, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -1, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        AttackModule::enable_safe_pos(boma);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 4.6, 361, 20, 0, 46, 3.2, 0.0, 0.0, 0.0, None, None, None, 0.75, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -1, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+    }
+    frame(lua_state, 40.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.8, 361, 20, 0, 40, 2.8, 0.0, 0.0, 0.0, None, None, None, 0.25, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, -1, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+    }
+}
+
 #[acmd_script( agent = "buddy_pad", script = "game_fall" , category = ACMD_GAME , low_priority)]
 unsafe fn buddy_pad_fall_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;    
@@ -300,6 +321,7 @@ pub fn install() {
         dash_sound,
         turn_dash_game,
         buddy_bullet_bakyun_game,
+        buddy_bullet_missile_game,
         buddy_pad_fall_game,
         damageflyhi_sound,
         damageflylw_sound,

--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -273,6 +273,7 @@ unsafe fn dedede_gordo_special_s_shot_game(fighter: &mut L2CAgentBase) {
     for _ in 0..181{
         if is_excute(fighter) {
             if !boma.is_status(*WEAPON_DEDEDE_GORDO_STATUS_KIND_HOP) {
+                GroundModule::update_force(boma);
                 /* Reduces damage on every bounce, by 12.5% of its last damage in this case */
                 let bounce_dmg_multiplier = ((WorkModule::get_int(boma, *WEAPON_DEDEDE_GORDO_STATUS_WORK_INT_BOUND_COUNT) as f32 + 5.0) * 0.125);
                 ATTACK(fighter, 0, 0, Hash40::new("hip"), 12.8 * bounce_dmg_multiplier, 60, 50, 0, 60, 0.9, 3.8, 3.8, 0.0, Some(-3.8), Some(-3.8), Some(0.0), 1.5, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, -8.4, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);

--- a/fighters/ken/src/acmd/other.rs
+++ b/fighters/ken/src/acmd/other.rs
@@ -226,8 +226,12 @@ unsafe fn game_movewms(fighter: &mut L2CAgentBase) {
         let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
         if (VarModule::is_flag(owner_module_accessor.object(), vars::shotos::instance::IS_CURRENT_HADOKEN_AIR)) {
             let lr = PostureModule::lr(owner_module_accessor);
+            GroundModule::set_rhombus_offset(boma, &Vector2f{x: -4.0 * lr, y: 3.0});
             KineticModule::reflect_speed(boma, &Vector3f{x: 0.26, y: lr * 0.97, z: 0.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
             VarModule::off_flag(owner_module_accessor.object(), vars::shotos::instance::IS_CURRENT_HADOKEN_AIR);
+        }
+        else{
+            GroundModule::set_rhombus_offset(boma, &Vector2f{x: 0.0, y: 0.0});
         }
     }
     wait(lua_state, 7.0);
@@ -271,8 +275,12 @@ unsafe fn game_movespwms(fighter: &mut L2CAgentBase) {
         let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(boma, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
         if (VarModule::is_flag(owner_module_accessor.object(), vars::shotos::instance::IS_CURRENT_HADOKEN_AIR)) {
             let lr = PostureModule::lr(owner_module_accessor);
+            GroundModule::set_rhombus_offset(boma, &Vector2f{x: -4.0 * lr, y: 3.0});
             KineticModule::reflect_speed(boma, &Vector3f{x: 0.26, y: lr * 0.97, z: 0.0}, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
             VarModule::off_flag(owner_module_accessor.object(), vars::shotos::instance::IS_CURRENT_HADOKEN_AIR);
+        }
+        else{
+            GroundModule::set_rhombus_offset(boma, &Vector2f{x: 0.0, y: 0.0}); 
         }
     }
     wait(lua_state, 10.0);

--- a/fighters/purin/src/acmd/specials.rs
+++ b/fighters/purin/src/acmd/specials.rs
@@ -2,6 +2,103 @@
 use super::*;
 
 
+#[acmd_script( agent = "purin", script = "game_specialnstartr", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_n_start_r_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialairnstartr", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_air_n_start_r_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialn", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_n_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma: &mut BattleObjectModuleAccessor = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        JostleModule::set_status(boma, false);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 30, 60, 0, 60, 2.5, 0.0, 5.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+        AttackModule::set_attack_keep_rumble(boma, 0, true);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialairn", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_air_n_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        JostleModule::set_status(boma, false);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 30, 60, 0, 60, 2.5, 0.0, 7.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_BODY);
+        AttackModule::set_attack_keep_rumble(boma, 0, true);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialnhold", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_n_hold_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialairnhold", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_air_n_hold_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialnturn", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_n_turn_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+        JostleModule::set_status(boma, true);
+    }
+}
+
+#[acmd_script( agent = "purin", script = "game_specialairnturn", category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_air_n_turn_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, true);
+        AttackModule::clear_all(boma);
+        JostleModule::set_status(boma, true);
+    }
+}
+
+#[acmd_script( agent = "purin", scripts = ["game_specialairnendl", "game_specialairnendr", "game_specialnendr", "game_specialnendl"], category = ACMD_GAME, low_priority )]
+unsafe fn purin_special_n_end(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        JostleModule::set_status(boma, true);
+        GroundModule::set_shape_flag(boma, *GROUND_CORRECT_SHAPE_RHOMBUS_MODIFY_FLAG_FIX as u16, false);
+    }
+}
+
 #[acmd_script( agent = "purin", script = "game_specials" , category = ACMD_GAME , low_priority)]
 unsafe fn purin_special_s_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -77,6 +174,15 @@ unsafe fn purin_special_lw_game(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
+        purin_special_n_start_r_game,
+        purin_special_air_n_start_r_game,
+        purin_special_n_game,
+        purin_special_air_n_game,
+        purin_special_n_hold_game,
+        purin_special_air_n_hold_game,
+        purin_special_n_turn_game,
+        purin_special_air_n_turn_game,
+        purin_special_n_end,
         purin_special_s_game,
         purin_special_air_s_game,
         purin_special_lw_game,

--- a/fighters/robin/src/acmd/other.rs
+++ b/fighters/robin/src/acmd/other.rs
@@ -214,6 +214,7 @@ unsafe fn robin_elwind_shoot0_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
+        GroundModule::modify_rhombus(boma, 0.0, 1.0, 1.0);
         ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 80, 30, 0, 100, 6.0, 0.0, 2.0, 0.5, Some(0.0), Some(-3.5), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
     }
     wait(lua_state, 4.0);

--- a/romfs/source/fighter/ken/param/vl.prcxml
+++ b/romfs/source/fighter/ken/param/vl.prcxml
@@ -36,6 +36,11 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <struct hash="map_collision_hadoken">
+    <float hash="up">2.0</float>
+    <float hash="down">-2.0</float>
+    <float hash="half_width">2.0</float>
+  </struct>
   <list hash="param_special_s">
     <struct index="0">
       <float hash="speed_x_mul">0.5</float>


### PR DESCRIPTION
Some ECB bugfixes for the following to prevent them from going through stages

- Dedede's gordo during gordo spit - Gordo ECB now properly updates on frame 1 when spitting gordo.
- Robin's Elwind - Elwind ECB Size reduced to prevent it from going through stage.
- Banjo egg - Egg ECB No longer rotates and is shifted downwards by 1 unit.
- Jigglypuff during neutral b - ECB no longer rotates and now stays in a fixed position during neutral b
- Ken's Hadouken - ECB Size increased and moved the ECB towards the back of the projectile during air hadouken. 

## Gordo

Old ECB

![ddd](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/d30f2445-23e2-4d9f-b7ce-0ba8d015f979)


Fixed ECB

![ddd](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/c62a28c2-31b1-4c80-b80f-f75e67e8e67f)




## Elwind

Old ECB

![Robin1](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/50e9e110-5fe8-4a02-98e6-440b2ccb81a5)

New ECB

![Robin1](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/24d66b73-4921-4125-8f20-b5d8dd1d17f3)

Note that this is the windbox from elwind touching the ground


## Egg

Old ECB

![egg](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/5eed4d04-b601-4da6-96ac-70e0d4751ba3)

Fixed ECB

![egg](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/9fa1bc3b-0181-47df-86a7-93d44682ed61)


## Jigglypuff

Old ECB Behavior

https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/5a85712b-d93b-4b3e-b3a6-cc89faabeb64

https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/91f1f659-a23b-4591-880a-e1987100a298

The first clip uses a consistent setup of hitting B on the 22nd frame of being airborne to go through the stage, the second clip shows the rotation of the ECB

Fixed ECB Behavior

https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/887f9cab-7565-4c00-8f27-1f88495e75d5


https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/a71208d2-3c2f-4930-a6a0-9b553e23b9f2


The first clip shows the same setup being used, second clip shows the ECB now being anchored in place.

## Ken

Old ECB

![ken](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/39c33180-0891-4394-a8f6-77a67c31f8ed)

This one may be hard to see but it's in the stage lol.

Fixed ECB

![airhado](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/419ce395-b0a0-4e2e-9e7b-db2ed3411a66)

![groundhado](https://github.com/HDR-Development/HewDraw-Remix/assets/115139386/1e20448e-9569-4164-a253-088390b020e0)



Resolves #137 
