### PR TITLE
Zelda Shorten Telecancel Clear Buffer Fix

### DIFF
--- a/fighters/zelda/src/opff.rs
+++ b/fighters/zelda/src/opff.rs
@@ -7,6 +7,8 @@ unsafe fn teleport_tech(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &m
     if boma.is_status(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2) {
         if compare_mask(ControlModule::get_pad_flag(boma), *FIGHTER_PAD_FLAG_SPECIAL_TRIGGER) {
             VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK);
+            ControlModule::reset_trigger(boma);
+            ControlModule::clear_command_one(boma, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_FLAG_SPECIAL_ANY);
             boma.change_status_req(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_3, true);
         }
     }
@@ -16,8 +18,8 @@ unsafe fn teleport_tech(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &m
     let touch_left = GroundModule::is_wall_touch_line(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
 
     if boma.is_status(*FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2) {
-        let touch_normal_y_left = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
-        let touch_normal_y_right = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
+        let touch_normal_y_left = GroundModule::get_touch_normal_y(boma, *GROUND_TOUCH_FLAG_LEFT_SIDE as u32);
+        let touch_normal_y_right = GroundModule::get_touch_normal_y(boma, *GROUND_TOUCH_FLAG_RIGHT_SIDE as u32);
         if (touch_right && touch_normal_y_right != 0.0)
         || (touch_left && touch_normal_y_left != 0.0)
         || VarModule::is_flag(boma.object(), vars::common::instance::IS_TELEPORT_WALL_RIDE)


### PR DESCRIPTION
Currently, shortening teleport into a ledge cancel frame perfectly will buffer a special move. This simply clears the buffer like similar moves to prevent this. 
*When this happens effects don't spawn, which is different from a vanilla telecancel. This leads me to believe it's edge-cancelling before effects spawn. This likely could also be fixed with a main_loop edit to make changing situation not force a fall/landing status.

https://github.com/HDR-Development/HewDraw-Remix/assets/122749442/570df6b5-e1ad-4d23-95c1-268f8df0cde1

