### PR TITLE
Ganondorf.

### DIFF
--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -6,7 +6,7 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    FT_MOTION_RATE(fighter, 4.0 / 6.0);
+    FT_MOTION_RATE(fighter, 3.0 / 6.0);
     frame(lua_state, 7.0);
     FT_MOTION_RATE(fighter, 2.0);
     frame(lua_state, 7.5);

--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -11,8 +11,8 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 2.0);
     frame(lua_state, 7.5);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
         ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.75);
     }
     frame(lua_state, 8.0);

--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -11,8 +11,8 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 2.0);
     frame(lua_state, 7.5);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
         ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.75);
     }
     frame(lua_state, 8.0);

--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -13,7 +13,10 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.75);
+        ATTACK(fighter, 2, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 2.0, 0.0, 12.0, 14.0, Some(0.0), Some(15.0), Some(14.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 0, 2.75);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 1, 2.75);
+        ATK_SET_SHIELD_SETOFF_MUL(fighter, 2, 2.75);
     }
     wait(lua_state, 3.0);
     if is_excute(fighter) {

--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -1,24 +1,64 @@
 
 use super::*;
 
-
 #[acmd_script( agent = "ganon", script = "game_attack11" , category = ACMD_GAME , low_priority)]
 unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    FT_MOTION_RATE(fighter, 4.0/8.0);
-    frame(lua_state, 8.0);  // ends up being frame 5
-    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 4.0 / 6.0);
+    frame(lua_state, 7.0);
+    FT_MOTION_RATE(fighter, 2.0);
+    frame(lua_state, 7.5);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("armr"), 10.0, 361, 95, 0, 35, 5.0, -5.0, -1.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("armr"), 10.0, 361, 95, 0, 35, 5.0, -0.5, -1.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 2, 0, Hash40::new("armr"), 10.0, 361, 95, 0, 35, 5.0, 4.0, -0.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
+        ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.75);
     }
+    frame(lua_state, 8.0);
+    FT_MOTION_RATE(fighter, 1.0);
     wait(lua_state, 3.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
-    
+}
+
+#[acmd_script( agent = "ganon", script = "effect_attack11" , category = ACMD_EFFECT , low_priority)]
+unsafe fn ganon_attack_11_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 7.5);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 0, 18, 4, 0, 25, 40, 1.0, true);
+        LAST_EFFECT_SET_RATE(fighter, 2);
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "sound_attack11" , category = ACMD_SOUND , low_priority)]
+unsafe fn ganon_attack_11_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_ganon_swing_s"));
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "expression_attack11" , category = ACMD_EXPRESSION , low_priority)]
+unsafe fn ganon_attack_11_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 5.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_nohitm"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+    }
 }
 
 #[acmd_script( agent = "ganon", script = "game_attackdash" , category = ACMD_GAME , low_priority)]
@@ -45,6 +85,10 @@ unsafe fn ganon_attack_dash_game(fighter: &mut L2CAgentBase) {
 pub fn install() {
     install_acmd_scripts!(
         ganon_attack_11_game,
+        ganon_attack_11_effect,
+        ganon_attack_11_sound,
+        ganon_attack_11_expression,
+
         ganon_attack_dash_game,
     );
 }

--- a/fighters/ganon/src/acmd/ground.rs
+++ b/fighters/ganon/src/acmd/ground.rs
@@ -6,17 +6,15 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 1.0);
-    FT_MOTION_RATE(fighter, 3.0 / 6.0);
-    frame(lua_state, 7.0);
-    FT_MOTION_RATE(fighter, 2.0);
-    frame(lua_state, 7.5);
+    FT_MOTION_RATE(fighter, 3.0 / 4.0);
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 6.0);
     if is_excute(fighter) {
         ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 5.0, 0.0, 12.0, 7.0, Some(0.0), Some(15.0), Some(7.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 70, 60, 0, 45, 3.5, 0.0, 12.0, 11.0, Some(0.0), Some(15.0), Some(11.0), 2.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_PUNCH);
         ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter, 0, 1, 2.75);
     }
-    frame(lua_state, 8.0);
-    FT_MOTION_RATE(fighter, 1.0);
     wait(lua_state, 3.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
@@ -27,10 +25,9 @@ unsafe fn ganon_attack_11_game(fighter: &mut L2CAgentBase) {
 unsafe fn ganon_attack_11_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 7.5);
+    frame(lua_state, 6.0);
     if is_excute(fighter) {
         EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 0, 18, 4, 0, 25, 40, 1.0, true);
-        LAST_EFFECT_SET_RATE(fighter, 2);
     }
 }
 
