### PR TITLE
Mega Man Adjustments (Again)

### DIFF
--- a/fighters/rockman/src/acmd/other.rs
+++ b/fighters/rockman/src/acmd/other.rs
@@ -116,7 +116,6 @@ unsafe fn rockman_hardknuckle_regular_game(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 5.0);
 	if is_excute(fighter) {
-        AttackModule::clear_all(boma);
         sv_kinetic_energy!(
             set_speed,
             fighter,
@@ -138,6 +137,10 @@ unsafe fn rockman_hardknuckle_regular_game(fighter: &mut L2CAgentBase) {
             0.0,
             0.05
         );
+    }
+    frame(lua_state, 6.0);
+	if is_excute(fighter) {
+        AttackModule::clear_all(boma);
     }
 }
 

--- a/fighters/rockman/src/acmd/specials.rs
+++ b/fighters/rockman/src/acmd/specials.rs
@@ -134,12 +134,12 @@ unsafe fn rockman_chargeshot_regular(agent: &mut L2CAgentBase) {
         if is_charge_max {
             damage = 15.0;
             bkb = 40;
-            kbg = 75;
+            kbg = 90;
         }
         else {
             damage = 9.0;
             bkb = 50;
-            kbg = 70;
+            kbg = 85;
         }
         macros::ATTACK(agent, 0, 0, Hash40::new("top"), damage, 361, kbg, 0, bkb, 2.6, 0.0, 0.0, 0.0, None, None, None, 0.3, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_SPEED, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_ENERGY);
         macros::ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 0.32);

--- a/fighters/rockman/src/opff.rs
+++ b/fighters/rockman/src/opff.rs
@@ -54,31 +54,31 @@ unsafe fn blade_toss_ac(boma: &mut BattleObjectModuleAccessor, status_kind: i32,
 }
 
 // upB freefalls after one use per airtime
-unsafe fn up_special_freefall(fighter: &mut L2CFighterCommon) {
-    if StatusModule::is_changing(fighter.module_accessor)
-    && (fighter.is_situation(*SITUATION_KIND_GROUND)
-        || fighter.is_situation(*SITUATION_KIND_CLIFF)
-        || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING]))
-    {
-        VarModule::off_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL);
-    }
-    if fighter.is_prev_status(*FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP) {
-        if StatusModule::is_changing(fighter.module_accessor) {
-            VarModule::on_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL);
-        }
-    }
-    if fighter.is_status(*FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP) {
-        if fighter.is_situation(*SITUATION_KIND_AIR)
-        && !StatusModule::is_changing(fighter.module_accessor)
-        && VarModule::is_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL) {
-            if CancelModule::is_enable_cancel(fighter.module_accessor) {
-                fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
-                let cancel_module = *(fighter.module_accessor as *mut BattleObjectModuleAccessor as *mut u64).add(0x128 / 8) as *const u64;
-                *(((cancel_module as u64) + 0x1c) as *mut bool) = false;  // CancelModule::is_enable_cancel = false
-            }
-        }
-    }
-}
+// unsafe fn up_special_freefall(fighter: &mut L2CFighterCommon) {
+//     if StatusModule::is_changing(fighter.module_accessor)
+//     && (fighter.is_situation(*SITUATION_KIND_GROUND)
+//         || fighter.is_situation(*SITUATION_KIND_CLIFF)
+//         || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING]))
+//     {
+//         VarModule::off_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL);
+//     }
+//     if fighter.is_prev_status(*FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP) {
+//         if StatusModule::is_changing(fighter.module_accessor) {
+//             VarModule::on_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL);
+//         }
+//     }
+//     if fighter.is_status(*FIGHTER_ROCKMAN_STATUS_KIND_SPECIAL_HI_JUMP) {
+//         if fighter.is_situation(*SITUATION_KIND_AIR)
+//         && !StatusModule::is_changing(fighter.module_accessor)
+//         && VarModule::is_flag(fighter.battle_object, vars::rockman::instance::UP_SPECIAL_FREEFALL) {
+//             if CancelModule::is_enable_cancel(fighter.module_accessor) {
+//                 fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL_SPECIAL, true);
+//                 let cancel_module = *(fighter.module_accessor as *mut BattleObjectModuleAccessor as *mut u64).add(0x128 / 8) as *const u64;
+//                 *(((cancel_module as u64) + 0x1c) as *mut bool) = false;  // CancelModule::is_enable_cancel = false
+//             }
+//         }
+//     }
+// }
 
 unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     if !fighter.is_in_hitlag()
@@ -115,7 +115,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     // utilt_command_input(boma, id, status_kind, situation_kind, frame);
     // jc_dtilt_hit(boma, status_kind, situation_kind, cat[0], frame);
     blade_toss_ac(boma, status_kind, situation_kind, cat[0], frame);
-    up_special_freefall(fighter);
+    // up_special_freefall(fighter);
     fastfall_specials(fighter);
 }
 

