### PR TITLE
Lucario Meter Nerfs

### DIFF
--- a/fighters/common/src/function_hooks/aura.rs
+++ b/fighters/common/src/function_hooks/aura.rs
@@ -76,18 +76,21 @@ unsafe extern "C" fn get_aura(object: *mut BattleObject) -> f32 {
 
     let aura_override = VarModule::get_float(object, vars::lucario::status::AURA_OVERRIDE);
     if aura_override > 0.0 {
+        // println!("aura_override: {}", aura_override);
         return aura_override;
     }
 
     if VarModule::is_flag(object, vars::lucario::instance::METER_IS_BURNOUT) {
-        return ParamModule::get_float(object, ParamType::Agent, "aura.penalty_aurapower");
+        let penalty_aurapower = ParamModule::get_float(object, ParamType::Agent, "aura.penalty_aurapower");
+        // println!("penalty_aurapower: {}", penalty_aurapower);
+        return penalty_aurapower;
     }
 
     let min_aurapower = ParamModule::get_float(object, ParamType::Agent, "aura.min_aurapower");
     let max_aurapower = ParamModule::get_float(object, ParamType::Agent, "aura.max_aurapower");
 
-    let charge = MeterModule::level(object) as f32;
-    let max_charge = MeterModule::meter_cap(object) as f32;
+    let charge = MeterModule::meter(object) as f32;
+    let max_charge = MeterModule::meter_cap(object) as f32 * MeterModule::meter_per_level(object);
 
     let diff = max_aurapower - min_aurapower;
     let aura_power = min_aurapower + (diff * charge.clamp(0.0, max_charge) / max_charge);

--- a/fighters/lucario/src/acmd/aerials.rs
+++ b/fighters/lucario/src/acmd/aerials.rs
@@ -124,13 +124,13 @@ unsafe fn lucario_attack_air_b_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         MeterModule::watch_damage(fighter.battle_object, true);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 13.0, 361, 100, 0, 30, 5.2, 0.0, 11.0, -14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 361, 100, 0, 30, 3.0, 0.0, 11.0, -9.0, Some(0.0), Some(11.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 14.6, 361, 100, 0, 30, 5.2, 0.0, 11.0, -14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 13.5, 361, 100, 0, 30, 3.0, 0.0, 11.0, -9.0, Some(0.0), Some(11.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     wait(lua_state, 4.0);
     if is_excute(fighter) {
         AttackModule::clear(boma, 0, false);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 9.0, 65, 77, 0, 30, 3.0, 0.0, 11.0, -9.0, Some(0.0), Some(11.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 10.1, 65, 77, 0, 30, 3.0, 0.0, 11.0, -9.0, Some(0.0), Some(11.0), Some(-2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 20.0);
     if is_excute(fighter) {
@@ -159,8 +159,8 @@ unsafe fn lucario_attack_air_hi_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
         MeterModule::watch_damage(fighter.battle_object, true);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 11.0, 80, 80, 0, 30, 5.0, 0.0, 11.0, 2.0, Some(0.0), Some(12.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_KICK);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 90, 100, 0, 40, 5.0, 0.0, 11.0, 2.0, Some(0.0), Some(20.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.4, 80, 80, 0, 30, 5.0, 0.0, 11.0, 2.0, Some(0.0), Some(12.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_KICK);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 13.5, 90, 100, 0, 40, 5.0, 0.0, 11.0, 2.0, Some(0.0), Some(20.0), Some(2.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_KICK);
     }
     wait(lua_state, 4.0);
     if is_excute(fighter) {

--- a/fighters/lucario/src/acmd/other.rs
+++ b/fighters/lucario/src/acmd/other.rs
@@ -343,10 +343,6 @@ unsafe fn game_downattacku(fighter: &mut L2CAgentBase) {
 unsafe fn game_appealhi(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
-    frame(lua_state, 50.0);
-    if is_excute(fighter) {
-        MeterModule::add(fighter.battle_object, 0.2 * MeterModule::meter_per_level(fighter.battle_object));
-    }
 }
 
 pub fn install() {

--- a/fighters/lucario/src/acmd/smashes.rs
+++ b/fighters/lucario/src/acmd/smashes.rs
@@ -38,14 +38,14 @@ unsafe fn lucario_attack_hi4_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 7.0);
     if is_excute(fighter) {
         MeterModule::watch_damage(fighter.battle_object, true);
-        ATTACK(fighter, 0, 0, Hash40::new("bust"), 5.0, 85, 100, 100, 0, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.25, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("armr"), 5.0, 112, 100, 100, 0, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.25, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("bust"), 5.6, 85, 100, 100, 0, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.25, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("armr"), 5.6, 112, 100, 100, 0, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.0, 0.25, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
         SA_SET(fighter, *SITUATION_KIND_AIR);
-        ATTACK(fighter, 0, 0, Hash40::new("bust"), 7.0, 80, 120, 0, 70, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("armr"), 7.0, 80, 120, 0, 70, 5.0, 3.0, 0.0, 0.0, Some(-3.0), Some(0.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("bust"), 7.9, 80, 120, 0, 70, 4.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("armr"), 7.9, 80, 120, 0, 70, 5.0, 3.0, 0.0, 0.0, Some(-3.0), Some(0.0), Some(0.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     frame(lua_state, 16.0);
     FT_MOTION_RATE(fighter, 2.0);
@@ -136,8 +136,8 @@ unsafe fn lucario_attack_lw4_game(fighter: &mut L2CAgentBase) {
     FT_MOTION_RATE(fighter, 1.000);
     if is_excute(fighter) {
         MeterModule::watch_damage(fighter.battle_object, true);
-        ATTACK(fighter, 0, 0, Hash40::new("top"), 12.0, 33, 99, 0, 30, 4.3, 0.0, 6.0, 15.0, Some(0.0), Some(6.0), Some(4.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
-        ATTACK(fighter, 1, 0, Hash40::new("top"), 12.0, 33, 99, 0, 30, 4.3, 0.0, 6.0, -15.0, Some(0.0), Some(6.0), Some(-4.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 0, 0, Hash40::new("top"), 13.5, 33, 99, 0, 30, 4.3, 0.0, 6.0, 15.0, Some(0.0), Some(6.0), Some(4.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
+        ATTACK(fighter, 1, 0, Hash40::new("top"), 13.5, 33, 99, 0, 30, 4.3, 0.0, 6.0, -15.0, Some(0.0), Some(6.0), Some(-4.5), 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_aura"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_LUCARIO, *ATTACK_REGION_PUNCH);
     }
     wait(lua_state, 5.0);
     if is_excute(fighter) {

--- a/fighters/lucario/src/acmd/specials.rs
+++ b/fighters/lucario/src/acmd/specials.rs
@@ -355,7 +355,7 @@ unsafe fn game_specialnbomb(fighter: &mut L2CAgentBase) {
     frame(lua_state, 37.0);
     if is_excute(fighter) {
         ArticleModule::shoot(boma, *FIGHTER_LUCARIO_GENERATE_ARTICLE_AURABALL, ArticleOperationTarget(*ARTICLE_OPE_TARGET_LAST), false);
-        MeterModule::drain_direct(fighter.battle_object, 2.0 * MeterModule::meter_per_level(fighter.battle_object));
+        MeterModule::drain_direct(fighter.battle_object, MeterModule::meter_per_level(fighter.battle_object));
         let frames = 120.max(VarModule::get_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME));
         VarModule::set_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME, frames);
     }
@@ -402,7 +402,7 @@ unsafe fn game_specialairnbomb(fighter: &mut L2CAgentBase) {
     frame(lua_state, 37.0);
     if is_excute(fighter) {
         ArticleModule::shoot(boma, *FIGHTER_LUCARIO_GENERATE_ARTICLE_AURABALL, ArticleOperationTarget(*ARTICLE_OPE_TARGET_LAST), false);
-        MeterModule::drain_direct(fighter.battle_object, 2.0 * MeterModule::meter_per_level(fighter.battle_object));
+        MeterModule::drain_direct(fighter.battle_object, MeterModule::meter_per_level(fighter.battle_object));
         let frames = 120.max(VarModule::get_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME));
         VarModule::set_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME, frames);
     }

--- a/fighters/lucario/src/opff.rs
+++ b/fighters/lucario/src/opff.rs
@@ -10,15 +10,15 @@ pub fn lucario_meter(fighter: &mut smash::lua2cpp::L2CFighterCommon) {
             return;
         }
         MeterModule::update(fighter.object(), false);
-        MeterModule::set_meter_cap(fighter.object(), 6);
-        MeterModule::set_meter_per_level(fighter.object(), 50.0);
+        MeterModule::set_meter_cap(fighter.object(), 2);
+        MeterModule::set_meter_per_level(fighter.object(), 100.0);
         utils::ui::UiManager::set_aura_meter_enable(fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32, true);
         utils::ui::UiManager::set_aura_meter_info(
-            fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32,
-            MeterModule::meter(fighter.object()),
+            (fighter.get_int(*FIGHTER_INSTANCE_WORK_ID_INT_ENTRY_ID) as u32),
+            (MeterModule::meter(fighter.object())),
             (MeterModule::meter_cap(fighter.object()) as f32 * MeterModule::meter_per_level(fighter.object())),
-            MeterModule::meter_per_level(fighter.object()),
-            VarModule::is_flag(fighter.object(), vars::lucario::instance::METER_IS_BURNOUT)
+            (MeterModule::meter_per_level(fighter.object())),
+            (VarModule::is_flag(fighter.object(), vars::lucario::instance::METER_IS_BURNOUT))
         );
     }
 }
@@ -134,7 +134,7 @@ unsafe fn sspecial(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
     && !VarModule::is_flag(fighter.battle_object, vars::lucario::instance::METER_IS_BURNOUT) {
         let bonus_aurapower = ParamModule::get_float(fighter.battle_object, ParamType::Agent, "aura.bonus_aurapower");
         VarModule::set_float(fighter.battle_object, vars::lucario::status::AURA_OVERRIDE, bonus_aurapower);
-        MeterModule::drain_direct(fighter.battle_object, 2.0 * MeterModule::meter_per_level(fighter.battle_object));
+        MeterModule::drain_direct(fighter.battle_object, MeterModule::meter_per_level(fighter.battle_object));
         pause_meter_regen(fighter, 120);
     }
 }
@@ -154,7 +154,7 @@ unsafe fn dspecial(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModule
     && !VarModule::is_flag(fighter.object(), vars::lucario::instance::METER_IS_BURNOUT) {
         fighter.change_status_req(*FIGHTER_STATUS_KIND_ATTACK_AIR, false);
         KineticModule::mul_speed(boma, &Vector3f{x: 0.5, y: 0.5, z: 0.5}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
-        MeterModule::drain_direct(fighter.object(), MeterModule::meter_per_level(fighter.object()) * 2.0);
+        MeterModule::drain_direct(fighter.object(), MeterModule::meter_per_level(fighter.object()));
         pause_meter_regen(fighter, 120);
     }
 }
@@ -251,7 +251,7 @@ unsafe fn meter_module(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMo
             VarModule::on_flag(fighter.battle_object, vars::lucario::instance::METER_IS_BURNOUT);
             PLAY_SE(fighter, Hash40::new("se_common_spirits_critical_l_tail"));
         }
-    } else if (meter >= meter_per_level * 2.0) { // exit burnout at 1 full bar
+    } else if (meter >= meter_per_level) { // exit burnout at 1 half bar
         if VarModule::is_flag(fighter.battle_object, vars::lucario::instance::METER_IS_BURNOUT) {
             VarModule::off_flag(fighter.battle_object, vars::lucario::instance::METER_IS_BURNOUT);
             PLAY_SE(fighter, Hash40::new("se_system_favorite_on"));
@@ -327,9 +327,9 @@ unsafe fn magic_series(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMo
     if [
         *FIGHTER_STATUS_KIND_ATTACK, 
         *FIGHTER_STATUS_KIND_ATTACK_DASH, 
-        *FIGHTER_STATUS_KIND_ATTACK_S3,
-        *FIGHTER_STATUS_KIND_ATTACK_HI3,
-        *FIGHTER_STATUS_KIND_ATTACK_LW3,
+        // *FIGHTER_STATUS_KIND_ATTACK_S3,
+        // *FIGHTER_STATUS_KIND_ATTACK_HI3,
+        // *FIGHTER_STATUS_KIND_ATTACK_LW3,
     ].contains(&status_kind) {
         if boma.is_cat_flag(Cat1::AttackS4) {
             StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_S4_START,true);

--- a/romfs/source/fighter/lucario/param/hdr.xml
+++ b/romfs/source/fighter/lucario/param/hdr.xml
@@ -11,9 +11,9 @@
     <struct hash="aura">
         <float hash="penalty_aurapower">0.85</float>
         <float hash="min_aurapower">0.85</float>
-        <float hash="max_aurapower">1.3</float>
+        <float hash="max_aurapower">1.15</float>
         <float hash="bonus_aurapower">1.5</float>
-        <float hash="regen_rate">0.125</float>
+        <float hash="regen_rate">0.05</float>
         <float hash="regen_rate_burnout">0.07</float>
         <float hash="regen_rate_defensive_mul">0.5</float>
         <float hash="shield_damage_meter_drain_mul">2.75</float>

--- a/romfs/source/fighter/lucario/param/vl.prcxml
+++ b/romfs/source/fighter/lucario/param/vl.prcxml
@@ -54,13 +54,13 @@
   <list hash="param_aurapower">
     <struct index="0">
       <float hash="se_middle_aurapower">1.0</float>
-      <float hash="se_high_aurapower">1.25</float>
+      <float hash="se_high_aurapower">1.10</float>
     </struct>
   </list>
   <list hash="param_aurascale">
     <struct index="0">
       <float hash="min_aura_power">0.85</float>
-      <float hash="max_aura_power">1.3</float>
+      <float hash="max_aura_power">1.15</float>
     </struct>
   </list>
 </struct>

--- a/utils/src/ui/aura_meter.rs
+++ b/utils/src/ui/aura_meter.rs
@@ -95,7 +95,7 @@ impl AuraMeter {
         set_pane_visible(self.bars[1], false);
         set_pane_visible(self.bars_background[0], false);
         set_pane_visible(self.bars_background[1], false);
-        set_pane_visible(self.number, true);
+        set_pane_visible(self.number, false);
 
         if self.original_bar_height < 0.0 {
             self.original_bar_width = get_width_height(self.bars[0]).0;
@@ -112,7 +112,7 @@ impl AuraMeter {
     }
 
     pub fn update_number(&mut self) {
-        set_pane_visible(self.number, true);
+        set_pane_visible(self.number, false);
 
         let left_x = self.current_number as f32 / 6.0;
         let right_x = (self.current_number + 1) as f32 / 6.0;
@@ -132,15 +132,15 @@ impl AuraMeter {
         let bar_total = per_level * 2.0;
 
         let number = current / bar_total;
-        let number = number.clamp(0.0, 3.0) as usize;
+        let number = number.clamp(0.0, 1.0) as usize;
 
-        let percent = if number == 3 {
+        let percent = if number == 1 {
             1.0
         } else {
             (current % bar_total) / bar_total
         };
 
-        if number != self.current_number && number != 3 {
+        if number != self.current_number && number != 1 {
             self.actual_percentage = percent;
             self.visual_percentage = 0.0;
         } else {
@@ -262,7 +262,7 @@ impl UiObject for AuraMeter {
             set_pane_visible(self.bars[1], false);
             set_pane_visible(self.number, false);
         } else {
-            set_pane_visible(self.number, true);
+            set_pane_visible(self.number, false);
         }
     }
 


### PR DESCRIPTION
```diff
- Aura damage multiplier 0.85x-1.3x --> 0.85x-1.15x
! BAir damage 13.0/12.0/9.0 --> 14.6/13.5/10.1 (under-compensation for max aura reduction)
! UAir damage 11.0/12.0 --> 12.4/13.5 (under-compensation for max aura reduction)
! USmash damage 5.0/7.0 --> 5.6/7.9 (under-compensation for max aura reduction)
! DSmash damage 12.0 --> 13.5 (under-compensation for max aura reduction)
NOTE: at max-aura, these moves will kill a few % later than before (not counting damage lost comboing into them)

+ removed 10 second passive regen pause on round start
- meter passive regen rate 0.125/frame --> 0.05/frame
- meter cap 300 --> 200
~ meter displayed visually as one slow-moving bar, rather than several

- [!!!] can no longer cancel tilt attacks into smash attacks
~ this change made to simplify shield pressure while encouraging use of grounded DSpecial metered cancel

- UTaunt meter bonus removed
```