@@ -38,7 +35,7 @@ unsafe fn ganon_attack_11_effect(fighter: &mut L2CAgentBase) {
 unsafe fn ganon_attack_11_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 7.0);
+    frame(lua_state, 5.0);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_ganon_swing_s"));
     }
@@ -55,7 +52,7 @@ unsafe fn ganon_attack_11_expression(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_nohitm"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
-    frame(lua_state, 7.0);
+    frame(lua_state, 6.0);
     if is_excute(fighter) {
         RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
     }

--- a/fighters/ganon/src/acmd/specials.rs
+++ b/fighters/ganon/src/acmd/specials.rs
@@ -195,9 +195,11 @@ unsafe fn ganon_special_air_s_catch_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     if is_excute(fighter) {
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 4.0, 0, 10, 0, 100, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
-        let speed_x = 1.7 * PostureModule::lr(boma);
-        WorkModule::set_float(boma, speed_x, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_X);
-        WorkModule::set_float(boma, 1.5, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_Y);
+        let lr = PostureModule::lr(boma);
+        let stick_x = ControlModule::get_stick_x(boma) * lr;
+        let speed_x = 0.5 * stick_x;
+        WorkModule::set_float(boma, speed_x + 1.0, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_X);
+        WorkModule::set_float(boma, 2.0, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_Y);
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
@@ -211,7 +213,9 @@ unsafe fn ganon_special_air_s_fall_game(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     if is_excute(fighter) {
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 4.0, 0, 10, 0, 100, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_NONE);
-        SET_SPEED_EX(fighter, 1.5, -5, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        let speed_x = WorkModule::get_float(boma, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_X);
+        SET_SPEED_EX(fighter, speed_x, -5, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        KineticModule::suspend_energy(boma, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
     }
     frame(lua_state, 2.0);
     if is_excute(fighter) {

--- a/fighters/ganon/src/acmd/tilts.rs
+++ b/fighters/ganon/src/acmd/tilts.rs
@@ -216,6 +216,21 @@ unsafe fn ganon_attack_hi3_effect(fighter: &mut L2CAgentBase) {
 
 }
 
+#[acmd_script( agent = "ganon", script = "sound_attackhi3" , category = ACMD_SOUND , low_priority)]
+unsafe fn ganon_attack_hi3_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_ganon_appeal_l01"));
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("vc_ganon_attack06"));
+        PLAY_SE(fighter, Hash40::new("se_ganon_swing_m"));
+    }
+}
+
 #[acmd_script( agent = "ganon", script = "expression_attackhi3" , category = ACMD_EXPRESSION , low_priority)]
 unsafe fn ganon_attack_hi3_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -240,17 +255,6 @@ unsafe fn ganon_attack_hi3_expression(fighter: &mut L2CAgentBase) {
     frame(lua_state, 15.0);
     if is_excute(fighter) {
         RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
-    }
-}
-
-#[acmd_script( agent = "ganon", script = "sound_attackhi3" , category = ACMD_SOUND , low_priority)]
-unsafe fn ganon_attack_hi3_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 9.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("vc_ganon_attack06"));
-        PLAY_SE(fighter, Hash40::new("se_ganon_swing_m"));
     }
 }
 

--- a/fighters/ganon/src/acmd/tilts.rs
+++ b/fighters/ganon/src/acmd/tilts.rs
@@ -2,7 +2,7 @@
 use super::*;
 
 