--- a/fighters/rockman/src/status/rockbuster/shoot_air.rs
+++ b/fighters/rockman/src/status/rockbuster/shoot_air.rs
@@ -74,7 +74,8 @@ unsafe extern "C" fn rockman_rockbuster_shoot_air_main_loop(fighter: &mut L2CFig
         return 1.into();
     }
     if sit == *SITUATION_KIND_GROUND {
-        fighter.change_status(FIGHTER_ROCKMAN_STATUS_KIND_ROCKBUSTER_SHOOT_LANDING.into(), false.into());
+        // fighter.change_status(FIGHTER_ROCKMAN_STATUS_KIND_ROCKBUSTER_SHOOT_LANDING.into(), false.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
         return 1.into();
     }
     0.into()

--- a/fighters/rockman/src/status/rockbuster/shoot_jump.rs
+++ b/fighters/rockman/src/status/rockbuster/shoot_jump.rs
@@ -57,7 +57,8 @@ unsafe extern "C" fn rockman_rockbuster_shoot_jump_main_loop(fighter: &mut L2CFi
         return 1.into();
     }
     if sit == *SITUATION_KIND_GROUND {
-        fighter.change_status(FIGHTER_ROCKMAN_STATUS_KIND_ROCKBUSTER_SHOOT_LANDING.into(), false.into());
+        // fighter.change_status(FIGHTER_ROCKMAN_STATUS_KIND_ROCKBUSTER_SHOOT_LANDING.into(), false.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
         return 1.into();
     }
     0.into()

--- a/fighters/rockman/src/status/special_n.rs
+++ b/fighters/rockman/src/status/special_n.rs
@@ -61,11 +61,13 @@ unsafe fn rockman_special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 
 unsafe extern "C" fn rockman_special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     let sit = fighter.global_table[SITUATION_KIND].get_i32();
-    if StatusModule::is_changing(fighter.module_accessor) || StatusModule::is_situation_changed(fighter.module_accessor) {
+    if StatusModule::is_situation_changed(fighter.module_accessor) {
         if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
             fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
             return 0.into();
         }
+    }
+    if StatusModule::is_changing(fighter.module_accessor) || StatusModule::is_situation_changed(fighter.module_accessor) {
         rockman_special_motion_helper(
             fighter,
             hash40("buster_charge_shot").into(),

--- a/fighters/rockman/src/status/special_n.rs
+++ b/fighters/rockman/src/status/special_n.rs
@@ -62,6 +62,10 @@ unsafe fn rockman_special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 unsafe extern "C" fn rockman_special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
     let sit = fighter.global_table[SITUATION_KIND].get_i32();
     if StatusModule::is_changing(fighter.module_accessor) || StatusModule::is_situation_changed(fighter.module_accessor) {
+        if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+            fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
+            return 0.into();
+        }
         rockman_special_motion_helper(
             fighter,
             hash40("buster_charge_shot").into(),

--- a/fighters/rockman/src/vtable_hook.rs
+++ b/fighters/rockman/src/vtable_hook.rs
@@ -207,14 +207,14 @@ unsafe fn rockman_do_leafshield_things_enable(ctx: &mut skyline::hooks::InlineCt
     FighterSpecializer_Rockman::set_leafshield(module_accessor, true);
 }
 
-const LEAFSHIELD_DISABLE_GROUPS: [WorkId; 5] = [
+const LEAFSHIELD_DISABLE_GROUPS: [WorkId; 6] = [
     // transition_groups::CHECK_GROUND_SPECIAL,
     // transition_groups::CHECK_AIR_SPECIAL,
     transition_groups::CHECK_GROUND_ESCAPE,
     // transition_groups::CHECK_AIR_ESCAPE,
     transition_groups::CHECK_GROUND_GUARD,
     transition_groups::CHECK_GROUND_ATTACK,
-    // transition_groups::CHECK_GROUND_CATCH,
+    transition_groups::CHECK_GROUND_CATCH,
     transition_groups::CHECK_AIR_ATTACK,
     transition_groups::CHECK_AIR_CLIFF
 ];

--- a/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
@@ -252,7 +252,7 @@ attack_12:
   extra:
     xlu_start: 0
     xlu_end: 0
-    cancel_frame: 28
+    cancel_frame: 24
     no_stop_intp: false
 attack_13:
   game_script: game_attack13

--- a/romfs/source/fighter/rockman/param/vl.prcxml
+++ b/romfs/source/fighter/rockman/param/vl.prcxml
@@ -27,6 +27,11 @@
       <float hash="limit_speed">0.75</float>
     </struct>
   </list>
+  <list hash="param_hardknuckle">
+    <struct index="0">
+      <float hash="speed">4.9</float>
+    </struct>
+  </list>
   <list hash="param_metalblade_other">
     <struct index="0">
       <float hash="stick_percent">100</float>


### PR DESCRIPTION
# Changelog

## Jab 2
- [+] FAF decreased (28 > 24)

## Down Air - Hard Knuckle
- [+] Hitbox Activity extended by 1 (4 > 5)
- [+] Travel Speed Increased (4.2 [Vanilla] > 4.9). Increases its range by around 2 units.

## Neutral Special - Mega Buster/Charge Shot
- [+] Added autocancel landing.
- [+] Increased Charge Shot's KBG (Uncharged/Charged) (70/75 > 85/90)

## Up Special - Rush Coil
- [+] Reverted Up Special Actionability Change

## Down Special - Leaf Shield
- [-] Removed the ability to Grab while Leaf Shield is active