### PR TITLE
Mario Brands

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -649,7 +649,8 @@ pub mod vars {
         pub mod status {
             // copy ability
             // flags
-            pub use super::super::mario::status::IS_SPECIAL_N_FIREBRAND;
+            pub use super::super::mario::status::FIREBRAND;
+            pub use super::super::luigi::status::THUNDERHAND;
             pub use super::super::mariod::status::CHILL_PILL;
             pub const MINING_TIMER: i32 = 0x11F4;
         }
@@ -776,8 +777,7 @@ pub mod vars {
         }
         pub mod status {
             // flag
-            pub use super::super::mario::status::IS_SPECIAL_N_DOUBLE_FIREBALL;
-            pub use super::super::mario::status::IS_SPECIAL_N_FIREBRAND;
+            pub const THUNDERHAND: i32 = 0x1100;
         }
     }
 
@@ -785,10 +785,8 @@ pub mod vars {
         pub mod instance {
             // flags
             pub const NOKNOK_SHELL: i32 = 0x0100;
-            pub const CAN_INPUT_SPECIAL_N_DOUBLE_FIREBALL:   i32 = 0x0101;
-            pub const SPECIAL_N_DOUBLE_FIREBALL_NOTIFY_FLAG: i32 = 0x0102;
-            pub const DISABLE_DSPECIAL_STALL:                i32 = 0x0103;
-            pub const SPECIAL_S_DISABLE_STALL:               i32 = 0x0104;
+            pub const DISABLE_DSPECIAL_STALL: i32 = 0x0101;
+            pub const SPECIAL_S_DISABLE_STALL: i32 = 0x0102;
         }
 
         pub mod status {
@@ -797,8 +795,7 @@ pub mod vars {
             pub const AERIAL_COMMAND_RISING: i32 = 0x1101;
             pub const AERIAL_COMMAND_RISEN: i32 = 0x1102;
 
-            pub const IS_SPECIAL_N_FIREBRAND: i32 = 0x1100;
-            pub const IS_SPECIAL_N_DOUBLE_FIREBALL: i32 = 0x1101;
+            pub const FIREBRAND: i32 = 0x1100;
         }
     }
 

--- a/fighters/kirby/src/acmd/copyspecials.rs
+++ b/fighters/kirby/src/acmd/copyspecials.rs
@@ -792,562 +792,155 @@ unsafe fn lucas_special_n_fire_sound(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "kirby", script = "game_luigispecialn" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "kirby", scripts = ["game_luigispecialn", "game_luigispecialairn"] , category = ACMD_GAME , low_priority)]
 unsafe fn luigi_special_n_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            ATTACK(fighter, 0, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 2.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 2, 0, Hash40::new("shoulderl"), 9.0, 69, 55, 0, 65, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            //HIT_NODE(fighter, Hash40::new("head"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("handl"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("arml"), *HIT_STATUS_XLU);
-            FT_MOTION_RATE(fighter, 2.0);
-        }
-        else{
-            ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
+        ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
     }
-    wait(lua_state, 5.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
-            FT_MOTION_RATE(fighter, 0.5);
-        }
-    }
+
 }
 
-#[acmd_script( agent = "kirby", script = "effect_luigispecialn" , category = ACMD_EFFECT , low_priority)]
+#[acmd_script( agent = "kirby", scripts = ["effect_luigispecialn", "effect_luigispecialairn"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn luigi_special_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        }
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("havel"), 3.0, 0.0, 0.0, 0, 90, 90, 0.5, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("havel"), 0.0, 0.0, 0.0, 0, 90, 90, 0.8, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.25);
-            FLASH(fighter, 0, 0.25, 1.0, 0.7);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
-            FLASH(fighter, 0, 1, 0, 0.353);
-        }
+        EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
+        FLASH(fighter, 0, 1, 0, 0.353);
     }
     frame(lua_state, 19.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
-    frame(lua_state, 28.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder"), false, false);
-    }
-    frame(lua_state, 32.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_elec_s"), true, true);
-    }
     frame(lua_state, 37.0);
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("luigi_fb_shoot"), false, false);
     }
+
 }
 
-#[acmd_script( agent = "kirby", script = "sound_luigispecialn" , category = ACMD_SOUND , low_priority)]
+#[acmd_script( agent = "kirby", scripts = ["sound_luigispecialn", "sound_luigispecialairn"] , category = ACMD_SOUND , low_priority)]
 unsafe fn luigi_special_n_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("se_common_elec_s_damage"));
-        }
-    }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
-            PLAY_SE(fighter, Hash40::new("se_common_elec_m_damage"));
-        }
-        else{
-            PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
-        }
+        PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
     }
+
 }
 
-#[acmd_script( agent = "kirby", script = "game_luigispecialairn" , category = ACMD_GAME , low_priority)]
-unsafe fn luigi_special_air_n_game(fighter: &mut L2CAgentBase)  {
+#[acmd_script( agent = "kirby", scripts = ["game_luigispecialnthunder", "game_luigispecialairnthunder"] , category = ACMD_GAME , low_priority)]
+unsafe fn luigi_special_n_thunder_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    }
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            ATTACK(fighter, 0, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 2.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 2, 0, Hash40::new("shoulderl"), 9.0, 69, 55, 0, 65, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            //HIT_NODE(fighter, Hash40::new("head"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("handl"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("arml"), *HIT_STATUS_XLU);
-            FT_MOTION_RATE(fighter, 2.0);
-        }
-        else{
-            ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 68, 55, 0, 65, 5.0, 0.0, 6.5, 9.0, None, None, None, 0.6, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 9.0, 68, 55, 0, 65, 3.0, 0.0, 6.5, 3.0, None, None, None, 0.6, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PUNCH);
     }
-    wait(lua_state, 5.0);
+    frame(lua_state, 21.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
-            FT_MOTION_RATE(fighter, 0.5);
-        }
     }
 }
 
-#[acmd_script( agent = "kirby", script = "effect_luigispecialairn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn luigi_special_air_n_effect(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "kirby", scripts = ["effect_luigispecialnthunder", "effect_luigispecialairnthunder"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn luigi_special_n_thunder_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 5, 15, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+    }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("havel"), 3.0, 0.0, 0.0, 0, 90, 90, 0.5, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("havel"), 0.0, 0.0, 0.0, 0, 90, 90, 0.8, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.25);
-            FLASH(fighter, 0, 0.25, 1.0, 0.7);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
-            FLASH(fighter, 0, 1, 0, 0.353);
+        let mut rand = &Vector3f::new(
+            app::sv_math::rand(hash40("fighter"), 50) as f32,
+            app::sv_math::rand(hash40("stage"), 50) as f32,
+            app::sv_math::rand(hash40("luigi"), 50) as f32
+        );
+        let mut flip = &Vector3f::new(
+            if app::sv_math::rand(hash40("fighter"), 1) == 0 { -1 } else { 1 } as f32,
+            if app::sv_math::rand(hash40("stage"), 1) == 0 { -1 } else { 1 } as f32,
+            if app::sv_math::rand(hash40("luigi"), 1) == 0 { -1 } else { 1 } as f32
+        );
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 6.5, 9.0, 0.0 + (rand.x * flip.x), 0, 0, 0.5, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 6.5, 9.0, 120.0 + (rand.y * flip.y), 0, 0, 0.5, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 6.5, 9.0, 240.0 + (rand.z * flip.z), 0, 0, 0.5, true);
+    }
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 0, 0.25, 1.0, 0.7);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("top"), 0.0, 6.5, 9.0, 0, 90, 90, 0.4, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_sp_flash"), Hash40::new("top"), 0.0, 6.5, 9.0, 0, 90, 90, 0.5, true);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
         }
     }
-    frame(lua_state, 19.0);
+    frame(lua_state, 20.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
-    frame(lua_state, 28.0);
+}
+
+#[acmd_script( agent = "kirby", scripts = ["sound_luigispecialnthunder", "sound_luigispecialairnthunder"], category = ACMD_SOUND, low_priority )]
+unsafe fn luigi_special_n_thunder_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 17.0);
     if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder"), false, false);
-    }
-    frame(lua_state, 32.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_elec_s"), true, true);
-    }
-    frame(lua_state, 37.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("luigi_fb_shoot"), false, false);
+        PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
+        PLAY_SE(fighter, Hash40::new("se_common_electric_hit_l"));
     }
 }
 
