### PR TITLE
Ledge occupancy buff

### DIFF
--- a/fighters/common/src/opff/ledges.rs
+++ b/fighters/common/src/opff/ledges.rs
@@ -40,7 +40,7 @@ unsafe fn occupy_ledge(boma: &mut BattleObjectModuleAccessor, status_kind: i32, 
         *FIGHTER_STATUS_KIND_CLIFF_JUMP1,
         *FIGHTER_STATUS_KIND_CLIFF_JUMP2,
         *FIGHTER_STATUS_KIND_CLIFF_JUMP3])
-    && MotionModule::frame(boma) > (FighterMotionModuleImpl::get_cancel_frame(boma, Hash40::new_raw(MotionModule::motion_kind(boma)), true) * 0.9) {
+        && FighterMotionModuleImpl::is_valid_cancel_frame(boma, -1, true) {
         VarModule::set_vec3(boma.object(), vars::common::instance::LEDGE_POS, Vector3f {x: 0.0, y: 0.0, z: 0.0});
     }
 }


### PR DESCRIPTION
Ledge now counts as "occupied" until your ledge getup/attack/roll/jump FAF, rather than FAF * 0.9 frames.