### PR TITLE
Remove NSpecial 1f Parry Forgiveness

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -678,7 +678,6 @@ pub mod vars {
             pub const DISABLE_SPECIAL_LW: i32 = 0x0102;
             pub const IS_POWERED_UP: i32 = 0x0103;
             pub const IS_USPECIAL_ATTACK_CANCEL: i32 = 0x0104;
-            pub const DISABLE_NSPECIAL_PARRY_FORGIVENESS: i32 = 0x0105;
 
             // ints
             pub const METER_PAUSE_REGEN_FRAME: i32 = 0x0100;

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -139,16 +139,11 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
 }
 
 pub unsafe fn taunt_parry_forgiveness(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_APPEAL, *FIGHTER_STATUS_KIND_SPECIAL_N])
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_APPEAL])
     && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
     && fighter.global_table[CURRENT_FRAME].get_i32() <= 1
     && fighter.is_parry_input()
     {
-        // prevents lucario from parrying during ASC
-        if fighter.kind() == *FIGHTER_KIND_LUCARIO
-        && VarModule::is_flag(fighter.battle_object, vars::lucario::instance::DISABLE_NSPECIAL_PARRY_FORGIVENESS) {
-            return;
-        }
         EffectModule::kill_all(fighter.module_accessor, *EFFECT_SUB_ATTRIBUTE_NONE as u32, true, false);
         SoundModule::stop_all_sound(fighter.module_accessor);
         fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());

--- a/fighters/lucario/src/opff.rs
+++ b/fighters/lucario/src/opff.rs
@@ -355,7 +355,6 @@ unsafe fn magic_series(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMo
         *FIGHTER_STATUS_KIND_ATTACK_AIR
     ].contains(&status_kind) {
         if boma.is_cat_flag(Cat1::SpecialN) {
-            VarModule::on_flag(fighter.battle_object, vars::lucario::instance::DISABLE_NSPECIAL_PARRY_FORGIVENESS);
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_SPECIAL_N,false);
         }
         if boma.is_cat_flag(Cat1::SpecialS) {

--- a/fighters/lucario/src/status/special_n.rs
+++ b/fighters/lucario/src/status/special_n.rs
@@ -176,7 +176,6 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
 
 #[status_script(agent = "lucario", status = FIGHTER_STATUS_KIND_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
 unsafe fn special_n_end(fighter: &mut L2CFighterCommon) -> L2CValue {
-    VarModule::off_flag(fighter.battle_object, vars::lucario::instance::DISABLE_NSPECIAL_PARRY_FORGIVENESS);
     lucario_special_n_save_charge_status(fighter);
     0.into()
 }


### PR DESCRIPTION
- fixes an issue that allowed characters to special-cancel NSpecial into parry/shield/grab
- follows the standard set by grab button (the other shield macro)

https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/47c6ff16-e307-4b0a-b599-d88ea9dc3b6d

https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/c35242f6-8905-4bf8-8e0e-2c1e48d4ae8e

https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/949ac8f3-53da-4341-b0e5-3da0a3d76ef8

https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/115fadeb-6df0-4c8a-8f35-c7f245af0afb