-#[acmd_script( agent = "kirby", script = "sound_luigispecialairn" , category = ACMD_SOUND , low_priority)]
-unsafe fn luigi_special_air_n_sound(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "kirby", scripts = ["expression_luigispecialnthunder", "expression_luigispecialairnthunder"], category = ACMD_EXPRESSION, low_priority )]
+unsafe fn luigi_special_n_thunder_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 12.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("se_common_elec_s_damage"));
-        }
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
-            PLAY_SE(fighter, Hash40::new("se_common_elec_m_damage"));
-        }
-        else{
-            PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
-        }
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
 }
 
-#[acmd_script( agent = "kirby", script = "game_mariospecialn" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "kirby", scripts = ["game_mariospecialn", "game_mariospecialairn"] , category = ACMD_GAME , low_priority)]
 unsafe fn mario_special_n_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 16.0/(14.0-1.0));
-        VarModule::off_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-            FT_MOTION_RATE(fighter, 3.0/(14.0-12.0));
-        }
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 10.0, 45, 110, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 12.0, 50, 115, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-        else {
-            ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 8.0, 40, 100, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 8.0, 40, 100, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            AttackModule::clear_all(boma);
-            FT_MOTION_RATE(fighter, 32.0/(49.0 - 21.0));
-        }
-        else {
-            FT_MOTION_RATE(fighter, 23.0/(49.0 - 21.0));
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", script = "effect_mariospecialn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn mario_special_n_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 2.0);
-    if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
-    }
-    frame(lua_state, 11.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
-            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
-        }
-    }
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        if PostureModule::lr(boma) > 0.0{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1.0, true);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 1, true);
-        }
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handl"), 1.0, 0, 0, 0, 0, 0, 0.3, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("havel"), 1.0, 0, 0, 0, 0, 0, 0.23, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.2);
-            EffectModule::enable_sync_init_pos_last(boma);
-        }
-    }
-    frame(lua_state, 15.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-        else{
-            FLASH(fighter, 1, 0, 0, 0.353);
-        }
-    }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        COL_NORMAL(fighter);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.75);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.35);
-        }
-        else{
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.75);
-        }
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.35);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
-        }
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", script = "sound_mariospecialn" , category = ACMD_SOUND , low_priority)]
-unsafe fn mario_special_n_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            PLAY_SE(fighter, Hash40::new("se_mario_smash_s01"));
-            PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", script = "game_mariospecialairn" , category = ACMD_GAME , low_priority)]
-unsafe fn mario_special_air_n_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 16.0/(14.0-1.0));
-        VarModule::off_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)){
-            VarModule::on_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND);
-            FT_MOTION_RATE(fighter, 3.0/(14.0-12.0));
-        }
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 10.0, 45, 110, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 12.0, 50, 115, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-        else {
-            ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 8.0, 40, 100, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 8.0, 40, 100, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            AttackModule::clear_all(boma);
-            FT_MOTION_RATE(fighter, 32.0/(49.0 - 21.0));
-        }
-        else {
-            FT_MOTION_RATE(fighter, 23.0/(49.0 - 21.0));
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", script = "effect_mariospecialairn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn mario_special_air_n_effect(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 11.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
-            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
-        }
-    }
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        if PostureModule::lr(boma) > 0.0{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1.0, true);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 1, true);
-        }
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("havel"), 1.0, 0, 0, 0, 0, 0, 0.3, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("handl"), 1.0, 0, 0, 0, 0, 0, 0.23, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.2);
-            EffectModule::enable_sync_init_pos_last(boma);
-        }
-    }
-    frame(lua_state, 15.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
-        else{
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-    }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        COL_NORMAL(fighter);
-    }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 1.0);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.5);
-        }
-        else{
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 1.0);
-        }
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.5);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
-        }
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", script = "sound_mariospecialairn" , category = ACMD_SOUND , low_priority)]
-unsafe fn mario_special_air_n_sound(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
-        if VarModule::is_flag(fighter.battle_object, vars::kirby::status::IS_SPECIAL_N_FIREBRAND) {
-            PLAY_SE(fighter, Hash40::new("se_mario_smash_s01"));
-            PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
-        }
-    }
-}
-
-#[acmd_script( agent = "kirby", scripts = ["game_mariodspecialnchill", "game_mariodspecialairnchill"] , category = ACMD_GAME , low_priority)]
-unsafe fn mariod_special_n_chill_game(fighter: &mut L2CAgentBase) {
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
     frame(lua_state, 10.0);
-    FT_MOTION_RATE_RANGE(fighter, 10.0, 14.0, 5.0);
+    FT_MOTION_RATE_RANGE(fighter, 10.0, 14.0, 8.0);
     frame(lua_state, 14.0);
     FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 10.0, 69, 90, 0, 50, 3.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 10.0, 69, 90, 0, 50, 4.5, 4.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 2, 0, Hash40::new("arml"), 10.0, 69, 90, 0, 50, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
+        ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
     }
-    frame(lua_state, 18.0);
-    FT_MOTION_RATE_RANGE(fighter, 18.0, 43.0, 37.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-    }
-    frame(lua_state, 43.0);
+    frame(lua_state, 21.0);
+    FT_MOTION_RATE_RANGE(fighter, 21.0, 49.0, 23.0);
+    frame(lua_state, 49.0);
     FT_MOTION_RATE(fighter, 1.0);
+
 }
 
-
-#[acmd_script( agent = "kirby", scripts = ["effect_mariodspecialnchill", "effect_mariodspecialairnchill"] , category = ACMD_EFFECT , low_priority)]
-unsafe fn mariod_special_n_chill_effect(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "kirby", scripts = ["effect_mariospecialn", "effect_mariospecialairn"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_special_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 2.0);
@@ -1356,80 +949,147 @@ unsafe fn mariod_special_n_chill_effect(fighter: &mut L2CAgentBase) {
             LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
         }
     }
-    frame(lua_state, 14.0);
+    frame(lua_state, 13.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_ice"), Hash40::new("arml"), 7.5, 0, 0, 0, 0, 0, 0.35, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.5);
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_ice_landing"), Hash40::new("arml"), 7.5, 0, 0, 0, 0, 0, 0.75, true);
-        LAST_EFFECT_SET_RATE(fighter, 0.75);
-        EffectModule::enable_sync_init_pos_last(boma);
-        EFFECT_FLIP(fighter, Hash40::new("mariod_capsule_shoot"), Hash40::new("mariod_capsule_shoot"), Hash40::new("top"), -1, 8, 11, 0, 0, 0, 0.46, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
-        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash"), Hash40::new("sys_smash_flash"), Hash40::new("top"), -1, 8, 11, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
-        if fighter.is_situation(*SITUATION_KIND_GROUND) {
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), -1, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
+        if PostureModule::lr(boma) > 0.0 {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1, true);
+        }
+        else {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 1, true);
         }
     }
     frame(lua_state, 15.0);
     if is_excute(fighter) {
-        FLASH(fighter, 0.5, 0.25, 1, 0.35);
+        FLASH(fighter, 1, 0, 0, 0.353);
     }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.5, 0.25, 1, 0.75);
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.5, 0.25, 1, 0.35);
-    }
-    frame(lua_state, 24.0);
+    frame(lua_state, 17.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
     frame(lua_state, 27.0);
     if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.75);
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
         COL_NORMAL(fighter);
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_ice"), false, true);
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_ice_landing"), false, true);
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
     }
     frame(lua_state, 40.0);
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
     }
-    frame(lua_state, 42.0);
+
+}
+
+#[acmd_script( agent = "kirby", scripts = ["sound_mariospecialn", "sound_mariospecialairn"] , category = ACMD_SOUND , low_priority)]
+unsafe fn mario_special_n_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 13.0);
     if is_excute(fighter) {
-        COL_NORMAL(fighter);
+        PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
     }
 }
 
