### PR TITLE
Ganondorf hotfix

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -168,9 +168,7 @@
   <float hash="escape_f_penalty_motion_rate">0</float>
   <float hash="escape_b_penalty_motion_rate">0</float>
   <float hash="smash_hold_reaction_mul">1.2</float>
-  <float hash="ganon_special_s_fall_hold_frame">55</float>
-  <float hash="ganon_special_s_fall_clatter_add_frame_up_limit">40</float>
-  <float hash="ganon_special_s_fall_clatter_add_frame_down_limit">30</float>
+  <float hash="ganon_special_s_fall_hold_frame">85</float>
   <!-- dk cargo carry: -->
   <!-- flat amount of clatter added when you enter cargo carry -->
   <float hash="shouldered_frame_add">30</float>


### PR DESCRIPTION
Fixes Flame Choke params being reduced more than intended