### PR TITLE
Killager

### DIFF
--- a/fighters/murabito/src/acmd/aerials.rs
+++ b/fighters/murabito/src/acmd/aerials.rs
@@ -46,8 +46,10 @@ unsafe fn murabito_attack_air_b_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 12.0);
     FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 365, 45, 0, 35, 3.5, 0.0, 5.5, -0.5, Some(0.0), Some(5.5), Some(-3.5), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 365, 45, 0, 35, 5.5, 0.0, 5.5, -10.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.0, 365, 45, 0, 35, 3.5, 0.0, 5.5, -0.5, Some(0.0), Some(5.5), Some(-3.5),   0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 2.0, 365, 45, 0, 35, 5.5, 0.0, 5.5, -10.0, None, None, None,                  0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 2.0, 80, 45, 0, 35, 3.5, 0.0, 5.5, -0.5, Some(0.0), Some(5.5), Some(-3.5),    0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 3, 0, Hash40::new("top"), 2.0, 80, 45, 0, 35, 5.5, 0.0, 5.5, -10.0, None, None, None,                   0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 24.0);
     if is_excute(fighter) {
@@ -56,11 +58,11 @@ unsafe fn murabito_attack_air_b_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 25.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 361, 135, 0, 40, 3.5, 0.0, 5.5, -0.5, Some(0.0), Some(5.5), Some(-3.5), 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_BOMB, *ATTACK_REGION_OBJECT);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 361, 135, 0, 40, 6.0, 0.0, 5.5, -10.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_BOMB, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 7.0, 361, 135, 0, 40, 6.0, 0.0, 5.5, -10.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_BOMB, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 28.0);
+    FT_MOTION_RATE(fighter, 19.0/(41.0-28.0));
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 19.0/(41.0-28.0));
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 31.0);
@@ -169,9 +171,9 @@ unsafe fn murabito_attack_air_hi_game(fighter: &mut L2CAgentBase) {
         }
     }
     frame(lua_state, 23.0);
+    FT_MOTION_RATE(fighter, 0.7);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        FT_MOTION_RATE(fighter, 0.7);
     }
     frame(lua_state, 29.0);
     if is_excute(fighter) {
@@ -185,13 +187,9 @@ unsafe fn murabito_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.769);
-    }
+    FT_MOTION_RATE(fighter, 0.769);
     frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.000);
-    }
+    FT_MOTION_RATE(fighter, 1.000);
     frame(lua_state, 14.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);

--- a/fighters/murabito/src/acmd/ground.rs
+++ b/fighters/murabito/src/acmd/ground.rs
@@ -13,14 +13,12 @@ unsafe fn murabito_attack_dash_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ArticleModule::generate_article(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_FLOWERPOT, false, 0);
     }
-    frame(lua_state, 9.0);
+    frame(lua_state, 7.0);
     if is_excute(fighter) {
         ArticleModule::shoot(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_FLOWERPOT, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
     }
     frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 30.0/(44.0-10.0));
-    }
+    FT_MOTION_RATE(fighter, 30.0/(44.0-10.0));
 }
 
 

--- a/fighters/murabito/src/acmd/other.rs
+++ b/fighters/murabito/src/acmd/other.rs
@@ -62,7 +62,7 @@ unsafe fn murabito_bullet_shoot_f_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 9.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.5, 361, 100, 0, 10, 1.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -1, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 2.5, 361, 100, 0, 10, 2.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -1, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
     }
     
 }

--- a/fighters/murabito/src/acmd/other.rs
+++ b/fighters/murabito/src/acmd/other.rs
@@ -53,10 +53,10 @@ unsafe fn murabito_bullet_shoot_f_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
 	if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 60, 80, 0, 55, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -3.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 7.0, 60, 132, 0, 50, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -3.5, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
         AttackModule::enable_safe_pos(boma);
     }
-    frame(lua_state, 3.0);
+    frame(lua_state, 2.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 4.0, 361, 100, 0, 25, 2.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -2, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_OBJECT);
     }

