### PR TITLE
Copy Ability Fixes

### DIFF
--- a/fighters/kirby/src/opff.rs
+++ b/fighters/kirby/src/opff.rs
@@ -1116,14 +1116,14 @@ pub unsafe fn lucas_offense_charge(fighter: &mut smash::lua2cpp::L2CFighterCommo
 
 // Piranha Plant Ptooie Stance
 pub unsafe fn packun_ptooie_stance(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, status_kind: i32) {
-    if fighter.is_status(*FIGHTER_KIRBY_STATUS_KIND_SPECIAL_N_SWALLOW) {
+    if fighter.is_status(*FIGHTER_KIRBY_STATUS_KIND_SPECIAL_N_SWALLOW_WAIT) {
         let opponent_boma = fighter.get_grabbed_opponent_boma();
         let grabbed_fighter = smash::app::utility::get_kind(opponent_boma);
         if grabbed_fighter == *FIGHTER_KIND_PACKUN {
             let old_stance = VarModule::get_int(boma.object(), vars::packun::instance::CURRENT_STANCE);
             let new_stance = VarModule::get_int(opponent_boma.object(), vars::packun::instance::CURRENT_STANCE);
             if new_stance != old_stance {
-                // println!("Copying Packun Flower's Current Stance, which is {}", new_stance);
+                // println!("Copying Pirahna Plant's Current Stance, which is {}", new_stance);
                 VarModule::set_int(boma.object(), vars::packun::instance::CURRENT_STANCE, new_stance);
             }
         }

--- a/fighters/kirby/src/status.rs
+++ b/fighters/kirby/src/status.rs
@@ -27,6 +27,7 @@ pub fn install() {
     gaogaen_special_n::install();
     ridley_special_n::install();
     ganon_special_n::install();
+    diddy_special_n_cancel::install();
     koopa_special_n::install();
     luigi_special_n::install();
     mario_special_n::install();
@@ -39,7 +40,7 @@ pub fn add_statuses() {
     special_hi_h::install();
     ganon_special_n_float::install();
     littlemac_special_n_cancel::install();
-    diddy_special_n_cancel::install();
+    diddy_special_n_cancel::install_custom();
 }
 
 #[smashline::fighter_init]


### PR DESCRIPTION
- Fixes an issue where if Kirby tried to inhale a strong projectile or an assist trophy the game would crash.

- Fixes an issue where trying to cancel Peanut Popgun would result in Kirby freezing and unable to move until he was hit or gets KOed.