### PR TITLE
Dark Samus recovery adjustment

### DIFF
--- a/romfs/source/fighter/samusd/param/vl.prcxml
+++ b/romfs/source/fighter/samusd/param/vl.prcxml
@@ -82,6 +82,7 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="sjump_ar_vy0">2.85</float>
+      <float hash="sjump_vx_max">0.2</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
### UpB:

- Rising max horizontal air speed reduced 0.57 -> 0.2