-#[acmd_script( agent = "ganon", scripts = ["game_attacks3", "game_attacks3hi", "game_attacks3lw"] , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "ganon", script = "game_attacks3" , category = ACMD_GAME , low_priority)]
 unsafe fn ganon_attack_s3_s_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -19,6 +19,60 @@ unsafe fn ganon_attack_s3_s_game(fighter: &mut L2CAgentBase) {
         ATTACK(fighter, 0, 0, Hash40::new("hip"), 13.0, 22, 81, 0, 32, 4.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
         ATTACK(fighter, 1, 0, Hash40::new("kneel"), 13.0, 22, 81, 0, 32, 5.0, -0.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
         ATTACK(fighter, 2, 0, Hash40::new("kneel"), 14.0, 22, 81, 0, 32, 5.5, 6.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+    }
+    frame(lua_state, 10.1);
+    FT_MOTION_RATE(fighter, 1.0/(12.0 - 10.1));
+    frame(lua_state, 12.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 14.0);
+    FT_MOTION_RATE(fighter, 20.0/(35.0 - 14.0));
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+
+}
+
+#[acmd_script( agent = "ganon", script = "game_attacks3hi" , category = ACMD_GAME , low_priority)]
+unsafe fn ganon_attack_s3_hi_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        HIT_NODE(fighter, Hash40::new("kneel"), *HIT_STATUS_XLU);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("hip"), 15.0, 22, 72, 0, 25, 4.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 1, 0, Hash40::new("kneel"), 15.0, 22, 72, 0, 25, 5.0, -0.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 2, 0, Hash40::new("kneel"), 16.0, 22, 72, 0, 25, 5.5, 6.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+    }
+    frame(lua_state, 14.0);
+    FT_MOTION_RATE(fighter, 20.0/(35.0 - 14.0));
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
+    }
+
+}
+
+#[acmd_script( agent = "ganon", script = "game_attacks3lw" , category = ACMD_GAME , low_priority)]
+unsafe fn ganon_attack_s3_lw_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE(fighter, 4.0/(8.0 - 1.0));
+    frame(lua_state, 8.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    if is_excute(fighter) {
+        HIT_NODE(fighter, Hash40::new("kneel"), *HIT_STATUS_XLU);
+    }
+    frame(lua_state, 10.0);
+    FT_MOTION_RATE(fighter, 1.0/(10.1 - 10.0));
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("hip"), 9.0, 22, 95, 0, 35, 4.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 1, 0, Hash40::new("kneel"), 9.0, 22, 95, 0, 35, 5.0, -0.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 2, 0, Hash40::new("kneel"), 10.0, 22, 95, 0, 35, 5.5, 6.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_THRU, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
     }
     frame(lua_state, 10.1);
     FT_MOTION_RATE(fighter, 1.0/(12.0 - 10.1));
@@ -67,54 +121,97 @@ unsafe fn ganon_attack_s3_lw_effect(fighter: &mut L2CAgentBase) {
 unsafe fn ganon_attack_hi3_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 1.0);
-    FT_MOTION_RATE(fighter, 0.579);
-    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        ArticleModule::remove_exist(fighter.module_accessor, *FIGHTER_GANON_GENERATE_ARTICLE_SWORD, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
+        ArticleModule::generate_article(fighter.module_accessor, *FIGHTER_GANON_GENERATE_ARTICLE_SWORD, false, 0);
+    }
+    frame(lua_state, 11.0);
+    FT_MOTION_RATE(fighter, 0.5);
+    frame(lua_state, 13.0);
     FT_MOTION_RATE(fighter, 1.0);
-    frame(lua_state, 20.0);
     if is_excute(fighter) {
-        HIT_NODE(fighter, Hash40::new("legl"), *HIT_STATUS_XLU);
-        HIT_NODE(fighter, Hash40::new("kneel"), *HIT_STATUS_XLU);
-        HIT_NODE(fighter, Hash40::new("footl"), *HIT_STATUS_XLU);
-        ATTACK(fighter, 0, 0, Hash40::new("kneel"), 12.0, 85, 67, 0, 60, 7.0, 6.2, 0.0, -2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 1, 0, Hash40::new("kneel"), 12.0, 83, 67, 0, 60, 6.75, 0.0, 0.0, -1.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 2, 0, Hash40::new("hip"), 12.0, 80, 67, 0, 60, 6.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 3, 0, Hash40::new("top"), 12.0, 80, 67, 0, 60, 6.5, 0.0, 8.0, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 4, 0, Hash40::new("top"), 12.0, 80, 67, 0, 60, 6.5, 0.0, 12.0, 7.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 0, 0, Hash40::new("haver"), 14.0, 78, 75, 0, 50, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("haver"), 14.0, 78, 75, 0, 50, 4.5, 0.0, 4.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 2, 0, Hash40::new("haver"), 14.0, 78, 75, 0, 50, 4.5, 0.0, 12.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
     }
-    frame(lua_state, 22.0);
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
-        AttackModule::clear(boma, 3, false);
-        AttackModule::clear(boma, 4, false);
+        ATTACK(fighter, 0, 0, Hash40::new("haver"), 8.0, 78, 75, 0, 50, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 1, 0, Hash40::new("haver"), 8.0, 78, 75, 0, 50, 4.5, 0.0, 4.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
+        ATTACK(fighter, 2, 0, Hash40::new("haver"), 8.0, 78, 75, 0, 50, 4.5, 0.0, 12.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_HEAVY, *ATTACK_REGION_SWORD);
     }
-    frame(lua_state, 27.0);
-    FT_MOTION_RATE_RANGE(fighter, 27.0, 47.0, 16.0);
+    frame(lua_state, 18.0);
     if is_excute(fighter) {
-        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
-        AttackModule::clear_all(boma);
+        AttackModule::clear_all(fighter.module_accessor);
     }
-    frame(lua_state, 47.0);
-    FT_MOTION_RATE(fighter, 1.0);
-    frame(lua_state, 54.0);
+    frame(lua_state, 41.0);
     if is_excute(fighter) {
-        StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_WAIT, false);
+        ArticleModule::remove_exist(fighter.module_accessor, *FIGHTER_GANON_GENERATE_ARTICLE_SWORD, ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
     }
-
 }
 
 #[acmd_script( agent = "ganon", script = "effect_attackhi3" , category = ACMD_EFFECT , low_priority)]
 unsafe fn ganon_attack_hi3_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 15.0);
