### PR TITLE
Misc adjustments 4

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -675,6 +675,8 @@ pub mod vars {
         pub mod instance {
             // flags
             pub const DISABLE_SPECIAL_S: i32 = 0x0100;
+            pub const DISABLE_MECHAKOOPA: i32 = 0x0101;
+            pub const MECHAKOOPA_IS_COOLDOWN: i32 = 0x0102;
         }
     }
 

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -743,7 +743,10 @@ pub mod vars {
 
     pub mod lucina {
         pub mod instance {
-            //int
+            // flag
+            pub const EQUIP_MASK: i32 = 0x0100;
+            
+            // int
             /// This int stores damage received from an attack during quick riposte
             pub const CURRENT_DAMAGE: i32 = 0x0100;
         }

--- a/fighters/cloud/src/acmd/ground.rs
+++ b/fighters/cloud/src/acmd/ground.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 #[acmd_script( agent = "cloud", script = "game_attack11" , category = ACMD_GAME , low_priority)]
@@ -72,6 +71,20 @@ unsafe fn cloud_attack_12_game(fighter: &mut L2CAgentBase) {
     
 }
 
+#[acmd_script( agent = "cloud", script = "game_attack13" , category = ACMD_GAME , low_priority)]
+unsafe fn cloud_attack_13_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 3.5, 30, 50, 0, 75, 4.5, 0.0, 9.0, 16.0, Some(0.0), Some(9.0), Some(8.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CLOUD_HIT, *ATTACK_REGION_SWORD);
+    }
+    wait(lua_state, 2.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+}
+
 #[acmd_script( agent = "cloud", script = "game_attackdash" , category = ACMD_GAME , low_priority)]
 unsafe fn cloud_attack_dash_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -107,7 +120,7 @@ pub fn install() {
     install_acmd_scripts!(
         cloud_attack_11_game,
         cloud_attack_12_game,
+        cloud_attack_13_game,
         cloud_attack_dash_game,
     );
 }
-

--- a/fighters/demon/src/opff.rs
+++ b/fighters/demon/src/opff.rs
@@ -28,18 +28,19 @@ unsafe fn slaughter_high_kick_devastator(boma: &mut BattleObjectModuleAccessor, 
     }
 }
 
