### PR TITLE
ROB 2.5: Meter and More

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1099,6 +1099,9 @@ pub mod vars {
             // flags
             pub const AIRTIME_BAIR: i32 = 0x0100;
             pub const AIRTIME_SIDEB: i32 = 0x0101;
+            pub const IS_INIT_METER: i32 = 0x0102;
+            pub const GROUNDED_UPB: i32 = 0x0103;
+            pub const UPB_CANCEL: i32 = 0x0104;
             // ints
             pub const PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE: i32 = 0x0100;
             pub const PREV_FUEL_THRESHOLD: i32 = 0x0101;

--- a/dynamic/src/ui.rs
+++ b/dynamic/src/ui.rs
@@ -46,6 +46,12 @@ extern "C" {
 
     #[link_name = "UiManager__set_aura_meter_info"]
     fn ui_manager_set_aura_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32, burnout: bool);
+
+    #[link_name = "UiManager__set_robot_meter_enable"]
+    fn ui_manager_set_robot_meter_enable(entry_id: u32, enable: bool);
+
+    #[link_name = "UiManager__set_robot_meter_info"]
+    fn ui_manager_set_robot_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32);
 }
 
 pub mod UiManager {
@@ -142,6 +148,18 @@ pub mod UiManager {
     pub fn set_aura_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32, burnout: bool) {
         unsafe {
             super::ui_manager_set_aura_meter_info(entry_id, current, max, per_level, burnout)
+        }
+    }
+
+    pub fn set_robot_meter_enable(entry_id: u32, enable: bool) {
+        unsafe {
+            super::ui_manager_set_robot_meter_enable(entry_id, enable)
+        }
+    }
+
+    pub fn set_robot_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        unsafe {
+            super::ui_manager_set_robot_meter_info(entry_id, current, max, per_level)
         }
     }
 }

--- a/fighters/robot/src/acmd/aerials.rs
+++ b/fighters/robot/src/acmd/aerials.rs
@@ -175,16 +175,19 @@ unsafe fn robot_attack_air_b_game(fighter: &mut L2CAgentBase) {
         for _ in 0..5 {
             wait(lua_state, 1.0);
             if is_excute(fighter) {
-                if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) && !VarModule::is_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_FINISHED){
+                if VarModule::is_flag(fighter.battle_object, vars::common::instance::IS_HEAVY_ATTACK) 
+                && !VarModule::is_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_FINISHED) 
+                && WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) > 10.0 {
                     // If holding down the button, increment the charge and continue the slowed animation
                     if ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_ATTACK) {
                         VarModule::on_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_STARTED);
                         VarModule::add_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL, 1.0);
                         let current_fuel = WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
