### PR TITLE
Steve - mining bugfixes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -638,12 +638,20 @@ pub mod vars {
         pub mod instance {
             // flags
             pub const DISABLE_SPECIAL_HI: i32 = 0x01FF; //Weird value to avoid conflicts with copy ability values
+        
+            // copy ability
+            // flags
+            pub const SHOULD_CYCLE_MATERIAL: i32 = 0x01F4;
+
+            // ints 
+            pub const MATERIAL_INDEX: i32 = 0x01F5;
         }
         pub mod status {
             // copy ability
             // flags
             pub use super::super::mario::status::IS_SPECIAL_N_FIREBRAND;
             pub use super::super::mariod::status::CHILL_PILL;
+            pub const MINING_TIMER: i32 = 0x11F4;
         }
     }
 

--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -411,6 +411,24 @@ unsafe fn trail_magic_cycle(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
     }
 }
 
+// handles kirby's mining behavior when copying steve
+unsafe fn pickel_mining(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) { 
+    if WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA) == *FIGHTER_KIND_PICKEL {
+        if VarModule::get_int(boma.object(), vars::kirby::instance::MATERIAL_INDEX) as i32 > 99 {
+            VarModule::set_int(boma.object(), vars::kirby::instance::MATERIAL_INDEX, 0);
+        }
+        
+        // wait 2 frames before letting the material table advance, preventing any jumps in entries
+        if !VarModule::is_flag(boma.object(), vars::kirby::instance::SHOULD_CYCLE_MATERIAL) {
+            if VarModule::get_int(boma.object(), vars::kirby::status::MINING_TIMER) == 0 {
+                VarModule::on_flag(boma.object(), vars::kirby::instance::SHOULD_CYCLE_MATERIAL);
+            } else {
+                VarModule::dec_int(boma.object(), vars::kirby::status::MINING_TIMER);
+            }
+        }
+    }
+}
+
 // Bite Early Throw and Turnaround
 unsafe fn bite_early_throw_turnaround(boma: &mut BattleObjectModuleAccessor, status_kind: i32, stick_x: f32, facing: f32, frame: f32) {
     if StatusModule::is_changing(boma) {
@@ -1155,6 +1173,9 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
 
     // Sora Magic Cycle Adjustment
     trail_magic_cycle(fighter, boma, frame);
+
+    // Steve Mining
+    pickel_mining(fighter, boma);
 
     // Bite Early Throw and Turnaround
     bite_early_throw_turnaround(boma, status_kind, stick_x, facing, frame);

--- a/fighters/pickel/src/material_table.rs
+++ b/fighters/pickel/src/material_table.rs
@@ -27,43 +27,71 @@ pub unsafe extern "C" fn material_table_hook(fighter: &mut Fighter, arg2: u64, a
     ];
     
     let pickel = &mut (*fighter).battle_object;
-    let index = VarModule::get_int(pickel, vars::pickel::instance::MATERIAL_INDEX) as i32;
-    let material = material_table[index as usize] as u32; // stores current table index to return
-    if VarModule::is_flag(pickel, vars::pickel::instance::SHOULD_CYCLE_MATERIAL) {
-        if material == (gold as u32) { // add redstone to gold entries
-            let pickel_boma = pickel.module_accessor;
-            let current_redstone = WorkModule::get_int(pickel_boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_RED_STONE);
-            let max_redstone = WorkModule::get_param_int(pickel_boma, hash40("param_private"), hash40("material_red_stone_max"));
-            let mut gain_amount = 6; // number of redstone steve should receive when mining gold
-            if (current_redstone + gain_amount) <= max_redstone {
-                FighterSpecializer_Pickel::add_material_num(pickel_boma, *FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, gain_amount);
-            } else if current_redstone != max_redstone {
-                gain_amount = max_redstone - current_redstone;
-                FighterSpecializer_Pickel::add_material_num(pickel_boma, *FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, gain_amount);
+    let kind = pickel.kind as i32;
+    if kind != *FIGHTER_KIND_KIRBY {
+        let index = VarModule::get_int(pickel, vars::pickel::instance::MATERIAL_INDEX) as i32;
+        let material = material_table[index as usize] as u32; // stores current table index to return
+        if VarModule::is_flag(pickel, vars::pickel::instance::SHOULD_CYCLE_MATERIAL) {
+            if material == (gold as u32) { // add redstone to gold entries
+                let pickel_boma = pickel.module_accessor;
+                let current_redstone = WorkModule::get_int(pickel_boma, *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_RED_STONE);
+                let max_redstone = WorkModule::get_param_int(pickel_boma, hash40("param_private"), hash40("material_red_stone_max"));
+                let mut gain_amount = 6; // number of redstone steve should receive when mining gold
+                if (current_redstone + gain_amount) <= max_redstone {
+                    FighterSpecializer_Pickel::add_material_num(pickel_boma, *FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, gain_amount);
+                } else if current_redstone != max_redstone {
+                    gain_amount = max_redstone - current_redstone;
+                    FighterSpecializer_Pickel::add_material_num(pickel_boma, *FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, gain_amount);
+                }
             }
+            if (0..99).contains(&index) { // continue the cycle
+                VarModule::inc_int(pickel, vars::pickel::instance::MATERIAL_INDEX);
+            } else { // reset the cycle
+                VarModule::set_int(pickel, vars::pickel::instance::MATERIAL_INDEX, 0);
+            }
+            VarModule::off_flag(pickel, vars::pickel::instance::SHOULD_CYCLE_MATERIAL);
+            VarModule::set_int(pickel, vars::pickel::status::MINING_TIMER, 2);
+            // logging for debug purposes
+            // let mut mat_name = "nothing lol";
+            // if material == 0 { mat_name = "dirt"; }
+            // else if material == 1 { mat_name = "wood"; }
+            // else if material == 2 { mat_name = "stone"; }
+            // else if material == 3 { mat_name = "iron"; }
+            // else if material == 4 { mat_name = "gold"; }
+            // else if material == 5 { mat_name = "redstone"; }
+            // else if material == 6 { mat_name = "diamond"; }
+            // else { mat_name = "...what?"; }
+            // println!("Steve mines entry {}/100, which is {}.", (index +1), mat_name);
         }
-        if (0..99).contains(&index) { // continue the cycle
-            VarModule::inc_int(pickel, vars::pickel::instance::MATERIAL_INDEX);
-        } else { // reset the cycle
-            VarModule::set_int(pickel, vars::pickel::instance::MATERIAL_INDEX, 0);
+
+        return material;
+    } else { // alternative logic for kirby
+        let index = VarModule::get_int(pickel, vars::kirby::instance::MATERIAL_INDEX) as i32;
+        let material = material_table[index as usize] as u32; // stores current table index to return
+        if VarModule::is_flag(pickel, vars::kirby::instance::SHOULD_CYCLE_MATERIAL) {
+            if (0..99).contains(&index) { // continue the cycle
+                VarModule::inc_int(pickel, vars::kirby::instance::MATERIAL_INDEX);
+            } else { // reset the cycle
+                VarModule::set_int(pickel, vars::kirby::instance::MATERIAL_INDEX, 0);
+            }
+            VarModule::off_flag(pickel, vars::kirby::instance::SHOULD_CYCLE_MATERIAL);
+            VarModule::set_int(pickel, vars::kirby::status::MINING_TIMER, 2);
+            // logging for debug purposes
+            // let mut mat_name = "nothing lol";
+            // if material == 0 { mat_name = "dirt"; }
+            // else if material == 1 { mat_name = "wood"; }
+            // else if material == 2 { mat_name = "stone"; }
+            // else if material == 3 { mat_name = "iron"; }
+            // else if material == 4 { mat_name = "gold. He gets iron instead"; }
+            // else if material == 6 { mat_name = "diamond. He gets iron instead"; }
+            // else { mat_name = "...what?"; }
+            // println!("Kirby mines entry {}/100, which is {}.", (index +1), mat_name);
         }
-        VarModule::off_flag(pickel, vars::pickel::instance::SHOULD_CYCLE_MATERIAL);
-        VarModule::set_int(pickel, vars::pickel::status::MINING_TIMER, 2);
-        // logging for debug purposes
-        // let mut mat_name = "nothing lol";
-        // if material == 0 { mat_name = "dirt"; }
-        // else if material == 1 { mat_name = "wood"; }
-        // else if material == 2 { mat_name = "stone"; }
-        // else if material == 3 { mat_name = "iron"; }
-        // else if material == 4 { mat_name = "gold"; }
-        // else if material == 5 { mat_name = "redstone"; }
-        // else if material == 6 { mat_name = "diamond"; }
-        // else { mat_name = "...what?"; }
-        // println!("Steve mines entry {}/100, which is {}.", (index +1), mat_name);
+        if material == (4 | 6) {
+            return 3; // give kirby iron instead of gold/diamond
+        }
+        return material;
     }
-
-
-    return material;
 }
 
 // overrides stage id check for things such as mining speed

--- a/fighters/pickel/src/status.rs
+++ b/fighters/pickel/src/status.rs
@@ -9,6 +9,7 @@ pub fn install() {
         guarddamage_end,
         guard,
         rebirth,
+        entry,
         attack_air_lw_start_main,
         special_s_pre,
         pre_jump
@@ -74,7 +75,7 @@ pub unsafe fn rebirth(fighter: &mut L2CFighterCommon) -> L2CValue {
     let dirt = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_GRADE_1);
     let wood = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_WOOD);
     let stone = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_STONE);
-    let iron =WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_IRON);
+    let iron = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_IRON);
     let gold = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_GOLD);
     let diamond = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_DIAMOND);
     let redstone = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_RED_STONE);
