### PR TITLE
Remove ledge option intangibility staling

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -111,6 +111,22 @@
   <float hash="cliff_dive_cont_value">-0.8786</float>
   <float hash="stand_stick_y">0.2</float>
   <float hash="stand_fb_stick_x">0.2</float>
+  <list hash="cliff_catch_motion_rate">
+    <float index="0">1</float>
+    <float index="1">1</float>
+    <float index="2">1</float>
+    <float index="3">1</float>
+    <float index="4">1</float>
+    <float index="5">1</float>
+    <float index="6">1</float>
+    <float index="7">1</float>
+  </list>
+  <list hash="0x1dff572177">
+    <float index="0">1</float>
+    <float index="1">1</float>
+    <float index="2">1</float>
+    <float index="3">1</float>
+  </list>
   <float hash="pass_stick_y">-0.6929</float>
   <int hash="passive_trigger_frame">20</int>
   <int hash="no_rapid_frame_value">40</int>


### PR DESCRIPTION
Ledge options will have the same amount of intangibility frames no matter how many times you regrab ledge beforehand.