-                        let current_fuel_depletion = (VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) * 15.0);
+                        let current_fuel_depletion = (VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) * 13.0);
                         if (current_fuel_depletion > current_fuel) {
                             VarModule::on_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_FINISHED);
                             WorkModule::set_float(boma, 0.0, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
+                            MeterModule::drain_direct(fighter.battle_object, 200.0);
                             FT_MOTION_RATE(fighter, 1.0);
                         } else {
                             FT_MOTION_RATE(fighter, 2.0);
@@ -201,8 +204,9 @@ unsafe fn robot_attack_air_b_game(fighter: &mut L2CAgentBase) {
     }
 
     if !VarModule::is_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_FINISHED) {
-        WorkModule::set_float(boma, WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) - (VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) * 6.0), *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
-		FT_MOTION_RATE(fighter, 1.0);
+        WorkModule::set_float(boma, WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) - (VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) * 13.0), *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
+		MeterModule::drain_direct(fighter.battle_object, (VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) * 13.0));
+        FT_MOTION_RATE(fighter, 1.0);
 
         if VarModule::get_float(fighter.battle_object, vars::robot::status::CHARGE_ATTACK_LEVEL) >= 5.0 {
             VarModule::on_flag(fighter.battle_object, vars::robot::status::IS_CHARGE_MAX);

--- a/fighters/robot/src/acmd/specials.rs
+++ b/fighters/robot/src/acmd/specials.rs
@@ -333,7 +333,13 @@ unsafe fn robot_special_hi_rise_game (fighter: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     if is_excute(fighter) {
         WorkModule::on_flag(fighter.module_accessor, vars::robot::status::HELD_BUTTON);
-        let mut workingDamage = robotFrames/4.0;
+        let mut workingDamage = robotFrames/3.5;
+
+        if robotFrames <= 10.0 {
+            MeterModule::drain_direct(fighter.object(), 20.0);
+        } else {
+            MeterModule::drain_direct(fighter.object(), (robotFrames * 2.0));
+        }
 
         if (workingDamage < 4.0) {
             workingDamage = 0.0;
@@ -354,8 +360,24 @@ unsafe fn robot_special_hi_rise_game (fighter: &mut L2CAgentBase) {
     frame(lua_state, 4.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        FT_MOTION_RATE(fighter, 0.6);
+
+        if VarModule::is_flag(fighter.battle_object, vars::robot::instance::GROUNDED_UPB) {
+            FT_MOTION_RATE(fighter, 9.0/(22.0-4.0));
+        }
     }
+
+    /*frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        if VarModule::is_flag(fighter.battle_object, vars::robot::instance::GROUNDED_UPB) {
+            VarModule::on_flag(fighter.battle_object, vars::robot::instance::UPB_CANCEL);
+        }
+    }*/
+
+    frame(lua_state, 22.0);
+    if is_excute(fighter) {
+        VarModule::on_flag(fighter.battle_object, vars::robot::instance::UPB_CANCEL);
+    }
+
 }
 
 #[acmd_script( agent = "robot", script = "effect_specialhirise" , category = ACMD_EFFECT , low_priority)]
@@ -367,7 +389,7 @@ unsafe fn robot_special_hi_rise_effect(fighter: &mut L2CAgentBase) {
         EFFECT_FOLLOW(fighter, Hash40::new("robot_nozzle_flare"), Hash40::new("knee1"), 1.5, 0, 0, 90, -90, 0, 1, true);
         LAST_EFFECT_SET_COLOR(fighter, 0.55, 0.55, 2.25);
     }
-    if (robotFrames/4.0) > 4.0 {
+    if (robotFrames/3.5) > 4.0 {
         frame(lua_state, 1.0);
         if is_excute(fighter) {
             EFFECT_FOLLOW(fighter, Hash40::new("robot_atk_lw_jet"), Hash40::new("knee"), 0, 0, 0, -90, -90, 0, 0.8, true);

--- a/fighters/robot/src/lib.rs
+++ b/fighters/robot/src/lib.rs
@@ -42,4 +42,8 @@ pub fn install(is_runtime: bool) {
     acmd::install();
     status::install();
     opff::install(is_runtime);
+    use opff::*;
+    smashline::install_agent_frames!(
+        robot_meter
+    );
 }

--- a/fighters/robot/src/opff.rs
+++ b/fighters/robot/src/opff.rs
@@ -2,7 +2,6 @@
 utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
 use globals::*;
-
  
 unsafe fn gyro_dash_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if StatusModule::is_changing(boma) {
@@ -78,114 +77,6 @@ unsafe fn bair_boost_detection(boma: &mut BattleObjectModuleAccessor){
     }
 }
 
-unsafe fn fuel_indicator_effect(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor){
-    let max_fuel = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("energy_max_frame"));
-    let current_fuel = WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE);
-
-    // Bools to hold which fuel level we're at
-    let mut low_fuel = false;
-    let mut mid_fuel = false;
-    let mut high_fuel = false;
-
-    // Fuel level thresholds
-    let high_fuel_threshold = max_fuel * 0.75;
-    let mid_fuel_threshold = max_fuel * 0.66;
-    let low_fuel_threshold = max_fuel * 0.33;
-
-    // Bool to hold whether or not our fuel threshold has changed
-    let mut is_fuel_threshold_changed = false;
-    let prev_fuel_threshold = VarModule::get_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD);
-    if current_fuel < low_fuel_threshold{
-        if VarModule::get_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD) != 1 {
-            is_fuel_threshold_changed = true;
-        }
-        VarModule::set_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD, 1);
-        low_fuel = true;
-    }
-    else if current_fuel < mid_fuel_threshold{
-        if VarModule::get_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD) != 2 {
-            is_fuel_threshold_changed = true;
-        }
-        VarModule::set_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD, 2);
-        mid_fuel = true;
-    }
-    else{
-        if VarModule::get_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD) != 3 {
-            is_fuel_threshold_changed = true;
-        }
-        VarModule::set_int(boma.object(), vars::robot::instance::PREV_FUEL_THRESHOLD, 3);
-        high_fuel = true;
-    }
-
-    // Respawn the effect if it's been removed
-    let fuel_effect_indicator_handle = VarModule::get_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE);
-    if !EffectModule::is_exist_effect(boma, fuel_effect_indicator_handle as u32) && !high_fuel { // Don't spawn the effect at high fuel
-        //EFFECT_FOLLOW(fighter, Hash40::new("robot_lamp_l"), Hash40::new("waist2"), 5.0, 0, 0, 0, 0, 0, 2.0, true);
-        let new_fuel_effect_indicator_handle = EffectModule::req_follow(
-            boma,
-            Hash40::new("robot_lamp_l"),
-            Hash40::new("waist1"),
-            &Vector3f::zero(),
-            &Vector3f::zero(),
-            1.75,
-            true,
-            0,
-            0,
-            0,
-            0,
-            0,
-            true,
-            true
-        ) as u32;
-        LAST_EFFECT_SET_RATE(fighter, 0.5);
-        //VarModule::set_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE, EffectModule::get_last_handle(boma) as i32);
-        VarModule::set_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE, new_fuel_effect_indicator_handle as i32);
-    }
-
-    // Kill the old effect and spawn the effect again with a new color if the fuel threshold has changed
-    let current_fuel_effect_indicator_handle = VarModule::get_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE) as u32;
-    if is_fuel_threshold_changed{
-        EffectModule::kill(boma, current_fuel_effect_indicator_handle as u32, true, true);
-        //EFFECT_FOLLOW(fighter, Hash40::new("robot_lamp_l"), Hash40::new("waist2"), 5.0, 0, 0, 0, 0, 0, 2.0, true);
-        if !high_fuel{ // Don't spawn the effect if high fuel
-            let new_fuel_effect_indicator_handle = EffectModule::req_follow(
-                boma,
-                Hash40::new("robot_lamp_l"),
-                Hash40::new("waist1"),
-                &Vector3f::new(0.0, 0.0, 0.0),
-                &Vector3f::zero(),
-                1.75,
-                true,
-                0,
-                0,
-                0,
-                0,
-                0,
-                true,
-                true
-            ) as u32;
-            LAST_EFFECT_SET_RATE(fighter, 0.5);
-            //VarModule::set_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE, EffectModule::get_last_handle(boma) as i32);
-            VarModule::set_int(boma.object(), vars::robot::instance::PASSIVE_FUEL_INDICATOR_EFFECT_HANDLE, new_fuel_effect_indicator_handle as i32);
-            if low_fuel {
-                // Don't change the effect color since it's already red
-            }
-            else if mid_fuel {
-                // Yellow fuel indicator
-                LAST_EFFECT_SET_COLOR(fighter, 2.0, 2.5, 0.1);
-            }
-            /*
-            // High fuel
-            else {
-                // Blue fuel indicator
-                LAST_EFFECT_SET_COLOR(fighter, 0.0, 1.1, 1.2);
-            }
-            */
-        }
-    }
-    
-}
-
 unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     if !fighter.is_in_hitlag()
     && !StatusModule::is_changing(fighter.module_accessor)