-#[acmd_script( agent = "kirby", scripts = ["sound_mariodspecialnchill", "sound_mariodspecialairnchill"], category = ACMD_SOUND, low_priority )]
-unsafe fn mariod_special_n_chill_sound(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "kirby", scripts = ["game_mariospecialnfire", "game_mariospecialairnfire"] , category = ACMD_GAME , low_priority)]
+unsafe fn mario_special_n_fire_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 10.0);
+    FT_MOTION_RATE_RANGE(fighter, 10.0, 11.0, 7.0);
+    frame(lua_state, 11.0);
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(-0.5, 0.0, 0.0));
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 14.0, 50, 101, 0, 52, 3.0, 0.0, 5.5, 4.5, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 14.0, 50, 101, 0, 52, 5.0, 0.0, 6.5, 11.5, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 40, 100, 0, 50, 3.0, 0.0, 5.5, 4.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 9.0, 40, 100, 0, 50, 5.0, 0.0, 6.5, 11.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+    }
+    frame(lua_state, 21.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "kirby", scripts = ["effect_mariospecialnfire", "effect_mariospecialairnfire"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_special_n_fire_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 10.5);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 6, 11, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(fighter) {
+        if PostureModule::lr(boma) > 0.0 {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 0.7, true);
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("haver"), 0, 0, 0, 0, 45, 0, 0.7, true);
+        }
+        else {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 0.7, true);
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("haver"), 0, 0, 0, 0, -45, 0, 0.7, true);
+        }
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+        }
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 1, 0, 0, 0.35);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handl"), 0.0, 0, 0, 0, 0, 0, 0.2, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handr"), 0.0, 0, 0, 0, 0, 0, 0.2, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("top"), 0, 6.5, 11.5, 0, 0, 0, 0.26, true);
+        LAST_EFFECT_SET_RATE(fighter, 1.2);
+        EffectModule::enable_sync_init_pos_last(boma);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+    }
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        COL_NORMAL(fighter);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 1, 0, 0, 0.75);
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
+    }
+    frame(lua_state, 21.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 1, 0, 0, 0.35);
+    }
+    frame(lua_state, 24.0);
+    if is_excute(fighter) {
+        COL_NORMAL(fighter);
+    }
+    frame(lua_state, 30.0);
+    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
+        EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
+    }
+}
+
+#[acmd_script( agent = "kirby", scripts = ["sound_mariospecialnfire", "sound_mariospecialairnfire"], category = ACMD_SOUND, low_priority )]
+unsafe fn mario_special_n_fire_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 14.0);
     if is_excute(fighter) {
-        PLAY_SE(fighter, Hash40::new("se_common_frieze_l"));
-        PLAY_SE(fighter, Hash40::new("vc_kirby_attack03"));
+        PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
+        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
+        PLAY_SE(fighter, Hash40::new("vc_kirby_attack02"));
     }
 }
 
-#[acmd_script( agent = "kirby", scripts = ["expression_mariodspecialnchill", "expression_mariodspecialairnchill"], category = ACMD_EXPRESSION, low_priority )]
-unsafe fn mariod_special_n_chill_expression(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "kirby", scripts = ["expression_mariospecialnfire", "expression_mariospecialairnfire"], category = ACMD_EXPRESSION, low_priority )]
+unsafe fn mario_special_n_fire_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
@@ -1454,7 +1114,7 @@ unsafe fn mariod_special_n_game(fighter: &mut L2CAgentBase) {
     }
 }
 
-#[acmd_script( agent = "kirby", scripts = ["effect_mariodspecialn", "effect_mariodspecialairn"] , category = ACMD_EFFECT , low_priority)]
+#[acmd_script( agent = "kirby", scripts = ["effect_mariospecialn", "effect_mariospecialairn"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn mariod_special_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -1478,9 +1138,83 @@ unsafe fn mariod_special_n_effect(fighter: &mut L2CAgentBase) {
 unsafe fn mariod_special_n_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 14.0);
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_mariod_special_n01"));
+    }
+}
+
+#[acmd_script( agent = "kirby", scripts = ["game_mariodspecialnchill", "game_mariodspecialairnchill"] , category = ACMD_GAME , low_priority)]
+unsafe fn mariod_special_n_chill_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 69, 84, 0, 42, 3.5, 0.0, 6.5, 4.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 69, 84, 0, 42, 4.75, 0.0, 4.0, 7.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
+    }
+    frame(lua_state, 19.0);
+    FT_MOTION_RATE_RANGE(fighter, 19.0, 43.0, 36.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 43.0);
+    FT_MOTION_RATE(fighter, 1.0);
+}
+
+
+#[acmd_script( agent = "kirby", scripts = ["effect_mariodspecialnchill", "effect_mariodspecialairnchill"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn mariod_special_n_chill_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 8, 11, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 0.5, 0.25, 1, 0.35);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_ice"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.35, true);
+        LAST_EFFECT_SET_RATE(fighter, 1.5);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_ice_landing"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.75, true);
+        LAST_EFFECT_SET_RATE(fighter, 0.75);
+        EffectModule::enable_sync_init_pos_last(boma);
+        EFFECT_FLIP(fighter, Hash40::new("mariod_capsule_shoot"), Hash40::new("mariod_capsule_shoot"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.46, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash"), Hash40::new("sys_smash_flash"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        COL_NORMAL(fighter);
+    }
+}
+
+#[acmd_script( agent = "kirby", scripts = ["sound_mariodspecialnchill", "sound_mariodspecialairnchill"], category = ACMD_SOUND, low_priority )]
+unsafe fn mariod_special_n_chill_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_frieze_l"));
+        PLAY_SE(fighter, Hash40::new("vc_kirby_attack03"));
+    }
+}
+
+#[acmd_script( agent = "kirby", scripts = ["expression_mariodspecialnchill", "expression_mariodspecialairnchill"], category = ACMD_EXPRESSION, low_priority )]
+unsafe fn mariod_special_n_chill_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
 }
 
@@ -1918,15 +1652,17 @@ pub fn install() {
         luigi_special_n_game,
         luigi_special_n_effect,
         luigi_special_n_sound,
-        luigi_special_air_n_game,
-        luigi_special_air_n_effect,
-        luigi_special_air_n_sound,
+        luigi_special_n_thunder_game,
+        luigi_special_n_thunder_effect,
+        luigi_special_n_thunder_sound,
+        luigi_special_n_thunder_expression,
         mario_special_n_game,
         mario_special_n_effect,
         mario_special_n_sound,
-        mario_special_air_n_game,
-        mario_special_air_n_effect,
-        mario_special_air_n_sound,
+        mario_special_n_fire_game,
+        mario_special_n_fire_effect,
+        mario_special_n_fire_sound,
+        mario_special_n_fire_expression,
         mariod_special_n_game,
         mariod_special_n_effect,
         mariod_special_n_sound,

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -2,6 +2,8 @@ use super::*;
 use globals::*;
 mod special_hi_h;
 mod gaogaen_special_n;
+mod luigi_special_n;
+mod mario_special_n;
 mod mariod_special_n;
 mod ridley_special_n;
 mod ganon_special_n;
@@ -25,6 +27,8 @@ pub fn install() {
     ridley_special_n::install();
     ganon_special_n::install();
     koopa_special_n::install();
+    luigi_special_n::install();
+    mario_special_n::install();
     mariod_special_n::install();
     lucas_special_n::install();
     sonic::install();

--- a/fighters/kirby/src/status/luigi_special_n.rs
+++ b/fighters/kirby/src/status/luigi_special_n.rs
@@ -1,17 +1,17 @@
 use super::*;
 use globals::*;
 
-#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_MARIOD_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_LUIGI_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe extern "C" fn special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_GROUND) {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("luigi_special_n"), 0.0, 1.0, false, 0.0, false, false);
     }
     else {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("luigi_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
     }
 
     fighter.main_shift(special_n_main_loop)
@@ -25,8 +25,8 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
         }
     }
     if fighter.status_frame() == 10 && (ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-        VarModule::on_flag(fighter.object(), vars::kirby::status::CHILL_PILL);
-        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_air_n_chill") };
+        VarModule::on_flag(fighter.object(), vars::kirby::status::THUNDERHAND);
+        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("luigi_special_n_thunder") } else { Hash40::new("luigi_special_air_n_thunder") };
         MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
     }
     if !StatusModule::is_changing(fighter.module_accessor) {
@@ -34,13 +34,13 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             if fighter.is_situation(*SITUATION_KIND_GROUND) {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::THUNDERHAND) { Hash40::new("luigi_special_n_thunder") } else { Hash40::new("luigi_special_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
             else {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_air_n_chill") } else { Hash40::new("mariod_special_air_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::THUNDERHAND) { Hash40::new("luigi_special_air_n_thunder") } else { Hash40::new("luigi_special_air_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
         }

--- a/fighters/kirby/src/status/mario_special_n.rs
+++ b/fighters/kirby/src/status/mario_special_n.rs
@@ -1,17 +1,17 @@
 use super::*;
 use globals::*;
 
-#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_MARIOD_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_MARIO_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe extern "C" fn special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_GROUND) {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mario_special_n"), 0.0, 1.0, false, 0.0, false, false);
     }
     else {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mario_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
     }
 
     fighter.main_shift(special_n_main_loop)
@@ -25,8 +25,8 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
         }
     }
     if fighter.status_frame() == 10 && (ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-        VarModule::on_flag(fighter.object(), vars::kirby::status::CHILL_PILL);
-        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_air_n_chill") };
+        VarModule::on_flag(fighter.object(), vars::kirby::status::FIREBRAND);
+        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("mario_special_n_fire") } else { Hash40::new("mario_special_air_n_fire") };
         MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
     }
     if !StatusModule::is_changing(fighter.module_accessor) {
@@ -34,13 +34,13 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             if fighter.is_situation(*SITUATION_KIND_GROUND) {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::FIREBRAND) { Hash40::new("mario_special_n_fire") } else { Hash40::new("mario_special_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
             else {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_air_n_chill") } else { Hash40::new("mariod_special_air_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::FIREBRAND) { Hash40::new("mario_special_air_n_fire") } else { Hash40::new("mario_special_air_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
         }

--- a/fighters/luigi/src/acmd/specials.rs
+++ b/fighters/luigi/src/acmd/specials.rs
@@ -1,108 +1,54 @@
-
 use super::*;
 
-#[acmd_script( agent = "luigi", script = "game_specialn" , category = ACMD_GAME , low_priority)]
-unsafe fn game_specialn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["game_specialn", "game_specialairn"] , category = ACMD_GAME , low_priority)]
+unsafe fn luigi_special_n_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND);
-        VarModule::off_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_DOUBLE_FIREBALL);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            ATTACK(fighter, 0, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 2.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 2, 0, Hash40::new("shoulderl"), 9.0, 69, 55, 0, 65, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            //HIT_NODE(fighter, Hash40::new("head"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("handl"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("arml"), *HIT_STATUS_XLU);
-            FT_MOTION_RATE(fighter, 2.0);
-        }
-        else{
-            ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
-    }
-    wait(lua_state, 5.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND) && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
-            FT_MOTION_RATE(fighter, 0.5);
-        }
+        ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
     }
 
 }
 