-unsafe fn jaw_breaker(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, motion_kind: u64, frame: f32) {
-    if [*FIGHTER_STATUS_KIND_ESCAPE].contains(&status_kind)
-        && boma.status_frame() > 17 {
-        if compare_mask(cat1, *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N){
-            VarModule::on_flag(boma.object(), vars::demon::instance::JAW_BREAKER);
-            boma.change_status_req(*FIGHTER_STATUS_KIND_ATTACK_HI3, false);
-        }
-    }
-    if ![*FIGHTER_STATUS_KIND_ESCAPE, *FIGHTER_STATUS_KIND_ATTACK_HI3].contains(&status_kind) {
-        VarModule::off_flag(boma.object(), vars::demon::instance::JAW_BREAKER);
-    }
-}
+// unsafe fn jaw_breaker(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, motion_kind: u64, frame: f32) {
+//     if [*FIGHTER_STATUS_KIND_ESCAPE].contains(&status_kind)
+//         && boma.status_frame() > 17 {
+//         if compare_mask(cat1, *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N){
+//             VarModule::on_flag(boma.object(), vars::demon::instance::JAW_BREAKER);
+//             boma.change_status_req(*FIGHTER_STATUS_KIND_ATTACK_HI3, false);
+//         }
+//     }
+//     if ![*FIGHTER_STATUS_KIND_ESCAPE, *FIGHTER_STATUS_KIND_ATTACK_HI3].contains(&status_kind) {
+//         VarModule::off_flag(boma.object(), vars::demon::instance::JAW_BREAKER);
+//     }
+// }
+
 unsafe fn lightning_screw_uppercut(boma: &mut BattleObjectModuleAccessor, cat1: i32, status_kind: i32, situation_kind: i32, motion_kind: u64, frame: f32) {
     if motion_kind == hash40("attack_stand_21") {
         if frame < 19.0{
@@ -232,7 +233,7 @@ unsafe fn up_special_freefall(fighter: &mut L2CFighterCommon, boma: &mut BattleO
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     slaughter_high_kick_devastator(boma, cat[0], status_kind, situation_kind, motion_kind);
-    jaw_breaker(boma, cat[0], status_kind, situation_kind, motion_kind, frame);
+    // jaw_breaker(boma, cat[0], status_kind, situation_kind, motion_kind, frame);
     korean_back_dash(boma, cat[0], status_kind, stick_y);
     lightning_screw_uppercut(boma, cat[0], status_kind, situation_kind, motion_kind, frame);
     spinning_demon(boma, cat[0], status_kind, situation_kind, motion_kind, frame);

--- a/fighters/kamui/src/acmd/other.rs
+++ b/fighters/kamui/src/acmd/other.rs
@@ -226,8 +226,8 @@ unsafe fn kamui_ryusensya_regular_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     if is_excute(fighter) {
         let lerp = WorkModule::get_float(boma, *WEAPON_KAMUI_RYUSENSYA_INSTANCE_WORK_ID_FLOAT_HOLD_RATE);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 45, 90, 0, 20, 5.0, 0.0, 0.0, 0.0, None, None, None, 0.3, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 10.0, 45, 90, 0, 30, 5.0, 0.0, 0.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 45, 90, 0, 20, 5.0, 0.0, 0.0, 0.0, None, None, None, 0.3, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 10.0, 45, 90, 0, 30, 5.0, 0.0, 0.0, 0.0, None, None, None, 0.5, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_NONE);
         attack!(fighter, *MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
         ATK_LERP_RATIO(fighter, lerp);
         AttackModule::enable_safe_pos(boma);

--- a/fighters/kamui/src/acmd/specials.rs
+++ b/fighters/kamui/src/acmd/specials.rs
@@ -8,6 +8,28 @@ unsafe fn kamui_special_n_end1_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE_RANGE(fighter, 1.0, 8.0, 5.0);
     frame(lua_state, 8.0);
     FT_MOTION_RATE(fighter, 1.0);
+    if is_excute(fighter) {
+        if WorkModule::is_flag(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLAG_IS_KAMUI) {
+            if sv_animcmd::get_value_float(fighter.lua_state_agent, *SO_VAR_FLOAT_LR) < 0.0 {
+                let lerp = WorkModule::get_float(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLOAT_HOLD_RATE);
+                ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 50, 100, 0, 50, 5.5, 0.0, 8.8, 15.0, Some(0.0), Some(8.8), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 1, 0, Hash40::new("top"), 18.0, 50, 100, 0, 50, 6.5, 0.0, 8.8, 15.0, Some(0.0), Some(8.8), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                attack!(fighter, *MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
+                ATK_LERP_RATIO(fighter, lerp);
+            }
+            else {
+                let lerp = WorkModule::get_float(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLOAT_HOLD_RATE);
+                ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 50, 100, 0, 50, 5.5, 0.0, 8.1, 15.0, Some(0.0), Some(8.1), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                ATTACK(fighter, 1, 0, Hash40::new("top"), 18.0, 50, 100, 0, 50, 6.5, 0.0, 8.1, 15.0, Some(0.0), Some(8.1), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
+                attack!(fighter, *MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
+                ATK_LERP_RATIO(fighter, lerp);
+            }
+        }
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
     frame(lua_state, 17.0);
     FT_MOTION_RATE_RANGE(fighter, 17.0, 45.0, 19.0);
     if is_excute(fighter) {
@@ -29,26 +51,6 @@ unsafe fn kamui_dragonhand_special_n_end1_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
-        if WorkModule::is_flag(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLAG_IS_KAMUI) {
-            if sv_animcmd::get_value_float(fighter.lua_state_agent, *SO_VAR_FLOAT_LR) < 0.0 {
-                let lerp = WorkModule::get_float(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLOAT_HOLD_RATE);
-                ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 50, 100, 0, 50, 5.5, 0.0, 8.8, 15.0, Some(0.0), Some(8.8), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                ATTACK(fighter, 1, 0, Hash40::new("top"), 18.0, 50, 100, 0, 50, 6.5, 0.0, 8.8, 15.0, Some(0.0), Some(8.8), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                attack!(fighter, *MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
-                ATK_LERP_RATIO(fighter, lerp);
-            }
-            else {
-                let lerp = WorkModule::get_float(boma, *WEAPON_KAMUI_DRAGONHAND_INSTANCE_WORK_ID_FLOAT_HOLD_RATE);
-                ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 50, 100, 0, 50, 5.5, 0.0, 8.1, 15.0, Some(0.0), Some(8.1), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                ATTACK(fighter, 1, 0, Hash40::new("top"), 18.0, 50, 100, 0, 50, 6.5, 0.0, 8.1, 15.0, Some(0.0), Some(8.1), Some(9.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_BITE);
-                attack!(fighter, *MA_MSC_CMD_ATTACK_SET_LERP, 0, 1);
-                ATK_LERP_RATIO(fighter, lerp);
-            }
-        }
-    }
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
     }
 }
 

--- a/fighters/koopajr/src/acmd/specials.rs
+++ b/fighters/koopajr/src/acmd/specials.rs
@@ -65,24 +65,15 @@ unsafe fn koopajr_special_n_shoot_effect(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "koopajr", script = "game_speciallw" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "koopajr", scripts = ["game_speciallw", "game_specialairlw"], category = ACMD_GAME , low_priority)]
 unsafe fn koopajr_special_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);
-    }
-}
-
-#[acmd_script( agent = "koopajr", script = "game_specialairlw" , category = ACMD_GAME , low_priority)]
-unsafe fn koopajr_special_air_lw_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 10.0);
-    if is_excute(fighter) {
-        ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);
+        if (VarModule::get_int(fighter.object(), vars::common::instance::GIMMICK_TIMER) <= 0) {
+            ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);
+        }
     }
 }
 
@@ -212,7 +203,6 @@ pub fn install() {
         koopajr_special_n_shoot_game,
         koopajr_special_n_shoot_effect,
         koopajr_special_lw_game,
-        koopajr_special_air_lw_game,
         koopajr_special_s_game,
         koopajr_special_s_spin_game,
         koopajr_special_air_s_game,

--- a/fighters/koopajr/src/acmd/specials.rs
+++ b/fighters/koopajr/src/acmd/specials.rs
@@ -71,8 +71,9 @@ unsafe fn koopajr_special_lw_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        if (VarModule::get_int(fighter.object(), vars::common::instance::GIMMICK_TIMER) <= 0) {
+        if !VarModule::is_flag(fighter.object(), vars::koopajr::instance::DISABLE_MECHAKOOPA) {
             ArticleModule::generate_article(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA, false, 0);
+            VarModule::on_flag(fighter.object(), vars::koopajr::instance::DISABLE_MECHAKOOPA);
         }
     }
 }

--- a/fighters/koopajr/src/lib.rs
+++ b/fighters/koopajr/src/lib.rs
@@ -43,5 +43,4 @@ pub fn install(is_runtime: bool) {
     status::install();
     opff::install(is_runtime);
     opff::install_remainclown();
-    smashline::install_agent_frame_callback!(mechakoopa_callback);
 }

--- a/fighters/koopajr/src/lib.rs
+++ b/fighters/koopajr/src/lib.rs
@@ -43,4 +43,5 @@ pub fn install(is_runtime: bool) {
     status::install();
     opff::install(is_runtime);
     opff::install_remainclown();
+    smashline::install_agent_frame_callback!(mechakoopa_callback);
 }

--- a/fighters/koopajr/src/opff.rs
+++ b/fighters/koopajr/src/opff.rs
@@ -86,12 +86,32 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     }
 }
 