@@ -229,12 +120,74 @@ unsafe fn upb_opff(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut Ba
         VarModule::set_float(fighter.battle_object, vars::robot::instance::FRAMES_SINCE_UPB, 0.0);
         VarModule::set_float(fighter.battle_object, vars::robot::instance::FRAMES_SINCE_UPB_RISE, 0.0);
         VarModule::set_float(fighter.battle_object, vars::robot::instance::JOINT_ROT, 0.0);
+        VarModule::off_flag(fighter.battle_object, vars::robot::instance::UPB_CANCEL);
+        VarModule::off_flag(fighter.battle_object, vars::robot::instance::GROUNDED_UPB);
     }
 
     if StatusModule::prev_status_kind(boma, 1) == *FIGHTER_STATUS_KIND_SPECIAL_HI
     {
         PostureModule::set_rot(fighter.module_accessor, &Vector3f::zero(), 0);
     }
+}
+
+unsafe fn meter_control(boma: &mut BattleObjectModuleAccessor) {
+    let entry_id = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID);
+    let info = app::lua_bind::FighterManager::get_fighter_information(crate::singletons::FighterManager(), app::FighterEntryID(entry_id));
+    if lua_bind::FighterManager::is_result_mode(utils::singletons::FighterManager()) {
+        MeterModule::reset(boma.object());
+    }
+    
+    if boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_WIN,
+        *FIGHTER_STATUS_KIND_LOSE,]) {
+        MeterModule::reset(boma.object());
+    }
+
+    if boma.is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_ENTRY,]) || !sv_information::is_ready_go() {
+        VarModule::on_flag(boma.object(), vars::robot::instance::IS_INIT_METER);
+    }
+
+    if VarModule::is_flag(boma.object(), vars::robot::instance::IS_INIT_METER) {
+        MeterModule::reset(boma.object());
+        MeterModule::set_meter_cap(boma.object(), 200);
+        MeterModule::set_meter_per_level(boma.object(), 100.0);
+        
+        MeterModule::add(boma.object(), 200.0);
+        VarModule::off_flag(boma.object(), vars::robot::instance::IS_INIT_METER);
+    }
+
+    if MeterModule::meter(boma.object()) < 200.0 && boma.is_situation(*SITUATION_KIND_GROUND) {
+        MeterModule::add(boma.object(), 0.75);
+    }
+
+
+    if MeterModule::meter(boma.object()) != WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) 
+    && !boma.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI) {
+        let diff = WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) - MeterModule::meter(boma.object());
+
+        if WorkModule::get_float(boma, *FIGHTER_ROBOT_INSTANCE_WORK_ID_FLOAT_BURNER_ENERGY_VALUE) == 10.0 {
+            let remain = MeterModule::meter(boma.object());
+            MeterModule::drain_direct(boma.object(), remain);
+        } else {
+            if diff >= 0.0 {
+                MeterModule::add(boma.object(), diff);
+            } else {
+                MeterModule::drain_direct(boma.object(), diff.abs());
+            }
+        }
+    }
+
+    if boma.is_status(*FIGHTER_STATUS_KIND_SPECIAL_HI) {
+        let robotFrames = VarModule::get_float(boma.object(), vars::robot::instance::FRAMES_SINCE_UPB);
+
+        if robotFrames == 1.0 {
+            MeterModule::drain_direct(boma.object(), 20.0);
+        } else if robotFrames > 10.0 {
+            MeterModule::drain_direct(boma.object(), 2.0);
+        }
+    }
+
 }
 
 pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