-#[acmd_script( agent = "luigi", script = "effect_specialn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn effect_specialn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["effect_specialn", "effect_specialairn"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn luigi_special_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        }
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("havel"), 3.0, 0.0, 0.0, 0, 90, 90, 0.5, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("havel"), 0.0, 0.0, 0.0, 0, 90, 90, 0.8, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.25);
-            FLASH(fighter, 0, 0.25, 1.0, 0.7);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
-            FLASH(fighter, 0, 1, 0, 0.353);
-        }
+        EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
+        FLASH(fighter, 0, 1, 0, 0.353);
     }
     frame(lua_state, 19.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
-    frame(lua_state, 28.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder"), false, false);
-    }
-    frame(lua_state, 32.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_elec_s"), true, true);
-    }
     frame(lua_state, 37.0);
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("luigi_fb_shoot"), false, false);
     }
+
 }
 
-#[acmd_script( agent = "luigi", script = "sound_specialn" , category = ACMD_SOUND , low_priority)]
-unsafe fn sound_specialn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["sound_specialn", "sound_specialairn"] , category = ACMD_SOUND , low_priority)]
+unsafe fn luigi_special_n_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("se_common_elec_s_damage"));
-        }
-    }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("vc_luigi_attack07"));
-            PLAY_SE(fighter, Hash40::new("se_common_elec_m_damage"));
-        }
-        else{
-            PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
-        }
+        PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
     }
+
 }
 
 #[acmd_script( agent = "luigi", scripts = ["expression_specialn", "expression_specialairn"], category = ACMD_EXPRESSION, low_priority )]
-unsafe fn expression_specialn(fighter: &mut L2CAgentBase) {
+unsafe fn luigi_special_n_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
@@ -110,113 +56,90 @@ unsafe fn expression_specialn(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if !VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            ControlModule::set_rumble(boma, Hash40::new("rbkind_explosion"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
-        }
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_explosion"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            macros::RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
-            ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
-        }
-    }
+
 }
 
-#[acmd_script( agent = "luigi", script = "game_specialairn" , category = ACMD_GAME , low_priority)]
-unsafe fn game_specialairn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["game_specialnthunder", "game_specialairnthunder"] , category = ACMD_GAME , low_priority)]
+unsafe fn luigi_special_n_thunder_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        VarModule::off_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND);
-        VarModule::off_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_DOUBLE_FIREBALL);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND);
-        }
-    }
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            ATTACK(fighter, 0, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 69, 55, 0, 65, 4.5, 2.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 2, 0, Hash40::new("shoulderl"), 9.0, 69, 55, 0, 65, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_PUNCH);
-            //HIT_NODE(fighter, Hash40::new("head"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("handl"), *HIT_STATUS_XLU);
-            //HIT_NODE(fighter, Hash40::new("arml"), *HIT_STATUS_XLU);
-            FT_MOTION_RATE(fighter, 2.0);
-        }
-        else{
-            ArticleModule::generate_article(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 68, 55, 0, 65, 5.0, 0.0, 9.0, 8.0, None, None, None, 0.6, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 9.0, 68, 55, 0, 65, 3.0, 0.0, 9.0, 2.0, None, None, None, 0.6, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_paralyze"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MAGIC, *ATTACK_REGION_PUNCH);
     }
-    wait(lua_state, 5.0);
+    frame(lua_state, 21.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
-        HitModule::set_status_all(boma, app::HitStatus(*HIT_STATUS_NORMAL), 0);
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND) && AttackModule::is_infliction_status(boma, *COLLISION_KIND_MASK_HIT) {
-            FT_MOTION_RATE(fighter, 0.5);
-        }
     }
-
 }
 
-#[acmd_script( agent = "luigi", script = "effect_specialairn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn effect_specialairn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["effect_specialnthunder", "effect_specialairnthunder"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn luigi_special_n_thunder_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 5, 15, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+    }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("havel"), 3.0, 0.0, 0.0, 0, 90, 90, 0.5, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_thunder"), Hash40::new("havel"), 0.0, 0.0, 0.0, 0, 90, 90, 0.8, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.25);
-            FLASH(fighter, 0, 0.25, 1.0, 0.7);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("luigi_fb_shoot"), Hash40::new("havel"), 0, 0, 0, -30, 0, 0, 1, true);
-            FLASH(fighter, 0, 1, 0, 0.353);
+        let mut rand = &Vector3f::new(
+            app::sv_math::rand(hash40("fighter"), 50) as f32,
+            app::sv_math::rand(hash40("stage"), 50) as f32,
+            app::sv_math::rand(hash40("luigi"), 50) as f32
+        );
+        let mut flip = &Vector3f::new(
+            if app::sv_math::rand(hash40("fighter"), 1) == 0 { -1 } else { 1 } as f32,
+            if app::sv_math::rand(hash40("stage"), 1) == 0 { -1 } else { 1 } as f32,
+            if app::sv_math::rand(hash40("luigi"), 1) == 0 { -1 } else { 1 } as f32
+        );
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 9.0, 8.0, 0.0 + (rand.x * flip.x), 0, 0, 0.5, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 9.0, 8.0, 120.0 + (rand.y * flip.y), 0, 0, 0.5, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_mball_beam"), Hash40::new("top"), 0.0, 9.0, 8.0, 240.0 + (rand.z * flip.z), 0, 0, 0.5, true);
+    }
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        FLASH(fighter, 0, 0.25, 1.0, 0.7);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_elec_s"), Hash40::new("top"), 0.0, 9.0, 8.0, 0, 90, 90, 0.4, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_sp_flash"), Hash40::new("top"), 0.0, 9.0, 8.0, 0, 90, 90, 0.5, true);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
         }
     }
-    frame(lua_state, 19.0);
+    frame(lua_state, 20.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
-    frame(lua_state, 28.0);
+}
+
+#[acmd_script( agent = "luigi", scripts = ["sound_specialnthunder", "sound_specialairnthunder"], category = ACMD_SOUND, low_priority )]
+unsafe fn luigi_special_n_thunder_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 17.0);
     if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_thunder"), false, false);
-    }
-    frame(lua_state, 32.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_elec_s"), true, true);
-    }
-    frame(lua_state, 37.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("luigi_fb_shoot"), false, false);
+        PLAY_SE(fighter, Hash40::new("vc_luigi_attack07"));
+        PLAY_SE(fighter, Hash40::new("se_common_electric_hit_l"));
     }
 }
 
