### PR TITLE
Phantom Cancel Bug Fix

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1191,7 +1191,7 @@ pub mod vars {
         pub mod instance {
             // flags
             pub const DEIN_ACTIVE: i32 = 0x0100;
-            pub const PHANTOM_RELEASED: i32 = 0x0101;
+            pub const PHANTOM_HIT: i32 = 0x0101;
             pub const HIT_CANCEL_PHANTOM: i32 = 0x0102;
 
             // ints

--- a/fighters/zelda/src/acmd/other.rs
+++ b/fighters/zelda/src/acmd/other.rs
@@ -368,14 +368,14 @@ unsafe fn zelda_phantom_attack_kick_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
 	let rush_speed = 4.5;
 	frame(lua_state, 0.0);
+	FT_MOTION_RATE(fighter, 6.0/(5.0-0.0));
 	if is_excute(fighter) {
 		KineticModule::unable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
-		FT_MOTION_RATE(fighter, 6.0/(5.0-0.0));
 	}
 	frame(lua_state, 5.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
 		KineticModule::enable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
-		FT_MOTION_RATE(fighter, 1.0);
 		fighter.clear_lua_stack();
 		lua_args!(fighter, WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL, rush_speed * PostureModule::lr(boma));
 		app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
@@ -432,20 +432,18 @@ unsafe fn zelda_phantom_attack_punch_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
 	let rush_speed = 5.0;
 	frame(lua_state, 0.0);
+	FT_MOTION_RATE(fighter, 2.0/(0.5-0.0));
 	if is_excute(fighter) {
 		ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 100, 60, 0, 4.0, 0.0, 7.0, 11.0, Some(0.0), Some(7.0), Some(7.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 3, true, false, true, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		ATTACK(fighter, 1, 0, Hash40::new("top"), 0.0, 361, 100, 40, 0, 6.0, 0.0, 7.0, 11.0, Some(0.0), Some(7.0), Some(7.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 3, true, false, true, true, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
-		FT_MOTION_RATE(fighter, 2.0/(0.5-0.0));
 		KineticModule::unable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
 	}
 	frame(lua_state, 0.5);
-	if is_excute(fighter) {
-		FT_MOTION_RATE(fighter, 1.0/(1.0-0.5));
-	}
+	FT_MOTION_RATE(fighter, 1.0/(1.0-0.5));
 	frame(lua_state, 1.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
 		KineticModule::enable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
-		FT_MOTION_RATE(fighter, 1.0);
 		fighter.clear_lua_stack();
 		lua_args!(fighter, WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL, rush_speed * PostureModule::lr(boma));
 		app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
@@ -503,8 +501,8 @@ unsafe fn zelda_phantom_attack_s_game(fighter: &mut L2CAgentBase) {
 		KineticModule::unable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
 	}
 	frame(lua_state, 3.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
-		FT_MOTION_RATE(fighter, 1.0);
 		ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 100, 50, 0, 5.0, 0.0, 8.0, 10.0, Some(0.0), Some(8.0), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 4, true, false, true, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		ATTACK(fighter, 1, 0, Hash40::new("top"), 0.0, 361, 100, 40, 0, 7.0, 0.0, 8.0, 10.0, Some(0.0), Some(8.0), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 4, true, false, true, true, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		KineticModule::enable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
@@ -601,8 +599,8 @@ unsafe fn zelda_phantom_attack_l_game(fighter: &mut L2CAgentBase) {
 		KineticModule::unable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
 	}
 	frame(lua_state, 3.0);
+	FT_MOTION_RATE(fighter, 1.0);
 	if is_excute(fighter) {
-		FT_MOTION_RATE(fighter, 1.0);
 		ATTACK(fighter, 0, 0, Hash40::new("top"), 0.0, 361, 100, 110, 0, 5.5, 0.0, 8.0, 10.0, Some(0.0), Some(8.0), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 3, true, false, true, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		ATTACK(fighter, 1, 0, Hash40::new("top"), 0.0, 361, 100, 80, 0, 7.0, 0.0, 8.0, 10.0, Some(0.0), Some(8.0), Some(4.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 3, true, false, true, true, false, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		KineticModule::enable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
@@ -831,6 +829,21 @@ unsafe fn zelda_phantom_attack_max_effect(fighter: &mut L2CAgentBase) {
 	}
 }
 
+#[acmd_script( agent = "zelda_phantom", script = "game_cancel" , category = ACMD_GAME , low_priority)]
+unsafe fn zelda_phantom_cancel_game(fighter: &mut L2CAgentBase) {
+	let owner_id = WorkModule::get_int(fighter.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
+	let zelda = utils::util::get_battle_object_from_id(owner_id);
+	frame(fighter.lua_state_agent, 1.0);
+	if VarModule::is_flag(zelda, vars::zelda::instance::HIT_CANCEL_PHANTOM) {
+		FT_MOTION_RATE_RANGE(fighter, 1.0, 34.0, 99.0);
+	}
+	frame(fighter.lua_state_agent, 30.0);//100
+	if VarModule::is_flag(zelda, vars::zelda::instance::HIT_CANCEL_PHANTOM) {
+		FT_MOTION_RATE_RANGE(fighter, 30.0, 90.0, 320.0); //8 seconds
+		VarModule::off_flag(zelda, vars::zelda::instance::HIT_CANCEL_PHANTOM);
+	}
+}
+
 #[acmd_script( agent = "zelda_phantom", script = "effect_cancel", category = ACMD_EFFECT, low_priority )]
 unsafe fn zelda_phantom_cancel_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -840,17 +853,14 @@ unsafe fn zelda_phantom_cancel_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT(fighter, Hash40::new("zelda_phantom_end2"), Hash40::new("top"), 0, 8, 0, 0, 0, 0, 1.3, 0, 0, 0, 0, 0, 0, true);
+		EFFECT_FOLLOW(fighter, Hash40::new("zelda_phantom_end2"), Hash40::new("top"), 0, 8, 0, 0, 0, 0, 1.3, false);
     }
-    frame(lua_state, 85.0);
+    frame(lua_state, 89.0);
     if is_excute(fighter) {
         EFFECT(fighter, Hash40::new("zelda_phantom_end"), Hash40::new("trans"), 0, 2, 0, 0, 0, 0, 1.18, 0, 0, 0, 0, 0, 0, true);
         LAST_EFFECT_SET_RATE(fighter, 1.75);
         EFFECT(fighter, Hash40::new("zelda_phantom_build"), Hash40::new("trans"), 0, 1.5, 0, 0, -90, 0, 0.75, 0, 0, 0, 0, 0, 0, true);
         LAST_EFFECT_SET_RATE(fighter, 1.5);
-    }
-    frame(lua_state, 89.0);
-    if is_excute(fighter) {
         fighter.on_flag(*WEAPON_ZELDA_PHANTOM_INSTANCE_WORK_ID_FLAG_END);
     }
 }
@@ -907,6 +917,7 @@ pub fn install() {
 		zelda_phantom_attack_l_effect,
 		zelda_phantom_attack_max_game,
 		zelda_phantom_attack_max_effect,
+		zelda_phantom_cancel_game,
 		zelda_phantom_cancel_effect,
         damageflyhi_sound,
         damageflylw_sound,

--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -61,13 +61,11 @@ unsafe fn phantom_special_cancel(fighter: &mut L2CFighterCommon, boma: &mut Batt
         *FIGHTER_STATUS_KIND_ATTACK_LW4,
         *FIGHTER_STATUS_KIND_ATTACK_DASH,
         *FIGHTER_STATUS_KIND_ATTACK_AIR]) {
-        if fighter.is_cat_flag(Cat1::SpecialLw) {
-            if !fighter.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR) {
+        if fighter.is_cat_flag(Cat1::SpecialLw) && !ArticleModule::is_exist(boma, *FIGHTER_ZELDA_GENERATE_ARTICLE_PHANTOM) {
+            if !fighter.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR) { //displacement flag
                 VarModule::on_flag(fighter.battle_object, vars::zelda::instance::HIT_CANCEL_PHANTOM);
-            } //displacement flag
-            if !ArticleModule::is_exist(boma, *FIGHTER_ZELDA_GENERATE_ARTICLE_PHANTOM) {
-                StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_SPECIAL_LW, false);
-            } //no cancel to activate
+            }//cancel if phantom is off cd
+            StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_SPECIAL_LW, false);
         }
     }
 }
@@ -120,12 +118,10 @@ unsafe fn dins_flag_reset(boma: &mut BattleObjectModuleAccessor) {
 }
 
 pub unsafe fn phantom_platdrop_effect(fighter:&mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) {
-        if fighter.status_frame() > 9 {
-            if ControlModule::get_stick_y(boma) < -0.66 && GroundModule::is_passable_ground(boma) {
-                GroundModule::pass_floor(boma);
-            }
-        }
+    if fighter.is_status(*FIGHTER_STATUS_KIND_SPECIAL_LW) && fighter.status_frame() > 9 {
+        if ControlModule::get_stick_y(boma) < -0.66 && GroundModule::is_passable_ground(boma) {
+            GroundModule::pass_floor(boma);
+        }//platdrop
     }
     if VarModule::get_int(fighter.battle_object, vars::zelda::instance::EFF_COOLDOWN_HANDLER) == -1 {
         if ArticleModule::is_exist(boma, *FIGHTER_ZELDA_GENERATE_ARTICLE_PHANTOM) {
@@ -141,6 +137,8 @@ pub unsafe fn phantom_platdrop_effect(fighter:&mut smash::lua2cpp::L2CFighterCom
         let handle = VarModule::get_int(fighter.battle_object, vars::zelda::instance::EFF_COOLDOWN_HANDLER) as u32;
         if !ArticleModule::is_exist(boma, *FIGHTER_ZELDA_GENERATE_ARTICLE_PHANTOM) {
             VarModule::set_int(fighter.battle_object, vars::zelda::instance::EFF_COOLDOWN_HANDLER, -2);//remove
+            VarModule::off_flag(fighter.battle_object, vars::zelda::instance::HIT_CANCEL_PHANTOM);
+            VarModule::off_flag(fighter.battle_object, vars::zelda::instance::PHANTOM_HIT);
         } else if !EffectModule::is_exist_effect(boma, handle as u32) {
             VarModule::set_int(fighter.battle_object, vars::zelda::instance::EFF_COOLDOWN_HANDLER, -1);
         } //reapply
@@ -207,10 +205,6 @@ pub unsafe fn zelda_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     }
 }
 
-extern "Rust" {
-    fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
-}
-
 #[smashline::weapon_frame_callback(main)]
 pub fn phantom_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
     unsafe { 
@@ -221,11 +215,14 @@ pub fn phantom_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
         let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
         let zelda = utils::util::get_battle_object_from_id(owner_id);
         let zelda_boma = &mut *(*zelda).module_accessor;
-        if weapon.is_status(*WEAPON_ZELDA_PHANTOM_STATUS_KIND_CANCEL) {
-            if StopModule::is_damage(weapon.module_accessor) && !AttackModule::is_infliction_status(weapon.module_accessor, *COLLISION_KIND_MASK_HIT | *COLLISION_KIND_MASK_SHIELD) {
-                MotionModule::set_rate(weapon.module_accessor, 0.25); //8s
-            }
-        } else if weapon.is_status(*WEAPON_ZELDA_PHANTOM_STATUS_KIND_BUILD) {
+        //hitcheck
+        if AttackModule::is_infliction(weapon.module_accessor, *COLLISION_KIND_MASK_HIT) {
+            VarModule::on_flag(zelda, vars::zelda::instance::PHANTOM_HIT); 
+        }
+        if StopModule::is_stop(weapon.module_accessor) && !VarModule::is_flag(zelda, vars::zelda::instance::PHANTOM_HIT) {
+            VarModule::on_flag(zelda, vars::zelda::instance::HIT_CANCEL_PHANTOM);
+        }//misc mechanics
+        if weapon.is_status(*WEAPON_ZELDA_PHANTOM_STATUS_KIND_BUILD) {
             let remaining_hitstun = WorkModule::get_float(zelda_boma, *FIGHTER_INSTANCE_WORK_ID_FLOAT_DAMAGE_REACTION_FRAME);
             if weapon.is_situation(*SITUATION_KIND_AIR) {
                 let through_passable_ground_stick_y= WorkModule::get_param_float(zelda_boma, hash40("common"), hash40("through_passable_ground_stick_y")) * -1.0;


### PR DESCRIPTION
Accidentally moved the displacement check outside of the phantom cd check, now properly only enables flag if it's cancelling (beta behavior). 
Additionally: 
- Fixes erroneous phantom cooldowns, using changed formatting with MOTION_RATE_RANGE (cleaner and more accurate) and ACMD instead of opff
- Fixed phantom hit checks to properly function and only apply on-hit. (infliction checks were getting reset when hit, and accidentally checked on-shield instead of only on-hit)