@@ -244,9 +197,23 @@ pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut
     bair_boost_reset(boma, status_kind, situation_kind);
     sideb_boost_reset(boma, status_kind, situation_kind);
     bair_boost_detection(boma);
-    fuel_indicator_effect(fighter, boma);
     fastfall_specials(fighter);
     upb_opff(fighter, boma);
+    meter_control(boma);
+}
+
+#[fighter_frame( agent = FIGHTER_KIND_ROBOT )]
+pub fn robot_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
+    unsafe {
+        MeterModule::update(fighter.object(), false);
+        utils::ui::UiManager::set_robot_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
+        utils::ui::UiManager::set_robot_meter_info(
+            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
+            MeterModule::meter(fighter.object()),
+            (MeterModule::meter_cap(fighter.object()) as f32 * MeterModule::meter_per_level(fighter.object())),
+            MeterModule::meter_per_level(fighter.object())
+        );
+    }
 }
 
 #[utils::macros::opff(FIGHTER_KIND_ROBOT )]

--- a/fighters/robot/src/status.rs
+++ b/fighters/robot/src/status.rs
@@ -58,6 +58,7 @@ unsafe fn special_hi_main(fighter: &mut L2CFighterCommon) -> L2CValue {
         } else {
             MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_hi"), 0.0, 1.0, false, 0.0, false, false);
             
+            VarModule::on_flag(fighter.battle_object, vars::robot::instance::GROUNDED_UPB);
             fighter.set_situation(L2CValue::I32(*SITUATION_KIND_AIR));
             PostureModule::add_pos(fighter.module_accessor, &Vector3f{x: 0.00, y: 3.0, z: 0.0});
             
@@ -103,6 +104,7 @@ unsafe fn special_hi_main(fighter: &mut L2CFighterCommon) -> L2CValue {
 
         } else {
             MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_hi"), 0.0, 1.0, false, 0.0, false, false);
+            VarModule::on_flag(fighter.battle_object, vars::robot::instance::GROUNDED_UPB);
             
             fighter.set_situation(L2CValue::I32(*SITUATION_KIND_AIR));
             PostureModule::add_pos(fighter.module_accessor, &Vector3f{x: 0.00, y: 3.0, z: 0.0});
@@ -339,6 +341,13 @@ unsafe extern "C" fn special_hi_keep_main_loop(fighter: &mut L2CFighterCommon) -
     VarModule::add_float(fighter.battle_object, vars::robot::instance::FRAMES_SINCE_UPB_RISE, 1.0);
     let robotKeepFrames = VarModule::get_float(fighter.battle_object, vars::robot::instance::FRAMES_SINCE_UPB_RISE);
 
+    /*if CancelModule::is_enable_cancel(fighter.module_accessor) {
+        if fighter.sub_wait_ground_check_common(false.into()).get_bool()
+        || fighter.sub_air_check_fall_common().get_bool() {
+            return 1.into();
+        }
+    }*/
+
     //return to upright
     let rotX = PostureModule::rot_x(fighter.module_accessor, 0);
     let lr = PostureModule::lr(fighter.module_accessor);
@@ -391,16 +400,17 @@ unsafe extern "C" fn special_hi_keep_main_loop(fighter: &mut L2CFighterCommon) -
         }
     } */
 
