### PR TITLE
Make defensive options slightly more reactable

### DIFF
--- a/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/brave/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/brave/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/captain/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/captain/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 catch:

--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/demon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/demon/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/edge/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/edge/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/elight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/elight/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/falco/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/falco/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/fox/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/fox/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 throw_lw:

--- a/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 guard_off:
   extra:
     cancel_frame: 12

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/ike/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ike/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/ken/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ken/motion/body/motion_patch.yaml
@@ -83,6 +83,63 @@ attack_s4_s:
 catch_attack:
   extra:
     cancel_frame: 0
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/krool/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/krool/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/link/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/link/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
@@ -61,6 +61,63 @@ attack_lw4:
 attack_s4_s:
   extra:
     cancel_frame: 51
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/master/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/master/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 catch:

--- a/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -24,6 +24,63 @@ attack_s4_s:
 catch_attack:
   extra:
     cancel_frame: 0
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/nana/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/nana/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/ness/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ness/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/packun/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/packun/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 throw_f:

--- a/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pit/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 escape:

--- a/romfs/source/fighter/popo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/popo/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/richter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/richter/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/robot/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/robot/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/samus/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samus/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 6
 guard_off:

--- a/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/simon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/simon/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/snake/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/snake/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/trail/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/trail/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 8
 fall_aerial:

--- a/romfs/source/fighter/wario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wario/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_f:

--- a/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 guard_off:

--- a/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:

--- a/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
@@ -1,3 +1,60 @@
+passive:
+  extra:
+    cancel_frame: 29
+passive_stand_f:
+  extra:
+    cancel_frame: 43
+passive_stand_b:
+  extra:
+    cancel_frame: 43
+down_stand_u:
+  extra:
+    cancel_frame: 32
+down_stand_d:
+  extra:
+    cancel_frame: 32
+down_attack_u:
+  extra:
+    cancel_frame: 48
+down_attack_d:
+  extra:
+    cancel_frame: 48
+down_forward_u:
+  extra:
+    cancel_frame: 38
+down_forward_d:
+  extra:
+    cancel_frame: 38
+down_back_u:
+  extra:
+    cancel_frame: 38
+down_back_d:
+  extra:
+    cancel_frame: 38
+down_spot_d:
+  extra:
+    cancel_frame: 32
+cliff_climb_quick:
+  extra:
+    cancel_frame: 37
+cliff_attack_quick:
+  extra:
+    cancel_frame: 58
+cliff_escape_quick:
+  extra:
+    cancel_frame: 52
+slip_stand:
+  extra:
+    cancel_frame: 24
+slip_attack:
+  extra:
+    cancel_frame: 52
+slip_escape_f:
+  extra:
+    cancel_frame: 31
+slip_escape_b:
+  extra:
+    cancel_frame: 31
 fall:
   blend_frames: 5
 fall_aerial:


### PR DESCRIPTION
Adds 2f to the FAF of the following defensive options:
- Tech-in-place
- Tech-roll
- Neutral getup (from knockdown)
- Getup roll (from knockdown)
- Getup attack (from knockdown)
- Ledge getup
- Ledge roll
- Ledge attack
- Slip neutral getup
- Slip getup roll
- Slip getup attack