### PR TITLE
Pacman adjustments

### DIFF
--- a/fighters/common/src/function_hooks/set_fighter_status_data.rs
+++ b/fighters/common/src/function_hooks/set_fighter_status_data.rs
@@ -39,7 +39,7 @@ unsafe fn set_fighter_status_data_hook(boma: &mut BattleObjectModuleAccessor, ar
         || (boma.kind() == *FIGHTER_KIND_MIIGUNNER
             && boma.is_status_one_of(&[*FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_GROUND, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_1_AIR, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_GROUND, *FIGHTER_MIIGUNNER_STATUS_KIND_SPECIAL_S3_2_AIR]))
         || (boma.kind() == *FIGHTER_KIND_PACMAN
-            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N]))
+            && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_N, *FIGHTER_STATUS_KIND_SPECIAL_LW]))
         || (boma.kind() == *FIGHTER_KIND_PIKMIN
             && boma.is_status_one_of(&[*FIGHTER_STATUS_KIND_SPECIAL_LW]))
         || (boma.kind() == *FIGHTER_KIND_RICHTER

--- a/fighters/pacman/src/acmd/aerials.rs
+++ b/fighters/pacman/src/acmd/aerials.rs
@@ -1,6 +1,33 @@
 
 use super::*;
 
+#[acmd_script( agent = "pacman", script = "game_attackairn" , category = ACMD_GAME , low_priority)]
+unsafe fn pacman_attack_air_n_game(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+        ATTACK(fighter, 0, 0, Hash40::new("pizzapacman"), 10.0, 50, 70, 0, 45, 7.6, 0.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+    }
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("pizzapacman"), 8.5, 50, 70, 0, 45, 7.2, 0.0, 0.5, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("pizzapacman"), 6.0, 50, 70, 0, 45, 4.5, 0.0, 0.5, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+    }
+    frame(lua_state, 20.0);
+    if is_excute(fighter) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 45.0);
+    if is_excute(fighter) {
+        WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+    }
+}
+
 #[acmd_script( agent = "pacman", script = "effect_attackairn" , category = ACMD_EFFECT , low_priority)]
 unsafe fn pacman_attack_air_n_effect(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
@@ -11,11 +38,11 @@ unsafe fn pacman_attack_air_n_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 4, 1, 0, 0, 90, 0.8, true, *EF_FLIP_YZ, 0.4);
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("throw"), 0, 4, 1, 0, 0, 90, 0.8, true, *EF_FLIP_YZ, 0.4);
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 7, 0, 0, 0, 90, 0.75, true, *EF_FLIP_YZ, 0.4);
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("throw"), 0, 7, 0, 0, 0, 90, 0.75, true, *EF_FLIP_YZ, 0.4);
     }
     frame(lua_state, 30.0);
     if is_excute(fighter) {
@@ -179,6 +206,7 @@ unsafe fn pacman_attack_air_lw_game(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
+        pacman_attack_air_n_game,
         pacman_attack_air_n_effect,
         pacman_attack_air_f_game,
         pacman_attack_air_b_game,

--- a/fighters/pacman/src/acmd/aerials.rs
+++ b/fighters/pacman/src/acmd/aerials.rs
@@ -1,6 +1,28 @@
 
 use super::*;
 
+#[acmd_script( agent = "pacman", script = "effect_attackairn" , category = ACMD_EFFECT , low_priority)]
+unsafe fn pacman_attack_air_n_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_NO_STOP(fighter, Hash40::new("pacman_change_start"), Hash40::new("pizzapacman"), 0, 0, 0, 0, 0, 0, 1, true);
+    }
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 4, 1, 0, 0, 90, 0.8, true, *EF_FLIP_YZ, 0.4);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 7, 0, 0, 0, 90, 0.75, true, *EF_FLIP_YZ, 0.4);
+    }
+    frame(lua_state, 30.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW(fighter, Hash40::new("pacman_change_end"), Hash40::new("pizzapacman"), 0, 0, 0, 0, 0, 0, 1, true);
+        EFFECT_OFF_KIND(fighter, Hash40::new("sys_spin_wind"), true, true);
+    }
+}
 
 #[acmd_script( agent = "pacman", script = "game_attackairf" , category = ACMD_GAME , low_priority)]
 unsafe fn pacman_attack_air_f_game(fighter: &mut L2CAgentBase) {
@@ -157,6 +179,7 @@ unsafe fn pacman_attack_air_lw_game(fighter: &mut L2CAgentBase) {
 
 pub fn install() {
     install_acmd_scripts!(
+        pacman_attack_air_n_effect,
         pacman_attack_air_f_game,
         pacman_attack_air_b_game,
         pacman_attack_air_hi_game,

--- a/fighters/pacman/src/acmd/aerials.rs
+++ b/fighters/pacman/src/acmd/aerials.rs
@@ -38,11 +38,11 @@ unsafe fn pacman_attack_air_n_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("throw"), 0, 4, 1, 0, 0, 90, 0.8, true, *EF_FLIP_YZ, 0.4);
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 5.9, 0.8, 0, 0, 90, 0.8, true, *EF_FLIP_YZ, 0.4);
     }
     frame(lua_state, 16.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("throw"), 0, 7, 0, 0, 0, 90, 0.75, true, *EF_FLIP_YZ, 0.4);
+        EFFECT_FOLLOW_FLIP_ALPHA(fighter, Hash40::new("sys_spin_wind"), Hash40::new("sys_spin_wind"), Hash40::new("top"), 0, 5.9, 0.7, 0, 0, 90, 0.75, true, *EF_FLIP_YZ, 0.4);
     }
     frame(lua_state, 30.0);
     if is_excute(fighter) {

--- a/fighters/pacman/src/acmd/aerials.rs
+++ b/fighters/pacman/src/acmd/aerials.rs
@@ -8,7 +8,7 @@ unsafe fn pacman_attack_air_n_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
-        ATTACK(fighter, 0, 0, Hash40::new("pizzapacman"), 10.0, 50, 70, 0, 45, 7.6, 0.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
+        ATTACK(fighter, 0, 0, Hash40::new("pizzapacman"), 10.0, 50, 70, 0, 45, 8.1, 0.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_BODY);
     }
     frame(lua_state, 6.0);
     if is_excute(fighter) {


### PR DESCRIPTION
[pacassets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14079693/pacassets.zip)
Removed excessive body shifting from uair and nair to make them feel more natural to use and easier to space. This slightly reduces the range of both aerials.

Increased size of initial nair hitbox to preserve ease of down special -> wavedash back -> nair. 7.6 -> 8.1

Added the ability to b-reverse and b-turnaround down special.

[pacman.webm](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/0d8b2ba8-0f0a-4bf6-a33d-bb1fb43e69c0)