+#[weapon_frame( agent = WEAPON_KIND_KOOPAJR_MECHAKOOPA, main)]
+pub fn mechakoopa_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
+    unsafe { 
+        if !smash::app::sv_information::is_ready_go() {
+            if weapon.is_status(*WEAPON_KOOPAJR_MECHAKOOPA_STATUS_KIND_DEAD) {
+                let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
+                let koopajr = utils::util::get_battle_object_from_id(owner_id);
+                VarModule::set_int(koopajr, vars::common::instance::GIMMICK_TIMER, 120);
+            }
+        }
+    }
+}
+
+pub unsafe fn mechakoopa_decrement(fighter: &mut L2CFighterCommon) {
+    if (VarModule::get_int(fighter.object(), vars::common::instance::GIMMICK_TIMER) > 0) {
+        VarModule::dec_int(fighter, vars::common::instance::GIMMICK_TIMER);
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     clown_cannon_shield_cancel(boma, status_kind, situation_kind, frame);
     // clown_cannon_dash_cancel(boma, status_kind, situation_kind, cat[0], frame);
     kart_jump_waveland(boma, status_kind, situation_kind, cat[0]);
     upB_kart_respawn(fighter, boma, status_kind);
     fastfall_specials(fighter);
+    mechakoopa_decrement(fighter);
 }
 
 

--- a/fighters/koopajr/src/opff.rs
+++ b/fighters/koopajr/src/opff.rs
@@ -49,6 +49,37 @@ unsafe fn upB_kart_respawn(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma:
     }
 }
 
