### PR TITLE
Exclude more SFX from from volume boost

### DIFF
--- a/fighters/common/src/function_hooks/sound.rs
+++ b/fighters/common/src/function_hooks/sound.rs
@@ -26,7 +26,8 @@ unsafe fn PLAY_SE_hook(lua_state: u64) {
 unsafe fn soundmodule__play_se_hook(sound_module: u64, se: smash::phx::Hash40, arg2: bool, arg3: bool, arg4: bool, arg5: bool, se_type: smash::app::enSEType) -> u64 {
     let handle = original!()(sound_module, se, arg2, arg3, arg4, arg5, se_type);
     let boma = *(sound_module as *mut *mut BattleObjectModuleAccessor).add(1);
-    if !utils::se::SE_LIST.contains(&se.hash) {
+    if se_type.0 == 0
+    && !utils::se::SE_LIST.contains(&se.hash) {
         // Increase volume of most of the game's SFX (excluding voice clips)
         SoundModule::set_se_vol(boma, handle as i32, 1.25, 0);
     }


### PR DESCRIPTION
Damage/landing/stepping SFX were not meant to have the 1.25x volume boost applied to them.