+    frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_arc_d"), Hash40::new("top"), 0, 15, -3, 180, 190, -90, 1.15, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.5);
+        if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -10, 0, 3.0, 0, 0, 120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        else {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -10, 0, 3.0, 0, 0, -120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        EFFECT_FOLLOW(fighter, Hash40::new("ganon_sword_flare"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
     }
-    frame(lua_state, 20.0);
+    frame(lua_state, 5.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_attack_impact"), Hash40::new("footl"), 1, 0, -1, 0, 0, 0, 1.65, true);
-        LAST_EFFECT_SET_RATE(fighter, 0.75);
+        if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -8, 0, 3.0, 0, 0, 120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        else {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -8, 0, 3.0, 0, 0, -120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+    }
+    frame(lua_state, 7.0);
+    if is_excute(fighter) {
+        if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -6, 0, 3.0, 0, 0, 120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        else {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -6, 0, 3.0, 0, 0, -120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -4, 0, 3.0, 0, 0, 120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        else {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -4, 0, 3.0, 0, 0, -120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        FOOT_EFFECT(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 180, 0, 1.0, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -2, 0, 3.0, 0, 0, 120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+        else {
+            EFFECT(fighter, Hash40::new("sys_damage_spark_s"), Hash40::new("top"), -2, 0, 3.0, 0, 0, -120, 1.0, 0, 0, 0, 0, 0, 0, false);
+        }
+    }
+    frame(lua_state, 13.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_attack_speedline"), Hash40::new("haver"), 0, 0, 0, -80, 0, 0, 1.2, 0, 0, 0, 0, 0, 0, true);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("ganon_sword_flare"), false, false);
+    }
+    frame(lua_state, 41.0);
+    if is_excute(fighter) {
+        FOOT_EFFECT(fighter, Hash40::new("sys_dash_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, false);
     }
 
 }
@@ -123,14 +220,24 @@ unsafe fn ganon_attack_hi3_effect(fighter: &mut L2CAgentBase) {
 unsafe fn ganon_attack_hi3_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 18.0);
     if is_excute(fighter) {
-        ControlModule::set_rumble(boma, Hash40::new("rbkind_nohitm"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+        ItemModule::set_have_item_visibility(fighter.module_accessor, false, 0);
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_TOP);
     }
-    frame(lua_state, 20.0);
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_nohits"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE_INTP, SLOPE_STATUS_LR, 3);
+    }
+    frame(lua_state, 13.0);
+    if is_excute(fighter) {
+        slope!(fighter, MA_MSC_CMD_SLOPE_SLOPE, SLOPE_STATUS_LR);
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackl"), 0);
+    }
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
         RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
     }
@@ -140,54 +247,147 @@ unsafe fn ganon_attack_hi3_expression(fighter: &mut L2CAgentBase) {
 unsafe fn ganon_attack_hi3_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 21.0);
+    frame(lua_state, 9.0);
     if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new_raw(0x11d7624dd3));
-        PLAY_SE(fighter, Hash40::new_raw(0x1279490e1c));
+        PLAY_SE(fighter, Hash40::new("vc_ganon_attack06"));
+        PLAY_SE(fighter, Hash40::new("se_ganon_swing_m"));
     }
-
 }
 
 #[acmd_script( agent = "ganon", script = "game_attacklw3" , category = ACMD_GAME , low_priority)]
 unsafe fn ganon_attack_lw3_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 10.0);
-    FT_MOTION_RATE(fighter, 1.0/(10.1 - 10.0));
+    frame(lua_state, 14.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("legr"), 13.0, 60, 88, 0, 35, 4.8, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.35, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 1, 0, Hash40::new("kneer"), 13.0, 70, 88, 0, 35, 4.8, 1.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.35, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 2, 0, Hash40::new("kneer"), 13.0, 80, 88, 0, 35, 4.8, 8.5, -0.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 3, 0.35, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 6.0, 65, 40, 10, 40, 3.0, 0.0, 3.0, 2.0, Some(0.0), Some(3.0), Some(14.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
-    frame(lua_state, 10.1);
-    FT_MOTION_RATE(fighter, 1.0/(12.0 - 10.1));
-    frame(lua_state, 12.0);
-    FT_MOTION_RATE(fighter, 1.0);
-    frame(lua_state, 13.0);
+    wait(lua_state, 4.0);
     if is_excute(fighter) {
-        AttackModule::clear_all(boma);
+        AttackModule::clear_all(fighter.module_accessor);
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
     }
-
+    frame(lua_state, 27.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+    }
 }
 
 #[acmd_script( agent = "ganon", script = "effect_attacklw3", category = ACMD_EFFECT, low_priority )]
 unsafe fn ganon_attack_lw3_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 9.0);
+    frame(lua_state, 14.0);
     if is_excute(fighter) {
-        EFFECT(fighter, Hash40::new("sys_attack_line"), Hash40::new("top"), -1, 9.5, 0, 10, 0, 0, 1.4, 0, 0, 0, 0, 0, 0, true);
+        EFFECT(fighter, Hash40::new("sys_crown"), Hash40::new("top"), 8.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8, 0, 0, 0, 0, 0, 0, false);
+        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_v"), Hash40::new("top"), 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "sound_attacklw3", category = ACMD_SOUND, low_priority )]
+unsafe fn ganon_attack_lw3_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_ganon_rnd_attack"));
+        PLAY_SE(fighter, Hash40::new("se_ganon_swing_l"));
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "expression_attacklw3", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn ganon_attack_lw3_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 6, true);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        EFFECT(fighter, Hash40::new("sys_attack_impact"), Hash40::new("kneer"), 8.5, -0.5, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, true);
-        FOOT_EFFECT(fighter, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.2, 0, 0, 0, 0, 0, 0, false);
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_nohitl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        QUAKE(fighter, *CAMERA_QUAKE_KIND_S);
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+    }
+    frame(lua_state, 27.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 10);
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "game_attacklw32" , category = ACMD_GAME , low_priority)]
+unsafe fn ganon_attack_lw32_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 8.0, 85, 60, 0, 75, 4.0, 0.0, 4.0, 3.0, Some(0.0), Some(4.0), Some(15.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.35, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+    }
+    wait(lua_state, 4.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(fighter.module_accessor);
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "effect_attacklw32", category = ACMD_EFFECT, low_priority )]
+unsafe fn ganon_attack_lw32_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_crown"), Hash40::new("top"), 9.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.8, 0, 0, 0, 0, 0, 0, false);
+        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_v"), Hash40::new("top"), 9, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "sound_attacklw32", category = ACMD_SOUND, low_priority )]
+unsafe fn ganon_attack_lw32_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_ganon_rnd_attack"));
+        PLAY_SE(fighter, Hash40::new("se_ganon_swing_l"));
+    }
+}
+
+#[acmd_script( agent = "ganon", script = "expression_attacklw32", category = ACMD_EXPRESSION, low_priority )]
+unsafe fn ganon_attack_lw32_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_TOP, 6, true);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(fighter.module_accessor, Hash40::new("rbkind_nohitl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+    }
+    frame(lua_state, 27.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 10);
     }
 }
 
 pub fn install() {
     install_acmd_scripts!(
         ganon_attack_s3_s_game,
+        ganon_attack_s3_hi_game,
+        ganon_attack_s3_lw_game,
         ganon_attack_s3_hi_effect,
         ganon_attack_s3_lw_effect,
         ganon_attack_hi3_game,
@@ -196,6 +396,13 @@ pub fn install() {
         ganon_attack_hi3_sound,
         ganon_attack_lw3_game,
         ganon_attack_lw3_effect,
+        ganon_attack_lw3_sound,
+        ganon_attack_lw3_expression,
+
+        ganon_attack_lw32_game,
+        ganon_attack_lw32_effect,
+        ganon_attack_lw32_sound,
+        ganon_attack_lw32_expression,
     );
 }
 

--- a/fighters/ganon/src/lib.rs
+++ b/fighters/ganon/src/lib.rs
@@ -6,6 +6,7 @@ pub mod acmd;
 
 pub mod status;
 pub mod opff;
+mod vtable_hook;
 
 use smash::{
     lib::{
@@ -41,6 +42,7 @@ use smashline::*;
 pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
+    vtable_hook::install();
     opff::install(is_runtime);
 
     if !is_runtime || is_hdr_available() {

--- a/fighters/ganon/src/status.rs
+++ b/fighters/ganon/src/status.rs
@@ -6,6 +6,7 @@ mod special_n;
 mod special_n_float;
 mod special_lw;
 mod special_s;
+mod special_air_s_catch;
 
 /// Prevents side b from being used again in air when it has been disabled by up-b fall
 unsafe extern "C" fn should_use_special_n_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -36,6 +37,10 @@ fn ganon_init(fighter: &mut L2CFighterCommon) {
     }
 }
 
+pub unsafe fn ganon_set_air(fighter: &mut L2CFighterCommon) {
+    fighter.set_situation(SITUATION_KIND_AIR.into());
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+}
 
 pub fn install() {
     smashline::install_agent_init_callbacks!(ganon_init);
@@ -43,6 +48,7 @@ pub fn install() {
     special_n::install();
     special_lw::install();
     special_s::install();
+    special_air_s_catch::install();
 }
 
 pub fn add_statuses() {

--- a/fighters/ganon/src/status.rs
+++ b/fighters/ganon/src/status.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod attack_lw3;
+
 mod special_n;
 mod special_n_float;
 mod special_lw;
@@ -37,6 +39,7 @@ fn ganon_init(fighter: &mut L2CFighterCommon) {
 
 pub fn install() {
     smashline::install_agent_init_callbacks!(ganon_init);
+    attack_lw3::install();
     special_n::install();
     special_lw::install();
     special_s::install();

--- a/fighters/ganon/src/status/attack_lw3.rs
+++ b/fighters/ganon/src/status/attack_lw3.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[status_script(agent = "ganon", status = FIGHTER_STATUS_KIND_ATTACK_LW3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn attack_lw3_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.status_AttackLw3_common();
+    fighter.main_shift(attack_lw3_main_loop)
+}
+
+unsafe extern "C" fn attack_lw3_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if CancelModule::is_enable_cancel(fighter.module_accessor)
+    && fighter.sub_wait_ground_check_common(false.into()).get_bool() {
+        return 0.into();
+    }
+
+    if !StatusModule::is_changing(fighter.module_accessor) {
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO)
+        && fighter.global_table[globals::CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_LW3 != 0 {
+            WorkModule::off_flag(fighter.module_accessor, *FIGHTER_STATUS_ATTACK_FLAG_ENABLE_COMBO);
+            MotionModule::change_motion(
+                fighter.module_accessor,
+                Hash40::new("attack_lw3_2"),
+                0.0,
+                1.0,
+                false,
+                0.0,
+                false,
+                false
+            );
+            fighter.clear_lua_stack();
+            sv_kinetic_energy::set_motion_energy_update_flag(fighter.lua_state_agent);
+        }
+    }
+
+    if fighter.global_table[globals::SITUATION_KIND].get_i32() == *SITUATION_KIND_AIR {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        return 0.into();
+    }
+    let jump_attack_frame = WorkModule::get_int(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_ATTACK_MINI_JUMP_ATTACK_FRAME);
+    if 0 < jump_attack_frame {
+        if !StopModule::is_stop(fighter.module_accessor)
+        && fighter.sub_check_button_jump().get_bool() {
+            let log = fighter.status_attack();
+            let info = log[0x10f40d7b92u64].get_i64();
+            let mot = MotionModule::motion_kind(fighter.module_accessor);
+            MotionAnimcmdModule::call_script_single(
+                fighter.module_accessor,
+                *FIGHTER_ANIMCMD_EXPRESSION,
+                Hash40::new_raw(mot),
+                -1
+            );
+            WorkModule::set_int64(fighter.module_accessor, info, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+            fighter.change_status_jump_mini_attack(true.into());
+            return 1.into();
+        }
+    }
+    if 1 == jump_attack_frame {
+        if !fighter.global_table[globals::IS_STOPPING].get_bool()
+        && WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND) > 0 {
+            let log = WorkModule::get_int64(fighter.module_accessor, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+            FighterStatusModuleImpl::reset_log_action_info(fighter.module_accessor, log);
+            WorkModule::set_int64(fighter.module_accessor, 0, *FIGHTER_STATUS_WORK_ID_INT_RESERVE_LOG_ATTACK_KIND);
+        }
+    }
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_SQUAT_WAIT.into(), false.into());
+    }
+    0.into()
+}
+
+#[status_script(agent = "ganon", status = FIGHTER_STATUS_KIND_ATTACK_LW3, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_END)]
+unsafe fn attack_lw3_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    sv_kinetic_energy!(
+        set_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_MOTION,
+        0.0,
+        0.0
+    );
+    fighter.status_end_AttackLw3()
+}
+
+pub fn install() {
+    smashline::install_status_scripts!(
+        attack_lw3_main,
+        attack_lw3_end
+    );
+}

--- a/fighters/ganon/src/status/special_air_s_catch.rs
+++ b/fighters/ganon/src/status/special_air_s_catch.rs
@@ -1,0 +1,59 @@
+use super::*;
+use globals::*;
+
+#[status_script(agent = "ganon", status = FIGHTER_GANON_STATUS_KIND_SPECIAL_AIR_S_CATCH, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+unsafe fn special_air_s_catch_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::set_rate(fighter.module_accessor, 0.0);
+    fighter.main_shift(special_air_s_catch_main_loop)
+}
+
+unsafe extern "C" fn special_air_s_catch_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.global_table[globals::CURRENT_FRAME].get_f32() == 1.0 {
+        MotionModule::change_motion(
+            fighter.module_accessor,
+            Hash40::new("special_air_s_catch"),
+            0.0,
+            1.0,
+            false,
+            0.0,
+            false,
+            false
+        );
+        ganon_set_air(fighter);
+        let speed_x = WorkModule::get_float(fighter.module_accessor, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_X);
+        let speed_y = WorkModule::get_float(fighter.module_accessor, *FIGHTER_GANON_STATUS_WORK_ID_FLOAT_EXPLOSION_AIR_SPEED_Y);
+        KineticModule::clear_speed_attr(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+        sv_kinetic_energy!(
+            set_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+            speed_y
+        );
+        let lr = PostureModule::lr(fighter.module_accessor);
+        sv_kinetic_energy!(
+            set_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_CONTROL,
+            speed_x * lr,
+            0.0
+        );
+        KineticModule::suspend_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
+    }
+    if fighter.global_table[globals::CURRENT_FRAME].get_f32() > 1.0 {
+        if MotionModule::is_end(fighter.module_accessor) {
+            fighter.change_status(FIGHTER_GANON_STATUS_KIND_SPECIAL_AIR_S_FALL.into(), false.into());
+            return 1.into();
+        }
+        if fighter.global_table[globals::SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+            fighter.change_status(FIGHTER_GANON_STATUS_KIND_SPECIAL_AIR_S_END.into(), false.into());
+            return 1.into();
+        }
+    }
+    0.into()
+}
+
+pub fn install() {
+    smashline::install_status_scripts!(
+        special_air_s_catch_main
+    );
+}

--- a/fighters/ganon/src/vtable_hook.rs
+++ b/fighters/ganon/src/vtable_hook.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[skyline::hook(offset = 0xaa67e0)]
+pub unsafe extern "C" fn ganon_status_transition(_vtable: u64, fighter: &mut Fighter) {
+    let module_accessor = fighter.battle_object.module_accessor;
+    let prev_status = StatusModule::prev_status_kind(module_accessor, 0) as u64;
+    let status = StatusModule::status_kind(module_accessor) as u64;
+    if prev_status < 0x36 {
+        if 1 << (prev_status & 0x3f) & 0xe00000000000u64 != 0
+        && status & 0xfffffffe != 0x2e {
+            ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+        }
+        if 1 << (prev_status & 0x3f) & 0x7000000000000u64 != 0
+        && 1 < status - 0x31 {
+            ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+        }
+        if 1 << (prev_status & 0x3f) & 0x38000000000000u64 != 0
+        && status & 0xfffffffe != 0x34 {
+            ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+        }
+        if prev_status == 0x2b {
+            ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+        }
+    }
+    if prev_status == 0x24 {
+        if status != 0x25 {
+            ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+        }
+    }
+    else if prev_status == 0x25 {
+        ArticleModule::remove_exist(module_accessor, 1, ArticleOperationTarget(0));
+    }
+    else if [0x2b, 0x2f, 0x32, 0x35].contains(&prev_status) {
+        if status == 0x24 {
+            ArticleModule::generate_article_enable(module_accessor, 1, false, -1);
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        ganon_status_transition
+    );
+}

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -168,7 +168,6 @@
   <float hash="escape_f_penalty_motion_rate">0</float>
   <float hash="escape_b_penalty_motion_rate">0</float>
   <float hash="smash_hold_reaction_mul">1.2</float>
-  <float hash="ganon_special_s_fall_hold_frame">85</float>
   <!-- dk cargo carry: -->
   <!-- flat amount of clatter added when you enter cargo carry -->
   <float hash="shouldered_frame_add">30</float>

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -57,13 +57,42 @@ throw_hi:
   extra:
     cancel_frame: 40
 attack_11:
-  extra:
-    cancel_frame: 29
-attack_lw3:
   flags:
-    move: false
+    move: true
   extra:
-    cancel_frame: 33
+    cancel_frame: 25
+attack_lw3:
+  extra:
+    cancel_frame: 36
+attack_lw3_2:
+  game_script: game_attacklw32
+  flags:
+    turn: false
+    loop: false
+    move: true
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+    - name: c02attacklw32.nuanmb
+  scripts:
+    - expression_attacklw32
+    - sound_attacklw32
+    - effect_attacklw32
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 36
+    freeze_during_hitstop: false
 attack_hi4:
   extra:
     cancel_frame: 66
@@ -71,10 +100,8 @@ attack_lw4:
   extra:
     cancel_frame: 66
 attack_hi3:
-  flags:
-    move: false
   extra:
-    cancel_frame: 48
+    cancel_frame: 38
 appeal_lw_r:
   extra:
     cancel_frame: 90

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -60,7 +60,7 @@ attack_11:
   flags:
     move: true
   extra:
-    cancel_frame: 25
+    cancel_frame: 23
 attack_lw3:
   extra:
     cancel_frame: 36

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -186,7 +186,7 @@ attack_air_f:
     cancel_frame: 40
 attack_air_n:
   extra:
-    cancel_frame: 40
+    cancel_frame: 42
 attack_s3_hi:
   game_script: game_attacks3hi
   flags:


### PR DESCRIPTION
# Changelog
(New animations need to be adjusted to finish in the HDR idle pose).
## Jab
- [*] Changed to a backfist smack.
- Hitbox Activity: 5 - 7
- Damage: 5
- Angle: 70
- BKB: 45
- KBG: 60
- Hitbox Size (Inner/Outer): 5/3.5
- FAF: 23 (I think)

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/202b04dc-3414-4a31-832c-611b0661b711

## Forward Tilt
Non-angled is unchanged.

### Down Angled
- [+] Startup decreased by 2 (8 > 6). Endlag consequently also decreased by 2.
- [-] Damage (Strong/Weak): 14/13 > 10/9
- [+] BKB: 32 > 35
- [+] KBG: 81 > 95
(These are Jab's old damage and knockback values).

### Up Angled
- [-] Startup increased by 2 (8 > 10). Endlag consequently also increased by 2.
- [+] Damage (Strong/Weak): 14/13 > 16/15
- [-] BKB: 32 > 25
- [-] KBG: 81 > 72

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/3cc27c6f-8a6f-4993-815f-0fef597efb39

## Up Tilt
- [*] Changed to an upwards sword hilt thrust.
### Strong Hit
- Hitbox Activity: 12 > 13
- Damage: 14
- Angle: 78
- BKB: 50
- KBG: 75
- Hitbox Sizes (Top/Middle/Bottom): 5/4.5/4.5
### Late Hit
- Hitbox Activity: 14 > 16
- Damage: 8
The rest is the same as above.

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/d65b70ee-77fa-4297-95b7-14c48478a3b6

- FAF: 37

## Down Tilt
- [*] Changed to a stomp. Transitions into a second stomp if Down Tilt is pressed between frames 18 and 27.
### Stomp 1
- Hitbox Activity: 14 > 17
- Damage: 6
- Knockback weakly sends in front of Ganondorf to follow-up into Stomp 2.
- FAF: 36

### Stomp 2
- Hitbox Activity: 14 > 17
- Damage: 8
- Angle: 85
- BKB: 75
- KBG: 60
- Hitbox Size: 4
- FAF: 36

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/d65d409a-7792-445a-9939-19d144ee856c

## Neutral Air
- [-] FAF increased by 2 to prevent wavedashing out of short hop buffered Neutral Air.

## Flame Choke (Air)
- [*] Mashability reverted to vanilla.
- [*] Vertical speed on grab reverted to vanilla (1.5 > 2.0).
- [*] Can no longer drift after grabbing the opponent. Horizontal Speed is now set upon grabbing the opponent, and persists throughout the entirety of falling.
- [*] Base horizontal speed on grabbing the opponent changed to 1.0. Horizontal speed can be adjusted before the grab lands by holding forward or backward, as low as 0.5 and as high as 1.5.
  - Notably, this means Ganondorf always moves forwards after grabbing an opponent.

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/0319f1e8-eae1-4b55-a20f-497cf0f61b22

[Ganon Assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14045911/Ganon.Assets.zip)
