### PR TITLE
MiiSF Apply X Speed Mul to Grounded USpecial3

### DIFF
--- a/fighters/miiswordsman/src/acmd/specials.rs
+++ b/fighters/miiswordsman/src/acmd/specials.rs
@@ -1045,6 +1045,11 @@ unsafe fn miiswordsman_special_hi2_fall_game(fighter: &mut L2CAgentBase) {
 unsafe fn miiswordsman_special_hi3_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    if is_excute(fighter) {
+        let start_x_mul = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "param_special_hi3.start_x_mul");
+        KineticModule::mul_speed(fighter.module_accessor, &Vector3f{x: start_x_mul, y: 1.0, z: 1.0}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
+    }
     frame(lua_state, 4.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("haver"), 14.0, 40, 64, 0, 90, 4.5, 1.0, 11.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);


### PR DESCRIPTION
Fixes a bug where the horizontal speed multiplier was not being applied to Mii Swordfighter's Hero Spin