-    if (robotKeepFrames > 22.0) {
-        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), true.into());
-    } 
+    if VarModule::is_flag(fighter.battle_object, vars::robot::instance::UPB_CANCEL) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        VarModule::off_flag(fighter.battle_object, vars::robot::instance::UPB_CANCEL);
+    }
 
     if fighter.is_situation(*SITUATION_KIND_GROUND) {
         fighter.change_status(FIGHTER_STATUS_KIND_WAIT.into(), true.into());
     }
     
     if MotionModule::is_end(fighter.module_accessor) {
-        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), true.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
     } 
 
     0.into()
@@ -420,7 +430,7 @@ unsafe fn special_hi_keep_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
 unsafe fn special_hi_keep_end(fighter: &mut L2CFighterCommon) -> L2CValue {
 
     PostureModule::set_rot(fighter.module_accessor, &Vector3f::zero(), 0);
-    KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+    //KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
     KineticModule::enable_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_CONTROL);
     KineticModule::resume_energy_all(fighter.module_accessor);
     0.into()

--- a/utils/src/ui.rs
+++ b/utils/src/ui.rs
@@ -6,12 +6,14 @@ use self::ff_meter::FfMeter;
 use self::power_board::PowerBoard;
 use self::pichu_meter::PichuMeter;
 use self::aura_meter::AuraMeter;
+use self::robot_meter::RobotMeter;
 
 mod ex_meter;
 mod ff_meter;
 mod power_board;
 mod pichu_meter;
 mod aura_meter;
+mod robot_meter;
 
 trait UiObject {
     fn update(&mut self);
@@ -26,6 +28,7 @@ static UI_MANAGER: Lazy<RwLock<UiManager>> = Lazy::new(|| RwLock::new(UiManager 
     power_board: [PowerBoard::default(); 8],
     pichu_meter: [PichuMeter::default(); 8],
     aura_meter: [AuraMeter::default(); 8],
+    robot_meter: [RobotMeter::default(); 8]
 }));
 
 #[repr(C)]
@@ -34,7 +37,8 @@ pub struct UiManager {
     ff_meter: [FfMeter; 8],
     power_board: [PowerBoard; 8],
     pichu_meter: [PichuMeter; 8],
-    aura_meter: [AuraMeter; 8]
+    aura_meter: [AuraMeter; 8],
+    robot_meter: [RobotMeter; 8]
 }
 
 impl UiManager {
@@ -223,6 +227,22 @@ impl UiManager {
             manager.aura_meter[Self::get_ui_index_from_entry_id(entry_id) as usize].set_meter_info(current, max, per_level, burnout);
         }
     }