@@ -98,6 +99,46 @@ pub unsafe fn rebirth(fighter: &mut L2CFighterCommon) -> L2CValue {
     let init_rstn = WorkModule::get_param_int(fighter.boma(), hash40("param_private"), hash40("start_material_red_stone_num"));
     if redstone > init_rstn { // reduce redstone to starting value
         FighterSpecializer_Pickel::sub_material_num(fighter.boma(), *FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, (redstone - init_rstn));
+    }
+    
+    return original!(fighter);
+}
+
+// handles materials when steve is entering the match, to account for salty runbacks
+#[status_script(agent = "pickel", status = FIGHTER_STATUS_KIND_ENTRY, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+pub unsafe fn entry(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let dirt = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_GRADE_1);
+    let wood = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_WOOD);
+    let stone = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_STONE);
+    let iron = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_IRON);
+    let gold = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_GOLD);
+    let diamond = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_DIAMOND);
+    let redstone = WorkModule::get_int(fighter.boma(), *FIGHTER_PICKEL_INSTANCE_WORK_ID_INT_MATERIAL_NUM_RED_STONE);
+    let remove_mats: [[i32;2];4] = [ // these materials will be removed on entry
+        [*FIGHTER_PICKEL_MATERIAL_KIND_STONE, stone],
+        [*FIGHTER_PICKEL_MATERIAL_KIND_IRON, iron],
+        [*FIGHTER_PICKEL_MATERIAL_KIND_GOLD, dirt],
+        [*FIGHTER_PICKEL_MATERIAL_KIND_DIAMOND, wood]]; 
+    for material in remove_mats {
+        let (kind, has) = (material[0], material[1]);
+        if has > 0 {
+            FighterSpecializer_Pickel::sub_material_num(fighter.boma(), kind, has);
+        }
+    }    
+    let init_dirt = WorkModule::get_param_int(fighter.boma(), hash40("param_private"), hash40("start_material_grade_1_num"));
+    let init_wood = WorkModule::get_param_int(fighter.boma(), hash40("param_private"), hash40("start_material_wood_num")); 
+    let init_rstn = WorkModule::get_param_int(fighter.boma(), hash40("param_private"), hash40("start_material_red_stone_num"));
+    let init_mats: [[i32;3];3] = [ // these materials will be reverted to the initial amount defined in params
+        [*FIGHTER_PICKEL_MATERIAL_KIND_GRADE_1, dirt, init_dirt],
+        [*FIGHTER_PICKEL_MATERIAL_KIND_WOOD, wood, init_wood],
+        [*FIGHTER_PICKEL_MATERIAL_KIND_RED_STONE, redstone, init_rstn]];
+    for material in init_mats {
+        let (kind, has, init) = (material[0], material[1], material[2]);
+        if has > init {
+            FighterSpecializer_Pickel::sub_material_num(fighter.boma(), kind, (has - init));
+        } else if has < init {
+            FighterSpecializer_Pickel::add_material_num(fighter.boma(), kind, (init - has));
+        }
     }
     
     return original!(fighter);


### PR DESCRIPTION
Addresses a couple issues with the new resource mechanics

- (*) Added support for Kirby's copy ability, which would previously crash when attempting to mine. Kirby's version of mining is much more watered down, and functions rather close to vanilla.
  - Kirby's mining pattern will follow the same order as Steve
  - Kirby only obtains building materials. When he reaches an entry for gold or diamond, he will receive iron instead
  - Kirby's index will not advance through landing attacks, as the reward for doing so (gold/diamond) doesn't apply to him

- (*) Steve's materials will be reset to their starting values whenever he is in the `ENTRY` status, fixing an issue where his inventory would remain the same during salty runbacks. Fixes #308.