+extern "Rust" {
+    fn gimmick_flash(boma: &mut BattleObjectModuleAccessor);
+}
+
+unsafe fn mechakoopa_cooldown(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    let cooldown_timer = VarModule::get_int(boma.object(), vars::common::instance::GIMMICK_TIMER);
+    let item_exists = ArticleModule::is_exist(boma, *FIGHTER_KOOPAJR_GENERATE_ARTICLE_MECHAKOOPA);
+    let koopa_is_disabled = VarModule::is_flag(boma.object(), vars::koopajr::instance::DISABLE_MECHAKOOPA);
+    let in_cooldown = VarModule::is_flag(boma.object(), vars::koopajr::instance::MECHAKOOPA_IS_COOLDOWN);
+
+    // make sure disable flag is set if the koopa exists
+    if item_exists && !koopa_is_disabled {
+        VarModule::on_flag(boma.object(), vars::koopajr::instance::DISABLE_MECHAKOOPA);
+    }
+    // initiate cooldown once the koopa stops existing
+    if !item_exists && !in_cooldown && koopa_is_disabled {
+        VarModule::on_flag(boma.object(), vars::koopajr::instance::MECHAKOOPA_IS_COOLDOWN);
+        VarModule::set_int(boma.object(), vars::common::instance::GIMMICK_TIMER, 120);
+    }
+    // decrement cooldown timer when active
+    if cooldown_timer > 0 {
+        VarModule::dec_int(boma.object(), vars::common::instance::GIMMICK_TIMER);
+    }
+    // enable the koopa once the timer is over
+    if cooldown_timer <= 0 && in_cooldown {
+        VarModule::off_flag(boma.object(), vars::koopajr::instance::MECHAKOOPA_IS_COOLDOWN);
+        VarModule::off_flag(boma.object(), vars::koopajr::instance::DISABLE_MECHAKOOPA);
+        gimmick_flash(boma);
+    }
+}
+
 unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     if !fighter.is_in_hitlag()
     && !StatusModule::is_changing(fighter.module_accessor)
@@ -86,36 +117,17 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     }
 }
 
-#[weapon_frame( agent = WEAPON_KIND_KOOPAJR_MECHAKOOPA, main)]
-pub fn mechakoopa_callback(weapon: &mut smash::lua2cpp::L2CFighterBase) {
-    unsafe { 
-        if !smash::app::sv_information::is_ready_go() {
-            if weapon.is_status(*WEAPON_KOOPAJR_MECHAKOOPA_STATUS_KIND_DEAD) {
-                let owner_id = WorkModule::get_int(weapon.module_accessor, *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER) as u32;
-                let koopajr = utils::util::get_battle_object_from_id(owner_id);
-                VarModule::set_int(koopajr, vars::common::instance::GIMMICK_TIMER, 120);
-            }
-        }
-    }
-}
-
-pub unsafe fn mechakoopa_decrement(fighter: &mut L2CFighterCommon) {
-    if (VarModule::get_int(fighter.object(), vars::common::instance::GIMMICK_TIMER) > 0) {
-        VarModule::dec_int(fighter, vars::common::instance::GIMMICK_TIMER);
-    }
-}
-
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     clown_cannon_shield_cancel(boma, status_kind, situation_kind, frame);
     // clown_cannon_dash_cancel(boma, status_kind, situation_kind, cat[0], frame);
     kart_jump_waveland(boma, status_kind, situation_kind, cat[0]);
     upB_kart_respawn(fighter, boma, status_kind);
     fastfall_specials(fighter);
-    mechakoopa_decrement(fighter);
+    mechakoopa_cooldown(fighter, boma);
 }
 
 