--- a/fighters/murabito/src/acmd/other.rs
+++ b/fighters/murabito/src/acmd/other.rs
@@ -83,17 +83,12 @@ unsafe fn murabito_flowerpot_throwed_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
 	if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("have"), 10.0, 70, 60, 0, 70, 4.2, 0.0, 2.5, 0.0, Some(0.0), Some(-2.0), Some(3.0), 0.6, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("have"), 10.0, 70, 60, 0, 70, 4.2, 0.0, 2.5, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
         AttackModule::enable_safe_pos(boma);
     }
-    wait(lua_state, 2.0);
-	if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("have"), 10.0, 70, 60, 0, 70, 4.2, 0.0, 2.5, 0.0, None, None, None, 0.6, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
-        AttackModule::enable_safe_pos(boma);
-    }
-    wait(lua_state, 4.0);
+    wait(lua_state, 6.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("have"), 6.0, 70, 60, 0, 70, 3.7, 0.0, 2.5, 0.0, None, None, None, 0.6, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("have"), 6.0, 70, 60, 0, 70, 3.7, 0.0, 2.5, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
     }
     
 }
@@ -113,7 +108,7 @@ unsafe fn murabito_flowerpot_bound_effect(fighter: &mut L2CAgentBase) {
         }
     }
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("have"), 4.0, 361, 60, 0, 40, 3.7, 0.0, 2.5, 0.0, None, None, None, 0.6, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("have"), 4.0, 361, 60, 0, 40, 3.7, 0.0, 2.5, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
     }
 }
 

--- a/fighters/murabito/src/acmd/smashes.rs
+++ b/fighters/murabito/src/acmd/smashes.rs
@@ -8,30 +8,7 @@ unsafe fn murabito_attack_s4_s_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 0.746);
         ArticleModule::generate_article_enable(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, false, 0);
-    }
-    frame(lua_state, 3.0);
-    if is_excute(fighter) {
-        if !ArticleModule::is_exist(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL) {
-            ArticleModule::generate_article(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, false, 0);
-        }
-    }
-    frame(lua_state, 4.0);
-    if is_excute(fighter) {
-        if !ArticleModule::is_exist(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL) {
-            ArticleModule::generate_article(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, false, 0);
-        }
-    }
-    frame(lua_state, 5.0);
-    if is_excute(fighter) {
-        if !ArticleModule::is_exist(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL) {
-            ArticleModule::generate_article(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, false, 0);
-        }
-    }
-    frame(lua_state, 16.0);
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.000);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
@@ -39,9 +16,23 @@ unsafe fn murabito_attack_s4_s_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
-        ArticleModule::shoot(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
+        ArticleModule::shoot(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
     }
-    
+}
+
+#[acmd_script( agent = "murabito_bowlingball", script = "game_fall", category = ACMD_GAME, low_priority)]
+unsafe fn murabito_bowlingball__game_fall(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 15.0, 45, 95, 0, 70, 6.0, 0.0, 0.0, 0.0, None, None, None, 1.25, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 1.75);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 17.0, 45, 95, 0, 70, 3.7, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+    }
 }
 
 #[acmd_script( agent = "murabito", script = "game_attackhi4" , category = ACMD_GAME , low_priority)]
