### PR TITLE
Sora recovery adjustment

### DIFF
--- a/romfs/source/fighter/trail/param/vl.prcxml
+++ b/romfs/source/fighter/trail/param/vl.prcxml
@@ -50,6 +50,8 @@
     <struct index="0">
       <float hash="start_accel_y_mul_air">0.6</float>
       <float hash="jump_accel_y">0.035</float>
+      <float hash="jump_accel_x_add">0.06</float>
+      <float hash="jump_speed_x_mul">0.3</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
## UpB:

- Rising horizontal additional air accel reduced 0.12 -> 0.06
- Rising horizontal max airspeed multiplier reduced 0.6 -> 0.3