-#[utils::macros::opff(FIGHTER_KIND_KOOPAJR )]
+#[utils::macros::opff(FIGHTER_KIND_KOOPAJR)]
 pub fn koopajr_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
     unsafe {
         common::opff::fighter_common_opff(fighter);

--- a/fighters/lucina/src/opff.rs
+++ b/fighters/lucina/src/opff.rs
@@ -93,6 +93,42 @@ unsafe fn up_special_proper_landing(fighter: &mut L2CFighterCommon) {
     }
 }
 
+// lets lucina toggle her mask on/off with down taunt
+unsafe fn mask_toggle(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, frame: f32) {
+    let mask_is_equipped = VarModule::is_flag(boma.object(), vars::lucina::instance::EQUIP_MASK);
+    let mask_is_exist = ArticleModule::is_exist(boma, *FIGHTER_LUCINA_GENERATE_ARTICLE_MASK);
+    
+    if fighter.is_motion_one_of(&[Hash40::new("appeal_lw_l"), Hash40::new("appeal_lw_r")])
+    && frame as i32 == 12 {
+        if mask_is_equipped { // take off mask
+            VarModule::off_flag(boma.object(), vars::lucina::instance::EQUIP_MASK);
+        } else { // put on mask
+            VarModule::on_flag(boma.object(), vars::lucina::instance::EQUIP_MASK);
+        }
+    } else {
+        if mask_is_equipped && !mask_is_exist {
+            ArticleModule::generate_article(boma, *FIGHTER_LUCINA_GENERATE_ARTICLE_MASK, false, -1);
+
+            let article = ArticleModule::get_article(boma, *FIGHTER_LUCINA_GENERATE_ARTICLE_MASK);
+            let article_id = smash::app::lua_bind::Article::get_battle_object_id(article) as u32;
+            let article_boma = sv_battle_object::module_accessor(article_id);
+            MotionModule::change_motion(article_boma, Hash40::new("appeal_lw"), 0.0, 1.0, false, 0.0, false, false);
+            MotionModule::set_frame(article_boma, 50.0, true);
+            MotionModule::set_rate(article_boma, 0.0);
+        } 
+        else if !mask_is_equipped && mask_is_exist
+        && !fighter.is_motion_one_of(&[Hash40::new("entry_l"), Hash40::new("entry_r")]) { // ignore during entry animation
+            ArticleModule::remove_exist(boma, *FIGHTER_LUCINA_GENERATE_ARTICLE_MASK, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
+        }
+    }
+
+    // remove mask on entry and death
+    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_ENTRY, *FIGHTER_STATUS_KIND_DEAD])
+    && mask_is_equipped {
+        VarModule::off_flag(boma.object(), vars::lucina::instance::EQUIP_MASK);
+    }
+}
+
 // symbol-based call for the fe characters' common opff
 extern "Rust" {
     fn fe_common(fighter: &mut smash::lua2cpp::L2CFighterCommon);
@@ -136,6 +172,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     // Magic Series
     //side_special_cancels(boma, status_kind, situation_kind, cat[0], motion_kind);
     up_special_proper_landing(fighter);
+    mask_toggle(fighter, boma, frame);
     fastfall_specials(fighter);
 }
 

--- a/fighters/lucina/src/status.rs
+++ b/fighters/lucina/src/status.rs
@@ -10,6 +10,7 @@ pub fn install() {
         lucina_specials2_main,
         lucina_specials3_main,
         lucina_specials3_exec_stop,
+        appeal_end
     );
 }
 
@@ -477,3 +478,8 @@ unsafe extern "C" fn special_lw_main_loop(fighter: &mut L2CFighterCommon) -> L2C
     0.into()
 }
 
+// stub out mask removal at the end of taunt
+#[status_script(agent = "lucina", status = FIGHTER_STATUS_KIND_APPEAL, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn appeal_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    1.into()
+}

--- a/fighters/richter/src/status/attacks3.rs
+++ b/fighters/richter/src/status/attacks3.rs
@@ -31,8 +31,12 @@ unsafe extern "C" fn attack_s3_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
 
     // <HDR>
     if StatusModule::is_changing(fighter.module_accessor)
