### PR TITLE
Added landing effect to grounded Min Min tether

### DIFF
--- a/fighters/tantan/src/acmd/specials.rs
+++ b/fighters/tantan/src/acmd/specials.rs
@@ -212,6 +212,9 @@ unsafe fn tantan_special_hi_air_effect(fighter: &mut L2CAgentBase) {
     let angle = WorkModule::get_float(boma,*FIGHTER_TANTAN_INSTANCE_WORK_ID_FLOAT_ATTACK_SHIFT_ANGLE_L);
     if is_excute(fighter) {
         EFFECT(fighter, Hash40::new("tantan_jump_air"), Hash40::new("pl1_have"), 0, 0, 0, 0, 180.0+angle, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            macros::LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 1.3, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
+        }
     }
     if !WorkModule::is_flag(boma, *FIGHTER_TANTAN_STATUS_SPECIAL_HI_FLAG_IS_SPECIAL_HI_AIR_PHYSICS) {
         if is_excute(fighter) {


### PR DESCRIPTION
Landing effect for Min Min grounded tether to match Byleth and Joker

AFTER

https://github.com/HDR-Development/HewDraw-Remix/assets/6856627/4dae202e-03d7-4dbe-ae2f-d802817e0d0f

BEFORE

https://github.com/HDR-Development/HewDraw-Remix/assets/6856627/6b14b57c-634f-49e1-87b5-c81648d1e8ab

VANILLA

https://github.com/HDR-Development/HewDraw-Remix/assets/6856627/9c9f3c28-4412-4c90-b19a-b630b8474e1a

https://github.com/HDR-Development/HewDraw-Remix/assets/6856627/5fc15a34-dffc-4592-872a-be14d59743a3