@@ -317,6 +308,7 @@ unsafe fn murabito_attack_lw4_sound(fighter: &mut L2CAgentBase) {
 pub fn install() {
     install_acmd_scripts!(
         murabito_attack_s4_s_game,
+        murabito_bowlingball__game_fall,
         murabito_attack_hi4_game,
         murabito_firework_shoot_game,
         murabito_attack_lw4_game,

--- a/fighters/murabito/src/acmd/smashes.rs
+++ b/fighters/murabito/src/acmd/smashes.rs
@@ -53,11 +53,11 @@ unsafe fn murabito_attack_hi4_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 1, 0, Hash40::new("top"), 3.0, 110, 100, 120, 0, 6.0, 0.0, 5.0, 6.0, None, None, None, 0.5, 0.1, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
         AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
     }
-    wait(lua_state, 2.0);
+    wait(lua_state, 1.0);
     if is_excute(fighter) {
         ArticleModule::shoot(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_FIREWORK, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
     }
-    wait(lua_state, 2.0);
+    wait(lua_state, 3.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -69,25 +69,19 @@ unsafe fn murabito_firework_shoot_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 3.0);
-    for x in 0..4 {
-        if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.5, 365, 30, 0, 55, 7.0, -0.75, 22.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 1.5, 110, 30, 0, 55, 2.8, -4.0, 19.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-            ATTACK(fighter, 2, 0, Hash40::new("top"), 1.5, 110, 30, 0, 55, 2.8, 2.5, 19.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-            ATTACK(fighter, 3, 0, Hash40::new("top"), 1.5, 185, 30, 0, 40, 2.8, -4.0, 25.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-            ATTACK(fighter, 4, 0, Hash40::new("top"), 1.5, 185, 30, 0, 40, 2.8, 2.5, 25.0, 0.0, None, None, None, 0.5, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
-            AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
-        }
-        wait(lua_state, 2.0);
-        if is_excute(fighter) {
-            AttackModule::clear_all(boma);
-        }
-        wait(lua_state, 2.0);
-    }
     if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 1.5, 110, 30, 0, 55, 3.5, -3.0, 20.0, 0.0,  None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 1.5, 110, 30, 0, 55, 3.5, 4.0, 20.0, 0.0,   None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 1.5, 185, 30, 0, 40, 3.5, -3.0, 27.0, 0.0,  None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
+        ATTACK(fighter, 3, 0, Hash40::new("top"), 1.5, 185, 30, 0, 40, 3.5, 4.0, 27.0, 0.0,   None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 3, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
+        AttackModule::set_no_damage_fly_smoke_all(boma, true, false);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
         ATTACK(fighter, 0, 0, Hash40::new("top"), 4.6, 90, 220, 0, 30, 10.0, 0.5, 24.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, true, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
     }
-    wait(lua_state, 2.0);
+    wait(lua_state, 4.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -95,7 +89,6 @@ unsafe fn murabito_firework_shoot_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x199c462b5d));
     }
-    
 }
 
 #[acmd_script( agent = "murabito", script = "game_attacklw4" , category = ACMD_GAME , low_priority)]

--- a/fighters/murabito/src/acmd/smashes.rs
+++ b/fighters/murabito/src/acmd/smashes.rs
@@ -15,9 +15,12 @@ unsafe fn murabito_attack_s4_s_game(fighter: &mut L2CAgentBase) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_START_SMASH_HOLD);
     }
     frame(lua_state, 20.0);
+    FT_MOTION_RATE_RANGE(fighter, 20.0, 60.0, 29.0);
     if is_excute(fighter) {
         ArticleModule::shoot(boma, *FIGHTER_MURABITO_GENERATE_ARTICLE_BOWLING_BALL, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL), false);
     }
+    frame(lua_state, 60.0);
+    FT_MOTION_RATE(fighter, 1.0);
 }
 
 #[acmd_script( agent = "murabito_bowlingball", script = "game_fall", category = ACMD_GAME, low_priority)]
@@ -26,12 +29,11 @@ unsafe fn murabito_bowlingball__game_fall(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 15.0, 45, 95, 0, 70, 6.0, 0.0, 0.0, 0.0, None, None, None, 1.25, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
-        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 1.75);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 15.0, 45, 95, 0, 70, 6.0, 0.0, 0.0, 0.0, None, None, None, 1.25, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 11, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 17.0, 45, 95, 0, 70, 3.7, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 2, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 17.0, 45, 95, 0, 70, 3.7, 0.0, 0.0, 0.0, None, None, None, 1.15, 0.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 11, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_OBJECT);
     }
 }
 

--- a/fighters/murabito/src/acmd/specials.rs
+++ b/fighters/murabito/src/acmd/specials.rs
@@ -25,6 +25,20 @@ unsafe fn murabito_special_lw1_game(fighter: &mut L2CAgentBase) {
     }
 }
 
