### PR TITLE
Float Input Adjustment + Mewtwo Fixes

### DIFF
--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -91,7 +91,7 @@ pub unsafe fn extra_floats(fighter: &mut L2CFighterCommon, boma: &mut BattleObje
             }
             if WorkModule::is_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF) 
             && !WorkModule::is_flag(boma, *FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_FALL_SLOWLY)
-            && !ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP)
+            && (!ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_JUMP) || boma.left_stick_y() >= -0.66)
             {
                 WorkModule::off_flag(boma, *FIGHTER_INSTANCE_WORK_ID_FLAG_SUPERLEAF);
             }
@@ -209,6 +209,9 @@ pub unsafe fn float_effects(fighter: &mut L2CFighterCommon, boma: &mut BattleObj
                     EffectModule::req_follow(boma, Hash40::new("mewtwo_final_aura"), Hash40::new("hip"), &Vector3f::zero(), &Vector3f::zero(), 1.25, true, 0, 0, 0, 0, 0, false, false);
                 }
             } else if fighter_kind == *FIGHTER_KIND_MEWTWO {
+                if status_kind == *FIGHTER_STATUS_KIND_ATTACK_AIR && boma.is_prev_status(*FIGHTER_STATUS_KIND_JUMP_AERIAL) {
+                    KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
+                }
                 if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) == 50  {
                 // consume double jump on f10 of float
                     fighter.set_int(2, *FIGHTER_INSTANCE_WORK_ID_INT_JUMP_COUNT);

--- a/fighters/mewtwo/src/opff.rs
+++ b/fighters/mewtwo/src/opff.rs
@@ -53,7 +53,9 @@ unsafe fn actionable_teleport_air(fighter: &mut L2CFighterCommon, boma: &mut Bat
         
     }
      //takes away float after 5 frames of jump
-    if boma.get_num_used_jumps() == 2 && (fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) == VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION)) {
+    if boma.get_num_used_jumps() == 2 
+    && !StatusModule::is_changing(fighter.module_accessor)
+    && fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME) == VarModule::get_int(boma.object(), vars::common::instance::FLOAT_DURATION) {
         if !(status_kind == *FIGHTER_STATUS_KIND_JUMP_AERIAL && boma.status_frame() <= 5) {
             fighter.set_int(0, *FIGHTER_INSTANCE_WORK_ID_INT_SUPERLEAF_FALL_SLOWLY_FRAME);
         }


### PR DESCRIPTION
Aiming to improve current float mechanics in lieu of a rewrite (targeting misinputs)

- [R] Floats require down + jump to trigger
- [*] Fixes a m2 super jump that would occur if you did a rising djc + float aerial at the same time
- [*] Fixes an issue where mewtwo jumping and floating at the same time would automatically cancel float into a fastfall (without releasing jump).
