### PR TITLE
DJC Leniency

### DIFF
--- a/fighters/common/src/djc.rs
+++ b/fighters/common/src/djc.rs
@@ -23,13 +23,6 @@ pub unsafe extern "C" fn attack_air_main_status(fighter: &mut L2CFighterCommon) 
 /// Performs the leniency check for double jump canceling
 #[utils::export(common::djc)]
 pub unsafe extern "C" fn attack_air_main_status_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_AERIAL {
-        let djc_leniency_frame = ParamModule::get_int(fighter.battle_object, ParamType::Common, "djc_leniency_frame");
-        if fighter.global_table[CURRENT_FRAME].get_i32() <= djc_leniency_frame && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
-            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
-            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
-        }
-    }
     if !fighter.status_AttackAir_Main_common().get_bool() {
         fighter.sub_air_check_superleaf_fall_slowly();
         if !fighter.global_table[IS_STOPPING].get_bool() {
@@ -54,12 +47,9 @@ pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_
 
         fighter.sub_attack_air_kind();
         if motion_kind == smash::hash40("jump_aerial_f") || motion_kind == smash::hash40("jump_aerial_b") {
-            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION)
-            && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+            if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
                 MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
                 MotionModule::set_weight(fighter.module_accessor, 1.0, true);
-            }
-            if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
             } else {
                 WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
@@ -85,10 +75,12 @@ fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_init(fighter: &mut L2C
 /// Inherits the double jump animation movement when doing an aerial (exec)
 #[smashline::hook(module = "common", symbol = "_ZN7lua2cpp16L2CFighterCommon59sub_attack_air_inherit_jump_aerial_motion_uniq_process_execEv")]
 pub unsafe extern "C" fn sub_attack_air_inherit_jump_aerial_motion_uniq_process_exec_impl(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[PREV_STATUS_KIND] == FIGHTER_STATUS_KIND_JUMP_AERIAL
+    if KineticModule::get_kinetic_type(fighter.module_accessor) == *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND 
     && fighter.global_table[FIGHTER_KIND] != FIGHTER_KIND_DEMON
+    && !fighter.is_in_hitlag()
+    && MotionModule::frame_2nd(fighter.module_accessor) >= 2.0
     && fighter.global_table[CURRENT_FRAME].get_i32() <= ParamModule::get_int(fighter.battle_object, ParamType::Common, "djc_leniency_frame")
-    && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+    && ControlModule::check_button_off(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
     }

--- a/fighters/peach/src/status/attack_air.rs
+++ b/fighters/peach/src/status/attack_air.rs
@@ -89,13 +89,6 @@ unsafe extern "C" fn peach_attack_air_no_float_main_loop(fighter: &mut L2CFighte
         fighter.change_status(FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START.into(), true.into());
         return 1.into();
     }
-
-    
-    if fighter.global_table[CURRENT_FRAME].get_i32() <= ParamModule::get_int(fighter.battle_object, ParamType::Common, "djc_leniency_frame")
-    && !ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
-        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
-    }
     if fighter.status_AttackAir_Main_common().get_bool() {
         return 0.into();
     }

--- a/fighters/trail/src/status/attack_air.rs
+++ b/fighters/trail/src/status/attack_air.rs
@@ -60,14 +60,9 @@ pub unsafe fn init_attack_air(fighter: &mut L2CFighterCommon) -> L2CValue {
 
     fighter.sub_attack_air_kind();
     if motion_kind == smash::hash40("jump_aerial_f") || motion_kind == smash::hash40("jump_aerial_b") {
-        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION)
-        && ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
+        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
             MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
             MotionModule::set_weight(fighter.module_accessor, 1.0, true);
-        }
-        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION){
-        }
-        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
             KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
         } else {
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
@@ -140,7 +135,7 @@ unsafe extern "C" fn sub_attack_air_n(fighter: &mut L2CFighterCommon) {
     }
     if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
         if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
-            MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
+            MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame.max(1.0), 1.0, false, 1.0);
             MotionModule::set_weight(fighter.module_accessor, 1.0, true);
         }
     }
@@ -227,18 +222,13 @@ unsafe extern "C" fn sub_attack_air_f(fighter: &mut L2CFighterCommon) {
         }
     }
     if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_IGNORE_2ND_MOTION) {
-        if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
             MotionModule::add_motion_2nd(fighter.module_accessor, Hash40::new_raw(motion_kind), frame, 1.0, false, 1.0);
             MotionModule::set_weight(fighter.module_accessor, 1.0, true);
+            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
+        } else {
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
+            KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
         }
-    }
-    if ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP) {
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_JUMP_AERIAL_MOTION_2ND);
-    }
-    else {
-        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
-        KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_MOTION_FALL);
-    }
     fighter.sub_attack_air_uniq_process_init();
     return;
 }


### PR DESCRIPTION
Due to engine differences djcs out of shorthops gain far less height, and inputting dj+aerial at the same time gains 0 jump momentum. In addition, there appears to be a bug where you can superjump during hitlag. This attempts to help with those issues, in lieu of an in-depth look by a dev. Tested with all djcers, dj arcs adjusted on ness/peach. Originally was going to be only code changes, however since I cannot properly fix the problem I additionally made the pre-existing jumps better (other than lucas)

Resolves #1888
Assets: [adjusted djc.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14016611/adjusted.djc.zip)

### DJC:
- [*] Releasing jump during a rising aerial now waits for hitlag to end, preventing some odd behaviors around the leniency window mentioned in issue (from my testing)
- [/] Djcs now wait until 1 frame of jump momentum has passed, and can cancel on frame 2+ of the arc
- [*] DJC check now only in exec, before it was in main, main_loop, and exec at the same time?

**Peach:**
- [/] Dip portion of dj widened, so that you can get perfect djcs even with the above change. However the curve is less steep, so you don't get sucked down as fast without manually fast falling.

**Ness:**
- [/] DJ arcs from brawl/pm have been ported, except with the rise portion starting 4 frames sooner and frames 6/7 gaining slightly more momentum. This enables faster-paced djc combos while not burdening him with the full slowness of his melee dj

**Lucas:**
- [*] DJ anim from before Oly's pr has been restored, no longer pushed forwards a frame (did not solve any issues)