-    && ([*FIGHTER_STATUS_KIND_SQUAT_WAIT, *FIGHTER_STATUS_KIND_SQUAT_RV].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
-        || fighter.stick_y() <= -0.5) {
+    && [*FIGHTER_STATUS_KIND_SQUAT,
+        *FIGHTER_STATUS_KIND_SQUAT_WAIT, 
+        *FIGHTER_STATUS_KIND_SQUAT_RV, 
+        *FIGHTER_STATUS_KIND_SQUAT_F, 
+        *FIGHTER_STATUS_KIND_ATTACK_S3].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
+    && fighter.left_stick_y() <= -0.5 {
         WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SQUAT);
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_squat_s3"), 0.0, 1.0, false, 0.0, false, false);
     }

--- a/fighters/richter/src/status/attacks3.rs
+++ b/fighters/richter/src/status/attacks3.rs
@@ -31,7 +31,8 @@ unsafe extern "C" fn attack_s3_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
 
     // <HDR>
     if StatusModule::is_changing(fighter.module_accessor)
-    && fighter.stick_y() <= -0.5 {
+    && ([*FIGHTER_STATUS_KIND_SQUAT_WAIT, *FIGHTER_STATUS_KIND_SQUAT_RV].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
+        || fighter.stick_y() <= -0.5) {
         WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SQUAT);
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_squat_s3"), 0.0, 1.0, false, 0.0, false, false);
     }