-#[acmd_script( agent = "luigi", script = "sound_specialairn" , category = ACMD_SOUND , low_priority)]
-unsafe fn sound_specialairn(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "luigi", scripts = ["expression_specialnthunder", "expression_specialairnthunder"], category = ACMD_EXPRESSION, low_priority )]
+unsafe fn luigi_special_n_thunder_expression(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 12.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("se_common_elec_s_damage"));
-        }
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            PLAY_SE(fighter, Hash40::new("vc_luigi_attack07"));
-            PLAY_SE(fighter, Hash40::new("se_common_elec_m_damage"));
-        }
-        else{
-            PLAY_SE(fighter, Hash40::new("se_luigi_special_n01"));
-        }
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
 }
 
@@ -527,27 +450,24 @@ unsafe fn game_specialairhi(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
-        game_specialn,
-        game_specialairn,
+        luigi_special_n_game,
+        luigi_special_n_effect,
+        luigi_special_n_sound,
+        luigi_special_n_expression,
+        luigi_special_n_thunder_game,
+        luigi_special_n_thunder_effect,
+        luigi_special_n_thunder_sound,
+        luigi_special_n_thunder_expression,
         game_specialairsstart,
         game_specials,
-        game_specialsdischarge,
-        game_specialairsend,
-        game_speciallw,
-        game_specialairlw,
-        game_specialhi,
-        game_specialairhi,
-
-        effect_specialn,
-        effect_specialairn,
         effect_specialshold,
         effect_specialairshold,
+        game_specialsdischarge,
         effect_specialsdischarge,
-
-        sound_specialn,
-        sound_specialairn,
-
-        expression_specialn,
+        game_specialairsend,
+        game_specialhi,
+        game_specialairhi,
+        game_speciallw,
+        game_specialairlw,
     );
 }
-

--- a/fighters/luigi/src/status.rs
+++ b/fighters/luigi/src/status.rs
@@ -1,4 +1,5 @@
 use super::*;
+mod special_n;
 
 #[status_script(agent = "luigi", status = FIGHTER_LUIGI_STATUS_KIND_SPECIAL_S_CHARGE, condition = LUA_SCRIPT_STATUS_FUNC_INIT_STATUS)]
 unsafe fn special_s_charge_init(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -137,4 +138,5 @@ pub fn install() {
         special_s_charge_end,
         special_s_charge_exit
     );
+    special_n::install();
 }

--- a/fighters/luigi/src/status/special_n.rs
+++ b/fighters/luigi/src/status/special_n.rs
@@ -1,17 +1,17 @@
 use super::*;
 use globals::*;
 
-#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_MARIOD_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+#[status_script(agent = "luigi", status = FIGHTER_STATUS_KIND_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe extern "C" fn special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_GROUND) {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_n"), 0.0, 1.0, false, 0.0, false, false);
     }
     else {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_air_n"), 0.0, 1.0, false, 0.0, false, false);
     }
 
     fighter.main_shift(special_n_main_loop)
@@ -25,8 +25,8 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
         }
     }
     if fighter.status_frame() == 10 && (ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-        VarModule::on_flag(fighter.object(), vars::kirby::status::CHILL_PILL);
-        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_air_n_chill") };
+        VarModule::on_flag(fighter.object(), vars::luigi::status::THUNDERHAND);
+        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("special_n_thunder") } else { Hash40::new("special_air_n_thunder") };
         MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
     }
     if !StatusModule::is_changing(fighter.module_accessor) {
@@ -34,13 +34,13 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             if fighter.is_situation(*SITUATION_KIND_GROUND) {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::luigi::status::THUNDERHAND) { Hash40::new("special_n_thunder") } else { Hash40::new("special_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
             else {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_air_n_chill") } else { Hash40::new("mariod_special_air_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::luigi::status::THUNDERHAND) { Hash40::new("special_air_n_thunder") } else { Hash40::new("special_air_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
         }

--- a/fighters/mario/src/acmd/specials.rs
+++ b/fighters/mario/src/acmd/specials.rs
@@ -1,176 +1,70 @@
+use smash::app::sv_animcmd::QUAKE;
 
 use super::*;
 
-#[acmd_script( agent = "mario", script = "game_specialn" , category = ACMD_GAME , low_priority)]
+#[acmd_script( agent = "mario", scripts = ["game_specialn", "game_specialairn"] , category = ACMD_GAME , low_priority)]
 unsafe fn mario_special_n_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 16.0/(14.0-1.0));
-        VarModule::off_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-            VarModule::on_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND);
-            FT_MOTION_RATE(fighter, 3.0/(14.0-12.0));
-        }
-    }
+    frame(lua_state, 10.0);
+    FT_MOTION_RATE_RANGE(fighter, 10.0, 14.0, 8.0);
     frame(lua_state, 14.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 12.0, 50, 110, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 12.0, 50, 115, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-        else {
-            ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
-    }
-    wait(lua_state, 2.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 9.0, 40, 100, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 40, 100, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
+        ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
     }
     frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            AttackModule::clear_all(boma);
-            FT_MOTION_RATE(fighter, 32.0/(49.0 - 21.0));
-        }
-        else {
-            FT_MOTION_RATE(fighter, 23.0/(49.0 - 21.0));
-        }
-    }
+    FT_MOTION_RATE_RANGE(fighter, 21.0, 49.0, 23.0);
+    frame(lua_state, 49.0);
+    FT_MOTION_RATE(fighter, 1.0);
 
 }
 
-#[acmd_script( agent = "mario", script = "effect_specialn" , category = ACMD_EFFECT , low_priority)]
+#[acmd_script( agent = "mario", scripts = ["effect_specialn", "effect_specialairn"] , category = ACMD_EFFECT , low_priority)]
 unsafe fn mario_special_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 2.0);
     if is_excute(fighter) {
-        LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
-    }
-    frame(lua_state, 11.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
-            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
         }
     }
     frame(lua_state, 13.0);
     if is_excute(fighter) {
-        if PostureModule::lr(boma) > 0.0{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1.0, true);
+        if PostureModule::lr(boma) > 0.0 {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1, true);
         }
-        else{
+        else {
             EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 1, true);
-        }
-
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handl"), 1.0, 0, 0, 0, 0, 0, 0.3, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("havel"), 1.0, 0, 0, 0, 0, 0, 0.23, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.2);
-            EffectModule::enable_sync_init_pos_last(boma);
         }
     }
     frame(lua_state, 15.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-        else{
-            FLASH(fighter, 1, 0, 0, 0.353);
-        }
+        FLASH(fighter, 1, 0, 0, 0.353);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.75);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
-        }
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
     frame(lua_state, 27.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.35);
-        }
-        else{
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.75);
-        }
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.35);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
-        }
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.35);
-        }
+        COL_NORMAL(fighter);
     }
     frame(lua_state, 40.0);
     if is_excute(fighter) {
         EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
     }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
+
 }
 
-#[acmd_script( agent = "mario", script = "sound_specialn" , category = ACMD_SOUND , low_priority)]
+#[acmd_script( agent = "mario", scripts = ["sound_specialn", "sound_specialairn"] , category = ACMD_SOUND , low_priority)]
 unsafe fn mario_special_n_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     frame(lua_state, 13.0);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            PLAY_SE(fighter, Hash40::new("se_mario_smash_s01"));
-            PLAY_SE(fighter, Hash40::new("vc_mario_attack07"));
-        }
     }
 }
 
@@ -183,97 +77,73 @@ unsafe fn mario_special_n_expression(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 14.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::luigi::status::IS_SPECIAL_N_FIREBRAND){
-            macros::RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
-            ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
-        } else {
-            ControlModule::set_rumble(boma, Hash40::new("rbkind_explosion"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
-        }
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_explosion"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
 }
 
-#[acmd_script( agent = "mario", script = "game_specialairn" , category = ACMD_GAME , low_priority)]
-unsafe fn mario_special_air_n_game(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "mario", scripts = ["game_specialnfire", "game_specialairnfire"] , category = ACMD_GAME , low_priority)]
+unsafe fn mario_special_n_fire_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 16.0/(14.0-1.0));
-        VarModule::off_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND);
-    }
-    frame(lua_state, 12.0);
-    if is_excute(fighter) {
-        if (ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(boma, *CONTROL_PAD_BUTTON_SPECIAL_RAW)){
-            VarModule::on_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND);
-            FT_MOTION_RATE(fighter, 3.0/(14.0-12.0));
-        }
-    }
+    frame(lua_state, 10.0);
+    FT_MOTION_RATE_RANGE(fighter, 10.0, 11.0, 7.0);
+    frame(lua_state, 11.0);
+    FT_MOTION_RATE(fighter, 1.0);
     frame(lua_state, 14.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 12.0, 50, 110, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 12.0, 50, 115, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
-        else {
-            ArticleModule::generate_article(boma, *FIGHTER_MARIO_GENERATE_ARTICLE_FIREBALL, false, 0);
-        }
+        KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(-0.5, 0.0, 0.0));
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 14.0, 50, 101, 0, 52, 3.0, 0.0, 6.5, 4.5, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 14.0, 50, 101, 0, 52, 5.0, 0.0, 7.5, 10.5, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
     }
