### PR TITLE
Robin recovery adjustments

### DIFF
--- a/fighters/reflet/src/opff.rs
+++ b/fighters/reflet/src/opff.rs
@@ -57,20 +57,20 @@ unsafe fn sword_length(boma: &mut BattleObjectModuleAccessor) {
 }
 
 // upB freefalls after one use per airtime
-unsafe fn up_special_freefall(fighter: &mut L2CFighterCommon) {
-    if StatusModule::is_changing(fighter.module_accessor)
-    && (fighter.is_situation(*SITUATION_KIND_GROUND)
-        || fighter.is_situation(*SITUATION_KIND_CLIFF)
-        || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING]))
-    {
-        VarModule::off_flag(fighter.battle_object, vars::reflet::instance::UP_SPECIAL_FREEFALL);
-    }
-    if fighter.is_prev_status(*FIGHTER_STATUS_KIND_SPECIAL_HI) {
-        if StatusModule::is_changing(fighter.module_accessor) {
-            VarModule::on_flag(fighter.battle_object, vars::reflet::instance::UP_SPECIAL_FREEFALL);
-        }
-    }
-}
+// unsafe fn up_special_freefall(fighter: &mut L2CFighterCommon) {
+//     if StatusModule::is_changing(fighter.module_accessor)
+//     && (fighter.is_situation(*SITUATION_KIND_GROUND)
+//         || fighter.is_situation(*SITUATION_KIND_CLIFF)
+//         || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING]))
+//     {
+//         VarModule::off_flag(fighter.battle_object, vars::reflet::instance::UP_SPECIAL_FREEFALL);
+//     }
+//     if fighter.is_prev_status(*FIGHTER_STATUS_KIND_SPECIAL_HI) {
+//         if StatusModule::is_changing(fighter.module_accessor) {
+//             VarModule::on_flag(fighter.battle_object, vars::reflet::instance::UP_SPECIAL_FREEFALL);
+//         }
+//     }
+// }
 
 unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     if !fighter.is_in_hitlag()
@@ -111,7 +111,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     elwind1_burn(fighter);
     levin_leniency(fighter, boma);
     sword_length(boma);
-    up_special_freefall(fighter);
+    // up_special_freefall(fighter);
     fastfall_specials(fighter);
 }
 

--- a/romfs/source/fighter/reflet/param/vl.prcxml
+++ b/romfs/source/fighter/reflet/param/vl.prcxml
@@ -56,7 +56,11 @@
   </list>
   <list hash="param_special_hi">
     <struct index="0">
+      <float hash="special_hi_shoot_store_x_initial_velocity_mul">0.975</float>
+      <float hash="special_hi_shoot_store_y_initial_velocity_mul">0.775</float>
       <float hash="special_hi_next_jump_y_speed">2.8</float>
+      <float hash="special_hi_shoot_store_x_second_velocity_mul">1.0875</float>
+      <float hash="special_hi_shoot_store_y_second_velocity_mul">0.4</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
- Reverts the once-per-airtime restriction of Elwind 1, making it always actionable again
- Slightly reduces angleability of Elwind 1 & 2