--- a/fighters/robot/src/acmd/aerials.rs
+++ b/fighters/robot/src/acmd/aerials.rs
@@ -467,9 +467,9 @@ unsafe fn robot_attack_air_lw_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 1.0);
     for _ in 0..6 {
         if is_excute(fighter) {
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.2, 365, 100, 40, 0, 3.0, 0.0, 6.0, -3.0, Some(0.0), Some(6.0), Some(3.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 1.2, 365, 100, 40, 0, 3.0, 0.0, 2.0, -3.0, Some(0.0), Some(2.0), Some(3.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 2, 0, Hash40::new("top"), 1.2, 365, 100, 40, 0, 2.0, 0.0, -2.0, -3.0, Some(0.0), Some(-2.0), Some(3.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 1.2, 365, 100, 40, 0, 3.0, 0.0, 6.0, -4.0, Some(0.0), Some(6.0), Some(8.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 1.2, 365, 100, 40, 0, 3.0, 0.0, 2.0, -4.0, Some(0.0), Some(2.0), Some(8.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 2, 0, Hash40::new("top"), 1.2, 80, 100, 40, 0, 2.0, 0.0, -3.0, -4.0, Some(0.0), Some(-3.0), Some(8.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_rush"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
         }
         wait(lua_state, 1.0);
         if is_excute(fighter) {
@@ -478,7 +478,7 @@ unsafe fn robot_attack_air_lw_game(fighter: &mut L2CAgentBase) {
         wait(lua_state, 2.0);
     }
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 40, 85, 0, 45, 8.0, 0.0, 1.0, 0.0, None, None, None, 2.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 40, 85, 0, 45, 6.0, 0.0, 2.5, 0.0, Some(0.0), Some(2.5), Some(7.0), 2.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_PUNCH);
     }
     wait(lua_state, 2.0);
     if is_excute(fighter) {
@@ -510,17 +510,15 @@ unsafe fn robot_attack_air_lw_effect(fighter: &mut L2CAgentBase) {
     };
     for _ in 0..6 {
         if is_excute(fighter) {
-            EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 1.5, 7, 0, effectX, 0, 0, 1.3, true, *EF_FLIP_NONE);
+            EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 3, 10, 1.5, effectX, 30, 0, 1.2, true, *EF_FLIP_NONE);
             LAST_EFFECT_SET_RATE(fighter, 3.0);
             effectX += 8.0;
             LAST_EFFECT_SET_COLOR(fighter, color_vec.x, color_vec.y, color_vec.z);
-            LANDING_EFFECT_FLIP(fighter, Hash40::new("sys_whirlwind_l"), Hash40::new("sys_whirlwind_r"), Hash40::new("top"), 0, 7, 0, effectX, 0, 0, 1, 0, 0, 0, 0, 0, 0, false, *EF_FLIP_NONE);
-            LAST_EFFECT_SET_RATE(fighter, 3.0);
         }
         wait(lua_state, 3.0);
     }
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_impact"), Hash40::new("top"), 3.0, -2.0, 0, 0, 0, 0, 1.5, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_impact"), Hash40::new("top"), 3.0, 2.0, 8.0, 0, 0, 0, 1.5, true);
         LAST_EFFECT_SET_RATE(fighter, 1.5);
     }
 }

--- a/fighters/simon/src/status/attacks3.rs
+++ b/fighters/simon/src/status/attacks3.rs
@@ -31,8 +31,12 @@ unsafe extern "C" fn attack_s3_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
 
     // <HDR>
     if StatusModule::is_changing(fighter.module_accessor)
-    && ([*FIGHTER_STATUS_KIND_SQUAT_WAIT, *FIGHTER_STATUS_KIND_SQUAT_RV].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
-        || fighter.stick_y() <= -0.5) {
+    && [*FIGHTER_STATUS_KIND_SQUAT,
+        *FIGHTER_STATUS_KIND_SQUAT_WAIT, 
+        *FIGHTER_STATUS_KIND_SQUAT_RV, 
+        *FIGHTER_STATUS_KIND_SQUAT_F, 
+        *FIGHTER_STATUS_KIND_ATTACK_S3].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
+    && fighter.left_stick_y() <= -0.5 {
         WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SQUAT);
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_squat_s3"), 0.0, 1.0, false, 0.0, false, false);
     }

--- a/fighters/simon/src/status/attacks3.rs
+++ b/fighters/simon/src/status/attacks3.rs
@@ -31,7 +31,8 @@ unsafe extern "C" fn attack_s3_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
 
     // <HDR>
     if StatusModule::is_changing(fighter.module_accessor)
-    && fighter.stick_y() <= -0.5 {
+    && ([*FIGHTER_STATUS_KIND_SQUAT_WAIT, *FIGHTER_STATUS_KIND_SQUAT_RV].contains(&fighter.global_table[PREV_STATUS_KIND].get_i32())
+        || fighter.stick_y() <= -0.5) {
         WorkModule::unable_transition_term_group_ex(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_SQUAT);
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("attack_squat_s3"), 0.0, 1.0, false, 0.0, false, false);
     }


### PR DESCRIPTION
Another assortment of fixes and adjustments. Check back periodically for more information

Assets: [misc-assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/13929733/misc-assets.zip)


___

## Zero Suit Samus
- (*) Fixed a visual issue with the animation for standing grab, where every expression was being displayed at once

Before | After
-- | --
<img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/867316bf-aad5-4499-9b25-cdcac6d0609f"></img> | <img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/6bf775f0-8996-46e9-a2f1-1fa9ed11660c"></img>

## R.O.B.
### Down Air
- [R] Adjusted animation to rotate R.O.B. more towards the camera, increasing the horizontal coverage of the attack

https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/f4c1906c-d147-430d-9734-3c943e034ae7

  - Multi-hits
    - [+] Horizontal hitbox size: 6u ➜ 12u
    - [+] Lowermost hitbox moved downward by 1u
    - [+] Angle of the lowermost hitbox has been changed from 365 ➜ 80, allowing the move to connect more reliably
  - Finisher
    - [/] Hitbox size: 8u ➜ 6u
    - [/] Hitbox moved upward by 1.5u
    - [/] Horizontal hitbox size: 1u ➜ 7u
- [$] Adjusted effects 

Before | After
-- | --
<img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/bfbe431f-ed03-493a-b34b-b81558db582c"></img> | <img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/6c727b08-7684-4889-a6d5-21a4f95cca71"></img>
<img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/c0e8dc62-d205-49f9-b40f-230986f57786"></img> | <img src="https://github.com/HDR-Development/HewDraw-Remix/assets/16338870/1661cff4-76b4-447f-a5b0-3861b8d4a7b2"></img>

## Lucina
- [$] Lucina can now equip her mask on/off by using down taunt

## Bowser Jr.
### Mecha Koopa
- [-] Added a 2 second cooldown before another Mecha Koopa can be summoned after the last one has been destroyed

## Corrin
### Dragon Fang Shot
- [+] Attached hitboxes to Corrin, removing clanking issues
- [+] Dragon Fang Shot Projectile SDI multiplier: 1.0 -> 0.5

## Simon + Richter
### Forward Tilt
- (*) Adjusted logic for the crouching variant, re-enabling the ability to input the attack using tilt stick

## Kazuya
Removes spotdodge attack