-    wait(lua_state, 2.0);
+    frame(lua_state, 16.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 9.0, 40, 100, 0, 50, 3.0, 0.5, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("arml"), 9.0, 40, 100, 0, 50, 5.5, 5.2, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
-            FT_MOTION_RATE(fighter, 1.0);
-        }
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 9.0, 40, 100, 0, 50, 3.0, 0.0, 6.5, 4.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 9.0, 40, 100, 0, 50, 5.0, 0.0, 7.5, 10.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 21.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            AttackModule::clear_all(boma);
-            FT_MOTION_RATE(fighter, 32.0/(49.0 - 21.0));
-        }
-        else {
-            FT_MOTION_RATE(fighter, 23.0/(49.0 - 21.0));
-        }
+        AttackModule::clear_all(boma);
     }
 }
 
-#[acmd_script( agent = "mario", script = "effect_specialairn" , category = ACMD_EFFECT , low_priority)]
-unsafe fn mario_special_air_n_effect(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "mario", scripts = ["effect_specialnfire", "effect_specialairnfire"] , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_special_n_fire_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
+    frame(lua_state, 10.5);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 6, 11, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
+    }
     frame(lua_state, 11.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
+        if PostureModule::lr(boma) > 0.0 {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 0.7, true);
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("haver"), 0, 0, 0, 0, 45, 0, 0.7, true);
+        }
+        else {
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 0.7, true);
+            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("haver"), 0, 0, 0, 0, -45, 0, 0.7, true);
+        }
+    }
+    frame(lua_state, 12.0);
+    if is_excute(fighter) {
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
             EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
             LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
         }
     }
-    frame(lua_state, 13.0);
-    if is_excute(fighter) {
-        if PostureModule::lr(boma) > 0.0{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, 45, 0, 1.0, true);
-        }
-        else{
-            EFFECT_FOLLOW(fighter, Hash40::new("mario_fb_shoot"), Hash40::new("havel"), 0, 0, 0, 0, -45, 0, 1, true);
-        }
-    }
     frame(lua_state, 14.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("havel"), 1.0, 0, 0, 0, 0, 0, 0.3, true);
-            EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("handl"), 1.0, 0, 0, 0, 0, 0, 0.23, true);
-            LAST_EFFECT_SET_RATE(fighter, 1.2);
-            EffectModule::enable_sync_init_pos_last(boma);
-        }
-    }
-    frame(lua_state, 15.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
-        else{
-            FLASH(fighter, 1, 0, 0, 0.35);
+        FLASH(fighter, 1, 0, 0, 0.35);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handl"), 1.0, 0, 0, 0, 0, 0, 0.2, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_flame"), Hash40::new("handr"), 1.0, 0, 0, 0, 0, 0, 0.2, true);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_bomb_a"), Hash40::new("top"), 0, 7.5, 10.5, 0, 0, 0, 0.26, true);
+        LAST_EFFECT_SET_RATE(fighter, 1.2);
+        EffectModule::enable_sync_init_pos_last(boma);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
         }
     }
     frame(lua_state, 17.0);
@@ -282,80 +152,46 @@ unsafe fn mario_special_air_n_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 18.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 1.0);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
-        }
+        FLASH(fighter, 1, 0, 0, 0.75);
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_bomb_a"), false, false);
     }
     frame(lua_state, 21.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
+        FLASH(fighter, 1, 0, 0, 0.35);
     }
     frame(lua_state, 24.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.5);
-        }
-        else{
-            COL_NORMAL(fighter);
-        }
+        COL_NORMAL(fighter);
     }
     frame(lua_state, 30.0);
     if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 1.0);
-        }
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 0.95, 0.522, 0.051, 0.5);
-            EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
-        }
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            FLASH(fighter, 1, 0, 0, 0.5);
-        }
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_flame"), false, false);
         EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
-    }
-    frame(lua_state, 42.0);
-    if is_excute(fighter) {
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            COL_NORMAL(fighter);
-        }
     }
 }
 
-#[acmd_script( agent = "mario", script = "sound_specialairn" , category = ACMD_SOUND , low_priority)]
-unsafe fn mario_special_air_n_sound(fighter: &mut L2CAgentBase) {
+#[acmd_script( agent = "mario", scripts = ["sound_specialnfire", "sound_specialairnfire"], category = ACMD_SOUND, low_priority )]
+unsafe fn mario_special_n_fire_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 13.0);
+    frame(lua_state, 14.0);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_mario_special_n01"));
-        if VarModule::is_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND) {
-            PLAY_SE(fighter, Hash40::new("se_mario_smash_s01"));
-            PLAY_SE(fighter, Hash40::new("vc_mario_attack07"));
-        }
+        PLAY_SE(fighter, Hash40::new("se_common_bomb_l"));
+        PLAY_SE(fighter, Hash40::new("vc_mario_attack07"));
+    }
+}
+
+#[acmd_script( agent = "mario", scripts = ["expression_specialnfire", "expression_specialairnfire"], category = ACMD_EXPRESSION, low_priority )]
+unsafe fn mario_special_n_fire_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }
 }
 
@@ -830,9 +666,10 @@ pub fn install() {
         mario_special_n_effect,
         mario_special_n_sound,
         mario_special_n_expression,
-        mario_special_air_n_game,
-        mario_special_air_n_effect,
-        mario_special_air_n_sound,
+        mario_special_n_fire_game,
+        mario_special_n_fire_effect,
+        mario_special_n_fire_sound,
+        mario_special_n_fire_expression,
         mario_special_s_game,
         mario_special_air_s_game,
         mario_special_lw_light,
@@ -847,4 +684,3 @@ pub fn install() {
         mario_special_air_hi_effect,
     );
 }
-

--- a/fighters/mario/src/opff.rs
+++ b/fighters/mario/src/opff.rs
@@ -120,18 +120,18 @@ unsafe fn dspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i
 }
 
 // Double fireball handling