+
+    #[export_name = "UiManager__set_robot_meter_enable"]
+    pub extern "C" fn set_robot_meter_enable(entry_id: u32, enable: bool) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.robot_meter[Self::get_ui_index_from_entry_id(entry_id) as usize].set_enable(enable);
+        }
+    }
+
+    #[export_name = "UiManager__set_robot_meter_info"]
+    pub extern "C" fn set_robot_meter_info(entry_id: u32, current: f32, max: f32, per_level: f32) {
+        let mut manager = UI_MANAGER.write();
+        unsafe {
+            manager.robot_meter[Self::get_ui_index_from_entry_id(entry_id) as usize].set_meter_info(current, max, per_level);
+        }
+    }
 }
 
 fn set_pane_visible(pane: u64, visible: bool) {
@@ -348,6 +368,7 @@ unsafe fn get_set_info_alpha(ctx: &skyline::hooks::InlineCtx) {
     manager.power_board[index] = PowerBoard::new(layout_udata);
     manager.pichu_meter[index] = PichuMeter::new(layout_udata);
     manager.aura_meter[index] = AuraMeter::new(layout_udata);
+    manager.robot_meter[index] = RobotMeter::new(layout_udata);
 }
 
 #[skyline::hook(offset = 0x138a6f0, inline)]
@@ -387,6 +408,11 @@ fn hud_update(_: &skyline::hooks::InlineCtx) {
     for aura_meter in mgr.aura_meter.iter_mut() {
         if aura_meter.is_valid() && aura_meter.is_enabled() {
             aura_meter.update();
+        }
+    }
+    for robot_meter in mgr.robot_meter.iter_mut() {
+        if robot_meter.is_valid() && robot_meter.is_enabled() {
+            robot_meter.update();
         }
     }
 }

--- a/utils/src/ui/robot_meter.rs
+++ b/utils/src/ui/robot_meter.rs
@@ -1,0 +1,333 @@
+use super::*;
+
+const BACKGROUND_RECHARGE: [f32; 4] = [255.0 / 255.0, 255.0 / 255.0, 255.0 / 255.0, 1.0];
+const BACKGROUND_BLACK: [f32; 4] = [88.0 / 255.0, 61.0 / 255.0, 4.0 / 255.0, 1.0];
+
+const FOREGROUND_CHARGE_FULL: [f32; 4] = [7.0 / 255.0, 131.0 / 255.0, 23.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_FULLB: [f32; 4] = [3.0 / 255.0, 65.0 / 255.0, 12.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_HALF: [f32; 4] = [225.0 / 255.0, 225.0 / 255.0, 17.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_HALFB: [f32; 4] = [112.0 / 255.0, 112.0 / 255.0, 8.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_EMPTY: [f32; 4] = [250.0 / 255.0, 22.0 / 255.0, 22.0 / 255.0, 1.0];
+const FOREGROUND_CHARGE_EMPTYB: [f32; 4] = [125.0 / 255.0, 11.0 / 255.0, 11.0 / 255.0, 1.0];
+
+const FULL_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    1.0, 0.0,
+    0.0, 1.0,
+    1.0, 1.0
+];
+
+const EMPTY_TEXCOORDS: [f32; 8] = [
+    0.0, 0.0,
+    0.0, 0.0,
+    0.0, 1.0,
+    0.0, 1.0
+];
+
+#[derive(Default, Copy, Clone)]
+#[repr(C)]
+pub struct RobotMeter {
+    // Panes
+    pub base_bar: u64,
+    pub bars: [u64; 2],
+    pub bars_background: [u64; 2],
+    pub number: u64,
+
+    // Initial state
+    pub original_bar_width: f32,
+    pub original_bar_height: f32,
+
+    pub original_bar2_width: f32,
+    pub original_bar2_height: f32,
+
+    // Progress tracking
+    pub actual_percentage: f32,
+    pub visual_percentage: f32,
+
+    // Number tracking
+    pub current_number: usize,
+    pub current_max: usize,
+
+    enabled: bool,
+}
+
+impl RobotMeter {
+    pub fn new(layout_data: u64) -> Self {
+        let base_bar = super::get_pane_from_layout(layout_data, "ff_meter_base\0")
+            .expect("Could not find the base robot meter!");
+
+        let bar1 = super::get_pane_from_layout(layout_data, "ff_meter_bar1\0")
+            .expect("Could not find first bar for robot meter!");
+        
+        let bar2 = super::get_pane_from_layout(layout_data, "ff_meter_bar2\0")
+            .expect("Could not find second bar for robot meter!");
+
+        let bar1_bg = super::get_pane_from_layout(layout_data, "ff_meter_bar1_bg\0")
+            .expect("Could not find first bg bar for robot meter!");
+
+        let bar2_bg = super::get_pane_from_layout(layout_data, "ff_meter_bar2_bg\0")
+            .expect("Could not find second bg bar for robot meter!");
+
+        let number = super::get_pane_from_layout(layout_data, "ff_meter_num\0")
+            .expect("Could not find number for robot meter!");
+
+        Self {
+            base_bar,
+            bars: [bar1, bar2],
+            bars_background: [bar1_bg, bar2_bg],
+            number,
+
+            original_bar_width: -1.0,
+            original_bar_height: -1.0,
+
+            original_bar2_width: -1.0,
+            original_bar2_height: -1.0,
+
+            actual_percentage: -1.0,
+            visual_percentage: -1.0,
+
+            current_number: 0,
+            current_max: 1,
+
+            enabled: false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        set_pane_visible(self.base_bar, true);
+        set_pane_visible(self.bars[0], false);
+        set_pane_visible(self.bars[1], false);
+        set_pane_visible(self.bars_background[0], false);
+        set_pane_visible(self.bars_background[1], false);
+        set_pane_visible(self.number, false);
+
+        if self.original_bar_height < 0.0 {
+            self.original_bar_width = get_width_height(self.bars[0]).0;
+            self.original_bar_height = get_width_height(self.bars[0]).1;
+
+            self.original_bar2_width = get_width_height(self.bars[1]).0;
+            self.original_bar2_height = get_width_height(self.bars[1]).1;
+        }
+
+        self.current_number = 0;
+        self.current_max = 1;
+        self.actual_percentage = 0.0;
+        self.visual_percentage = 0.0;
+    }
+
+    pub fn update_number(&mut self) {
+        set_pane_visible(self.number, false);
+
+        let left_x = self.current_number as f32 / 6.0;
+        let right_x = (self.current_number + 1) as f32 / 6.0;
+
+        set_tex_coords(
+            self.number,
+            [
+                left_x, 0.0,
+                right_x, 0.0,
+                left_x, 1.0,
+                right_x, 1.0
+            ]
+        );
+    }
+
+    pub fn set_meter_info(&mut self, current: f32, max: f32, per_level: f32) {
+        let bar_total = per_level * 2.0;
+        
+        let number = current / bar_total;
+        let number = number.clamp(0.0, 1.0) as usize;
+
+        let percent = if number == 1 {
+            1.0
+        } else {
+            (current % bar_total) / bar_total
+        };
+
+        if number != self.current_number && number != 1 {
+            self.actual_percentage = percent;
+            self.visual_percentage = 0.0;
+        } else {
+            self.actual_percentage = percent;
+        }
+
+        self.current_number = number;
+    }
+
+    pub fn set_tex_coords(&mut self) {
+        // Handle the first bar
+        set_pane_colors(self.bars_background[0], BACKGROUND_RECHARGE, BACKGROUND_BLACK);
+        set_pane_colors(self.bars_background[1], BACKGROUND_RECHARGE, BACKGROUND_BLACK);
+        set_pane_colors(self.bars[0], FOREGROUND_CHARGE_FULL, FOREGROUND_CHARGE_FULLB);
+        set_pane_colors(self.bars[1], FOREGROUND_CHARGE_FULL, FOREGROUND_CHARGE_FULLB);
+
+        if self.actual_percentage >= 0.6 {
+            set_tex_coords(self.bars_background[0], FULL_TEXCOORDS);
+            set_width_height(self.bars_background[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+
+            if self.actual_percentage >= 1.0 {
+                set_tex_coords(self.bars_background[1], FULL_TEXCOORDS);
+                set_width_height(self.bars_background[1], self.original_bar2_width, self.original_bar2_height);
+                set_pane_visible(self.bars_background[1], true);
+            } else {
+                let percentage = (self.actual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars_background[1], true);
+                set_tex_coords(
+                    self.bars_background[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars_background[1], self.original_bar2_width * percentage, self.original_bar2_height);
+            }
+        } else if self.actual_percentage <= 0.2 {
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGE_EMPTY, FOREGROUND_CHARGE_EMPTYB);
+            set_pane_colors(self.bars[1], FOREGROUND_CHARGE_EMPTY, FOREGROUND_CHARGE_EMPTYB);
+            set_tex_coords(self.bars_background[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars_background[1], 0.0, 0.0);
+            set_pane_visible(self.bars_background[1], false);
+
+            let percentage = self.actual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars_background[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars_background[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+        } else {
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGE_HALF, FOREGROUND_CHARGE_HALFB);
+            set_pane_colors(self.bars[1], FOREGROUND_CHARGE_HALF, FOREGROUND_CHARGE_HALFB);
+            set_tex_coords(self.bars_background[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars_background[1], 0.0, 0.0);
+            set_pane_visible(self.bars_background[1], false);
+
+            let percentage = self.actual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars_background[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars_background[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars_background[0], true);
+        }
+    
+        if self.visual_percentage >= 0.5 {
+            set_tex_coords(self.bars[0], FULL_TEXCOORDS);
+            set_width_height(self.bars[0], self.original_bar_width, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+
+            if self.visual_percentage >= 1.0 {
+                set_tex_coords(self.bars[1], FULL_TEXCOORDS);
+                set_width_height(self.bars[1], self.original_bar2_width, self.original_bar2_height);
+                set_pane_visible(self.bars[1], true);
+            } else {
+                let percentage = (self.visual_percentage - 0.5) / 0.5;
+                set_pane_visible(self.bars[1], true);
+                set_tex_coords(
+                    self.bars[1],
+                    [
+                        0.0, 0.0,
+                        percentage, 0.0,
+                        0.0, 1.0,
+                        percentage, 1.0
+                    ]
+                );
+                set_width_height(self.bars[1], self.original_bar2_width * percentage, self.original_bar2_height);
+            }
+        } else if self.actual_percentage <= 0.2 {
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGE_EMPTY, FOREGROUND_CHARGE_EMPTYB);
+            set_pane_colors(self.bars[1], FOREGROUND_CHARGE_EMPTY, FOREGROUND_CHARGE_EMPTYB);
+            set_tex_coords(self.bars[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars[1], 0.0, 0.0);
+            set_pane_visible(self.bars[1], false);
+
+            let percentage = self.visual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+        } else {
+            set_pane_colors(self.bars[0], FOREGROUND_CHARGE_HALF, FOREGROUND_CHARGE_HALFB);
+            set_pane_colors(self.bars[1], FOREGROUND_CHARGE_HALF, FOREGROUND_CHARGE_HALFB);
+            set_tex_coords(self.bars[1], EMPTY_TEXCOORDS);
+            set_width_height(self.bars[1], 0.0, 0.0);
+            set_pane_visible(self.bars[1], false);
+
+            let percentage = self.visual_percentage / 0.5;
+
+            set_tex_coords(
+                self.bars[0],
+                [
+                    0.0, 0.0,
+                    percentage, 0.0,
+                    0.0, 1.0,
+                    percentage, 1.0
+                ]
+            );
+
+            set_width_height(self.bars[0], self.original_bar_width * percentage, self.original_bar_height);
+            set_pane_visible(self.bars[0], true);
+        }
+    }
+
+    pub fn update_percentages(&mut self) {
+        self.visual_percentage = f32::min(self.visual_percentage + 0.01, self.actual_percentage);
+    }
+}
+
+impl UiObject for RobotMeter {
+    fn update(&mut self) {
+        self.update_number();
+        self.set_tex_coords();
+        self.update_percentages();
+    }
+
+    fn is_valid(&self) -> bool {
+        is_pane_valid(self.base_bar)
+            && is_pane_valid(self.number)
+    }
+
+    fn set_enable(&mut self, enable: bool) {
+        if enable && !self.enabled {
+            self.reset();
+        } else if !enable {
+            set_pane_visible(self.base_bar, false);
+            set_pane_visible(self.number, false);
+            set_pane_visible(self.bars[0], false);
+            set_pane_visible(self.bars[1], false);
+            set_pane_visible(self.bars_background[0], false);
+            set_pane_visible(self.bars_background[1], false);
+        }
+        self.enabled = enable;
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}


### PR DESCRIPTION
### New feature: Meter!
ROB's fuel gauge is now visible through a meter system, replacing the old glowing orb that he had on his chest. Use this to get accurate information on your current fuel state.

https://github.com/HDR-Development/HewDraw-Remix/assets/115596132/a8f3a096-117b-4b8f-b5e8-3e1366f1c631

### New feature: Grounded Upb!
ROB's Grounded Upb previously did not have much of a use, this has been changed so that his upb can be cancelled earlier when used on the ground. Use this to provide more offensive pressure!

https://github.com/HDR-Development/HewDraw-Remix/assets/115596132/4c69b1c5-2d1d-4feb-be0a-25463e22c9ff

### Miscellaneous
- Fixed a bug where charged bair was using far less fuel than intended (6 fuel per charge level -> 13 fuel per charge level)
- Fixed a bug where you could get one charge level on bair with no fuel.
- Upb spike is slightly stronger (0.25 damage per charge frame > 0.29 damage per charge frame)