+#[acmd_script( agent = "murabito", scripts = ["game_speciallw2", "game_specialairlw2"] , category = ACMD_GAME , low_priority)]
+unsafe fn game_speciallw2(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_MURABITO_INSTANCE_WORK_ID_FLAG_WATER);
+    }
+    frame(lua_state, 31.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_MURABITO_INSTANCE_WORK_ID_FLAG_WATER);
+    }
+}
+
 #[acmd_script( agent = "murabito", script = "game_speciallw3hit" , category = ACMD_GAME , low_priority)]
 unsafe fn murabito_special_lw3_hit_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -55,6 +69,7 @@ unsafe fn murabito_special_air_lw3_hit_game(fighter: &mut L2CAgentBase) {
 pub fn install() {
     install_acmd_scripts!(
         murabito_special_lw1_game,
+        game_speciallw2,
         murabito_special_lw3_hit_game,
         murabito_special_air_lw3_hit_game,
     );

--- a/fighters/murabito/src/lib.rs
+++ b/fighters/murabito/src/lib.rs
@@ -43,5 +43,7 @@ pub fn install(is_runtime: bool) {
     status::install();
     opff::install(is_runtime);
     use opff::*;
-    smashline::install_agent_frames!(flowerpot_frame, clayrocket_frame);
+    smashline::install_agent_frame_callbacks!(
+        article_frame_callback,
+    );
 }

--- a/fighters/murabito/src/opff.rs
+++ b/fighters/murabito/src/opff.rs
@@ -109,19 +109,17 @@ pub unsafe fn murabito_frame(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     }
 }
 
-#[weapon_frame( agent = WEAPON_KIND_MURABITO_FLOWERPOT )]
-fn flowerpot_frame(weapon: &mut L2CFighterBase) {
-    unsafe {
-        if weapon.is_status( *WEAPON_MURABITO_FLOWERPOT_STATUS_KIND_THROWED ) && AttackModule::is_infliction_status(weapon.module_accessor, *COLLISION_KIND_MASK_HIT) {
-            weapon.change_status(WEAPON_MURABITO_FLOWERPOT_STATUS_KIND_BURST.into(), false.into());
+#[smashline::weapon_frame_callback(main)]
+pub fn article_frame_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
+    unsafe { 
+        if weapon.kind() == *WEAPON_KIND_MURABITO_FLOWERPOT {
+            if weapon.is_status( *WEAPON_MURABITO_FLOWERPOT_STATUS_KIND_THROWED ) && AttackModule::is_infliction_status(weapon.module_accessor, *COLLISION_KIND_MASK_HIT) {
+                weapon.change_status(WEAPON_MURABITO_FLOWERPOT_STATUS_KIND_BURST.into(), false.into());
+            }
+        } else if weapon.kind() == *WEAPON_KIND_MURABITO_CLAYROCKET {
+            WorkModule::on_flag(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_FLAG_NO_DEAD);
+        } else {
+            return;
         }
-    }
-}
-
-/// prevents rocket from despawning in the blastzone
-#[weapon_frame( agent = WEAPON_KIND_MURABITO_CLAYROCKET )]
-fn clayrocket_frame(weapon: &mut L2CFighterBase) {
-    unsafe {
-        WorkModule::on_flag(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_FLAG_NO_DEAD);
     }
 }

--- a/fighters/murabito/src/opff.rs
+++ b/fighters/murabito/src/opff.rs
@@ -4,10 +4,10 @@ use super::*;
 use globals::*;
 
 unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind: i32, frame: f32) {
-    if StatusModule::is_changing(boma) {
-        return;
-    }
-    if boma.is_status_one_of(&[*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_AIR, 
+    if frame < 12.0
+    || boma.is_button_on(Buttons::SpecialAll)
+    || StatusModule::is_changing(boma)
+    || !boma.is_status_one_of(&[*FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_AIR, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_DASH_B, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_DASH_F, 
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_JUMP,
@@ -17,18 +17,13 @@ unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_WALK_B,
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_WALK_BRAKE_B,
         *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_WALK_BRAKE_F,
-        *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_WALK_F])
-    && frame > 12.0
-    && boma.is_button_on(Buttons::Guard) {
-        if situation_kind == *SITUATION_KIND_AIR {
-            WorkModule::unable_transition_term_group(boma, *FIGHTER_STATUS_TRANSITION_GROUP_CHK_AIR_ESCAPE);
-            ControlModule::clear_command_one(boma, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_AIR_ESCAPE);
-            StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_FALL, false);
-        }
-        if situation_kind == *SITUATION_KIND_GROUND {
-            StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_WAIT, false);
-        }
+        *FIGHTER_MURABITO_STATUS_KIND_SPECIAL_LW_WATER_WALK_F]) {
+        return;
     }
+    WorkModule::off_flag(boma, *FIGHTER_MURABITO_INSTANCE_WORK_ID_FLAG_WATER);
+    EffectModule::kill_kind(boma, Hash40::new("murabito_water"), false, false);
+    SoundModule::stop_se(boma, Hash40::new("se_murabito_special_l02"), 0);
+    CancelModule::enable_cancel(boma);
 }
 
 unsafe fn uspecial_cancels(boma: &mut BattleObjectModuleAccessor, situation_kind: i32, frame: f32) {

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -1,51 +1,51 @@
+attack_11:
+  extra:
+    cancel_frame: 16
+attack_12:
+  extra:
+    cancel_frame: 18
+attack_12_end:
+  extra:
+    cancel_frame: 30
+attack_air_b:
+  extra:
+    cancel_frame: 41
+attack_lw3:
+  flags:
+    move: false
+  extra:
+    cancel_frame: 33
+attack_s3_s:
+  extra:
+    cancel_frame: 34
+attack_s4_s:
+  extra:
+    cancel_frame: 60
+catch_attack:
+  extra:
+    cancel_frame: 0
 fall:
   blend_frames: 5
 fall_aerial:
   blend_frames: 5
 fall_special:
   blend_frames: 5
+furafura_end:
+  extra:
+    cancel_frame: 10
 guard_off:
   blend_frames: 4
   extra:
     cancel_frame: 12
-throw_f:
-  extra:
-    cancel_frame: 38
 throw_b:
   extra:
     cancel_frame: 30
-throw_lw:
+throw_f:
   extra:
-    cancel_frame: 31
+    cancel_frame: 38
 throw_hi:
   extra:
     cancel_frame: 38
-attack_12:
+throw_lw:
   extra:
-    cancel_frame: 18
-attack_11:
-  extra:
-    cancel_frame: 16
-attack_lw3:
-  flags:
-    move: false
-  extra:
-    cancel_frame: 33
-attack_s4_s:
-  extra:
-    cancel_frame: 60
-attack_s3_s:
-  extra:
-    cancel_frame: 34
-attack_air_b:
-  extra:
-    cancel_frame: 41
-attack_12_end:
-  extra:
-    cancel_frame: 30
-catch_attack:
-  extra:
-    cancel_frame: 0
-furafura_end:
-  extra:
-    cancel_frame: 10
+    cancel_frame: 31


### PR DESCRIPTION
## Can Canceling (DSpecial2)
- now uses a special button hold check, instead of a shield cancel

releasing the special button after frame 12 will make the move immediately actionable and cancel any further watering. this shouldn't have any functional differences from the previous mechanic, but is simpler and more intuitive to use.

## FSmash
- faf 56 --> 49 (vanilla)
- startup 21 --> 23
- hitlag mul 1.0 --> 1.25 (early) / 1.15 (late)
- shield damage +2 --> +11

historically bowling ball has been -4 on shield (point blank) up to plus on shield (from platforms). while we shouldn't go that far, considering the history and its startup/FAF/range, I'm making this less punishable on shield point blank.

## USmash
- fireworks spawn 1f sooner
- fireworks multihit id0 removed (improves reliability)
- fireworks multihits better spread out while covering same effective area
- hitlag 0.5 --> 1.0
- for-loop hitboxes replaced with rehit-rate hitboxes (improves consistency)
- rehit-rate 4f --> 3f (adds 1 multihit)
- launcher active f30-31 --> f30-33
should fix some instances of players falling out of the multihits during the earlier frames, and falling inbetween the scoop and first multihit.

## FAir
- early hit
  - active f1-2 --> f1
  - size 4.5u --> 4.0u
  - kbg 80 --> 132
  - bkb 55 --> 50
  - kills inkling on bf platform with optimal DI at 157%
- late hit
  - size 1.5u --> 2.0u

this move is now effectively more precise with an early hit that's more punishing at later percents and provides insurance against drawn-out stocks. 

1f less activity on early hit should prevent some instances of ranged off-stage kills with FAir (not gimps) as the early hit has effectively 0.6x the previous range.

## BAir
- multihits
  - added ground-only pop-up hitbox with angle 80
more reliably scoops grounded opponents when rising with the move.

## Dash Attack
- startup f9 --> f7
- hitlag 0.6 --> 1.0
- removed reverse hits (they were based on the projectile's position, not villager's)