-unsafe fn double_fireball(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    if boma.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) && VarModule::is_flag(boma.object(), vars::mario::instance::CAN_INPUT_SPECIAL_N_DOUBLE_FIREBALL) {
-        let restart_frame = 10.0;
-        if boma.is_cat_flag(Cat1::SpecialN) || boma.is_cat_flag(Cat1::SpecialS) || boma.is_cat_flag(Cat1::SpecialHi) || boma.is_cat_flag(Cat1::SpecialLw){
-            VarModule::off_flag(fighter.battle_object, vars::mario::status::IS_SPECIAL_N_FIREBRAND);
-            VarModule::off_flag(boma.object(), vars::mario::instance::CAN_INPUT_SPECIAL_N_DOUBLE_FIREBALL);
-            VarModule::on_flag(boma.object(), vars::mario::instance::SPECIAL_N_DOUBLE_FIREBALL_NOTIFY_FLAG);
-            //MotionModule::set_frame_sync_anim_cmd(boma, restart_frame, true, true, false);
-            boma.change_status_req(*FIGHTER_STATUS_KIND_SPECIAL_N, false);
-        }
-    }
-}
+// unsafe fn double_fireball(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+//     if boma.is_status(*FIGHTER_STATUS_KIND_SPECIAL_N) && VarModule::is_flag(boma.object(), vars::mario::instance::CAN_INPUT_SPECIAL_N_DOUBLE_FIREBALL) {
+//         let restart_frame = 10.0;
+//         if boma.is_cat_flag(Cat1::SpecialN) || boma.is_cat_flag(Cat1::SpecialS) || boma.is_cat_flag(Cat1::SpecialHi) || boma.is_cat_flag(Cat1::SpecialLw){
+//             VarModule::off_flag(fighter.battle_object, vars::mario::status::FIREBRAND);
+//             VarModule::off_flag(boma.object(), vars::mario::instance::CAN_INPUT_SPECIAL_N_DOUBLE_FIREBALL);
+//             VarModule::on_flag(boma.object(), vars::mario::instance::SPECIAL_N_DOUBLE_FIREBALL_NOTIFY_FLAG);
+//             //MotionModule::set_frame_sync_anim_cmd(boma, restart_frame, true, true, false);
+//             boma.change_status_req(*FIGHTER_STATUS_KIND_SPECIAL_N, false);
+//         }
+//     }
+// }
 
 // Once down special is called, imediately uses special low shoot and circumvent the charge mechanic of the og down-b
 unsafe fn galaxy_spin_poc(fighter: &mut L2CFighterCommon ,boma: &mut BattleObjectModuleAccessor, status_kind: i32) {

--- a/fighters/mario/src/status.rs
+++ b/fighters/mario/src/status.rs
@@ -1,6 +1,7 @@
 use super::*;
 use globals::*;
 
+mod special_n;
 
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
     // Reset cape stall flag on landing or ledgegrab
@@ -22,16 +23,5 @@ fn mario_init(fighter: &mut L2CFighterCommon) {
 
 pub fn install() {
     smashline::install_agent_init_callbacks!(mario_init);
-    install_status_scripts!(
-        //mario_special_lw_shoot_main,
-    );
-}
-
-
-#[status_script(agent = "mario", status = FIGHTER_MARIO_STATUS_KIND_SPECIAL_LW_SHOOT, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
-pub unsafe fn mario_special_lw_shoot_main(fighter: &mut L2CFighterCommon) -> L2CValue{
-    let lua_state = fighter.lua_state_agent;
-    let boma = fighter.boma();
-
-    return 0.into();
+    special_n::install();
 }

--- a/fighters/mario/src/status/special_n.rs
+++ b/fighters/mario/src/status/special_n.rs
@@ -1,17 +1,17 @@
 use super::*;
 use globals::*;
 
-#[status_script(agent = "kirby", status = FIGHTER_KIRBY_STATUS_KIND_MARIOD_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
+#[status_script(agent = "mario", status = FIGHTER_STATUS_KIND_SPECIAL_N, condition = LUA_SCRIPT_STATUS_FUNC_STATUS_MAIN)]
 unsafe extern "C" fn special_n_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_GROUND) {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_n"), 0.0, 1.0, false, 0.0, false, false);
     }
     else {
         GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
         KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
-        MotionModule::change_motion(fighter.module_accessor, Hash40::new("mariod_special_air_n"), 0.0, 1.0, false, 0.0, false, false);
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_air_n"), 0.0, 1.0, false, 0.0, false, false);
     }
 
     fighter.main_shift(special_n_main_loop)
@@ -25,8 +25,8 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
         }
     }
     if fighter.status_frame() == 10 && (ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
-        VarModule::on_flag(fighter.object(), vars::kirby::status::CHILL_PILL);
-        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_air_n_chill") };
+        VarModule::on_flag(fighter.object(), vars::mario::status::FIREBRAND);
+        let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("special_n_fire") } else { Hash40::new("special_air_n_fire") };
         MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
     }
     if !StatusModule::is_changing(fighter.module_accessor) {
@@ -34,13 +34,13 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             if fighter.is_situation(*SITUATION_KIND_GROUND) {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_n_chill") } else { Hash40::new("mariod_special_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::mario::status::FIREBRAND) { Hash40::new("special_n_fire") } else { Hash40::new("special_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
             else {
                 GroundModule::correct(fighter.module_accessor, smash::app::GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
                 KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_AIR_STOP);
-                let motion = if VarModule::is_flag(fighter.object(), vars::kirby::status::CHILL_PILL) { Hash40::new("mariod_special_air_n_chill") } else { Hash40::new("mariod_special_air_n") };
+                let motion = if VarModule::is_flag(fighter.object(), vars::mario::status::FIREBRAND) { Hash40::new("special_air_n_fire") } else { Hash40::new("special_air_n") };
                 MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
             }
         }

--- a/fighters/mariod/src/acmd/specials.rs
+++ b/fighters/mariod/src/acmd/specials.rs
@@ -47,17 +47,14 @@ unsafe fn mariod_special_n_sound(fighter: &mut L2CAgentBase) {
 unsafe fn mariod_special_n_chill_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 10.0);
-    FT_MOTION_RATE_RANGE(fighter, 10.0, 14.0, 5.0);
-    frame(lua_state, 14.0);
     FT_MOTION_RATE(fighter, 1.0);
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
-        ATTACK(fighter, 0, 0, Hash40::new("shoulderl"), 10.0, 69, 90, 0, 50, 3.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("arml"), 10.0, 69, 90, 0, 50, 4.5, 4.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 2, 0, Hash40::new("arml"), 10.0, 69, 90, 0, 50, 4.5, 6.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 69, 84, 0, 42, 3.5, 0.0, 6.5, 4.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 69, 84, 0, 42, 4.75, 0.0, 4.0, 7.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_ice"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIOD_CAPSULE, *ATTACK_REGION_PUNCH);
     }
-    frame(lua_state, 18.0);
-    FT_MOTION_RATE_RANGE(fighter, 18.0, 43.0, 37.0);
+    frame(lua_state, 19.0);
+    FT_MOTION_RATE_RANGE(fighter, 19.0, 43.0, 36.0);
     if is_excute(fighter) {
         AttackModule::clear_all(boma);
     }
@@ -69,68 +66,27 @@ unsafe fn mariod_special_n_chill_game(fighter: &mut L2CAgentBase) {
 unsafe fn mariod_special_n_chill_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 2.0);
+    frame(lua_state, 12.0);
     if is_excute(fighter) {
-        if fighter.is_situation(*SITUATION_KIND_GROUND) {
-            LANDING_EFFECT(fighter, Hash40::new("sys_action_smoke_h"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0, 0, false);
-        }
-    }
-    frame(lua_state, 14.0);
-    if is_excute(fighter) {
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_ice"), Hash40::new("arml"), 7.5, 0, 0, 0, 0, 0, 0.35, true);
-        LAST_EFFECT_SET_RATE(fighter, 1.5);
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_ice_landing"), Hash40::new("arml"), 7.5, 0, 0, 0, 0, 0, 0.75, true);
-        LAST_EFFECT_SET_RATE(fighter, 0.75);
-        EffectModule::enable_sync_init_pos_last(boma);
-        EFFECT_FLIP(fighter, Hash40::new("mariod_capsule_shoot"), Hash40::new("mariod_capsule_shoot"), Hash40::new("top"), -1, 8, 11, 0, 0, 0, 0.46, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
-        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash"), Hash40::new("sys_smash_flash"), Hash40::new("top"), -1, 8, 11, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
-        if fighter.is_situation(*SITUATION_KIND_GROUND) {
-            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), -1, 0, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 0, false);
-        }
+        EFFECT(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("top"), 8, 11, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
     }
     frame(lua_state, 15.0);
     if is_excute(fighter) {
         FLASH(fighter, 0.5, 0.25, 1, 0.35);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_hit_ice"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.35, true);
+        LAST_EFFECT_SET_RATE(fighter, 1.5);
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_ice_landing"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.75, true);
+        LAST_EFFECT_SET_RATE(fighter, 0.75);
+        EffectModule::enable_sync_init_pos_last(boma);
+        EFFECT_FLIP(fighter, Hash40::new("mariod_capsule_shoot"), Hash40::new("mariod_capsule_shoot"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.46, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash"), Hash40::new("sys_smash_flash"), Hash40::new("top"), 0, 4, 7, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+        if fighter.is_situation(*SITUATION_KIND_GROUND) {
+            EFFECT_FOLLOW(fighter, Hash40::new("sys_h_smoke_b"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.5, true);
+            LAST_EFFECT_SET_COLOR(fighter, 0.2, 0.2, 0.2);
+            LANDING_EFFECT(fighter, Hash40::new("sys_atk_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
     }
-    frame(lua_state, 18.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.5, 0.25, 1, 0.75);
-    }
-    frame(lua_state, 21.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.5, 0.25, 1, 0.35);
-    }
-    frame(lua_state, 24.0);
-    if is_excute(fighter) {
-        COL_NORMAL(fighter);
-    }
-    frame(lua_state, 27.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
-    }
-    frame(lua_state, 30.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.75);
-    }
-    frame(lua_state, 33.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
-    }
-    frame(lua_state, 36.0);
-    if is_excute(fighter) {
-        COL_NORMAL(fighter);
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_hit_ice"), false, true);
-        EFFECT_OFF_KIND(fighter, Hash40::new("sys_ice_landing"), false, true);
-    }
-    frame(lua_state, 39.0);
-    if is_excute(fighter) {
-        FLASH(fighter, 0.75, 0.75, 1.0, 0.35);
-    }
-    frame(lua_state, 40.0);
-    if is_excute(fighter) {
-        EFFECT_OFF_KIND(fighter, Hash40::new("mario_fb_shoot"), false, false);
-    }
-    frame(lua_state, 42.0);
+    frame(lua_state, 19.0);
     if is_excute(fighter) {
         COL_NORMAL(fighter);
     }
@@ -140,10 +96,10 @@ unsafe fn mariod_special_n_chill_effect(fighter: &mut L2CAgentBase) {
 unsafe fn mariod_special_n_chill_sound(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 14.0);
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
         PLAY_SE(fighter, Hash40::new("se_common_frieze_l"));
-        PLAY_SE(fighter, Hash40::new("vc_mariod_012")); //vc_mariod_win02_02
+        PLAY_SE(fighter, Hash40::new("vc_mariod_012"));
     }
 }
 
@@ -154,7 +110,7 @@ unsafe fn mariod_special_n_chill_expression(fighter: &mut L2CAgentBase) {
     if is_excute(fighter) {
         slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
     }
-    frame(lua_state, 14.0);
+    frame(lua_state, 15.0);
     if is_excute(fighter) {
         ControlModule::set_rumble(boma, Hash40::new("rbkind_55_smash"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
     }

--- a/fighters/mariod/src/status/special_n.rs
+++ b/fighters/mariod/src/status/special_n.rs
@@ -24,13 +24,11 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             return 1.into();
         }
     }
-
     if fighter.status_frame() == 10 && (ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL) || ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_SPECIAL_RAW)) {
         VarModule::on_flag(fighter.object(), vars::mariod::status::CHILL_PILL);
         let motion = if fighter.is_situation(*SITUATION_KIND_GROUND) { Hash40::new("special_n_chill") } else { Hash40::new("special_air_n_chill") };
         MotionModule::change_motion_inherit_frame(fighter.module_accessor, motion, -1.0, 1.0, 0.0, false, false);
     }
-
     if !StatusModule::is_changing(fighter.module_accessor) {
         if StatusModule::is_situation_changed(fighter.module_accessor) {
             if fighter.is_situation(*SITUATION_KIND_GROUND) {
@@ -47,7 +45,6 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             }
         }
     }
-
     if MotionModule::is_end(fighter.module_accessor) {
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
             StatusModule::change_status_request_from_script(fighter.module_accessor, *FIGHTER_STATUS_KIND_WAIT, false);
@@ -56,6 +53,7 @@ unsafe extern "C" fn special_n_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
             StatusModule::change_status_request_from_script(fighter.module_accessor, *FIGHTER_STATUS_KIND_FALL, false);
         }
     }
+
     return 0.into()
 }
 

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -473,9 +473,125 @@ luigi_special_n:
 luigi_special_air_n:
   extra:
     cancel_frame: 41
+luigi_special_n_thunder:
+  game_script: game_luigispecialnthunder
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: luigid00specialnthunder.nuanmb
+  scripts:
+  - expression_luigispecialnthunder
+  - sound_luigispecialnthunder
+  - effect_luigispecialnthunder
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 55
+    freeze_during_hitstop: false
+luigi_special_air_n_thunder:
+  game_script: game_luigispecialairnthunder
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: luigid00specialairnthunder.nuanmb
+  scripts:
+  - expression_luigispecialairnthunder
+  - sound_luigispecialairnthunder
+  - effect_luigispecialairnthunder
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 55
+    freeze_during_hitstop: false
 mario_special_n:
   extra:
     cancel_frame: 41
+mario_special_n_fire:
+  game_script: game_mariospecialnfire
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: mariod00specialnfire.nuanmb
+  scripts:
+  - expression_mariospecialnfire
+  - sound_mariospecialnfire
+  - effect_mariospecialnfire
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 46
+    freeze_during_hitstop: false
+mario_special_air_n_fire:
+  game_script: game_mariospecialairnfire
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: mariod00specialairnfire.nuanmb
+  scripts:
+  - expression_mariospecialairnfire
+  - sound_mariospecialairnfire
+  - effect_mariospecialairnfire
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 46
+    freeze_during_hitstop: false
 mariod_special_n:
   extra:
     cancel_frame: 47

--- a/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
@@ -17,6 +17,9 @@ catch_l:
 special_n:
   extra:
     cancel_frame: 41
+special_air_n:
+  extra:
+    cancel_frame: 41
 attack_13:
   extra:
     cancel_frame: 23
@@ -72,13 +75,68 @@ attack_s3_hi:
 attack_air_lw:
   extra:
     cancel_frame: 32
-special_air_n:
-  extra:
-    cancel_frame: 41
 attack_air_hi:
   extra:
     cancel_frame: 30
 attack_hi4_hold:
+special_n_thunder:
+  game_script: game_specialnthunder
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: d00specialnthunder.nuanmb
+  scripts:
+  - expression_specialnthunder
+  - sound_specialnthunder
+  - effect_specialnthunder
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 55
+    freeze_during_hitstop: false
+special_air_n_thunder:
+  game_script: game_specialairnthunder
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: d00specialairnthunder.nuanmb
+  scripts:
+  - expression_specialairnthunder
+  - sound_specialairnthunder
+  - effect_specialairnthunder
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 55
+    freeze_during_hitstop: false
 special_air_s_end:
   extra:
     cancel_frame: 36

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -71,6 +71,64 @@ landing_air_lw:
 attack_air_hi:
   extra:
     cancel_frame: 30
+special_n_fire:
+  game_script: game_specialnfire
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: d00specialnfire.nuanmb
+  scripts:
+  - expression_specialnfire
+  - sound_specialnfire
+  - effect_specialnfire
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 46
+    freeze_during_hitstop: false
+special_air_n_fire:
+  game_script: game_specialairnfire
+  flags:
+    turn: false
+    loop: false
+    move: false
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: d00specialairnfire.nuanmb
+  scripts:
+  - expression_specialairnfire
+  - sound_specialairnfire
+  - effect_specialairnfire
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 46
+    freeze_during_hitstop: false
 special_lw_light:
     game_script: game_speciallwlight
     flags:

--- a/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
@@ -85,7 +85,7 @@ special_n_chill:
     unk_2000: false
   blend_frames: 0
   animations:
-  - name: d00specialn.nuanmb
+  - name: d00specialnchill.nuanmb
   scripts:
   - expression_specialnchill
   - sound_specialnchill
@@ -114,7 +114,7 @@ special_air_n_chill:
     unk_2000: false
   blend_frames: 0
   animations:
-  - name: d00specialairn.nuanmb
+  - name: d00specialairnchill.nuanmb
   scripts:
   - expression_specialairnchill
   - sound_specialairnchill


### PR DESCRIPTION
Assets: [assets-brands.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14047325/assets-brands.zip)

## Mario
### Firebrand
 - (!) Given a new animation based on Superstar Saga
 - (!) Pushes Mario backwards very slightly
 - [+] Orb hitbox moved outward
 - Early
   - [+] Damage: 12.0% -> 14.0%
   - [=] BKB: 50 -> 52
   - [=] KBG: 115 -> 101
   - [/] Hitlag Multiplier: 1.2x -> 1.1x
   - [-] Hitbox Size (orb): 5.5u -> 5.0u
 - Late
   - [-] Hitbox Size (orb): 5.5u -> 5.0u

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/6aa09cd4-916c-4c50-a0c1-de4d34b56f02


## Luigi
### Thunderhand
 - (!) Given a new animation based on Superstar Saga
 - (!) Paralyzes opponents
 - Hitbox Duration: F17-20
 - Damage: 9.0%
 - Angle: 68
 - BKB: 65
 - KBG: 55
 - Hitlag Multiplier: 0.6x
 - SDI Multiplier: 0.5x
 - Hitbox Size (arm/hand): 3.0/5.0u
 - FAF: 55

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/6c1a4ff5-faf3-4b4e-bc4e-4f6fa1d91de5


## Dr. Mario
### Chill Pill
 - (!) Given a new animation
 - [R] Hand hitbox lowered
 - [+] Damage: 10.0% -> 12.0%
 - [/] BKB: 50 -> 42
 - [/] KBG: 90 -> 84
 - [+] Hitbox Size (hand): 4.5u -> 4.75u
 - [+] FAF: 57 -> 56

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/8416b2bd-73f1-44e4-a466-767a548784a0


## Kirby
### Firebrand / Thunderhand / Chill Pill
 - (!) Given new animations and matched properties
 - (Chill Pill animation still in progress)

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/7989c30f-3e46-462d-aa1a-c06a0a19c627

https://github.com/HDR-Development/HewDraw-Remix/assets/55216313/1cbdcb05-f9e7-419b-9213-da649d4bc225