### PR TITLE
Mario/Doc ftilt animation adjustment

### DIFF
--- a/fighters/mario/src/acmd/tilts.rs
+++ b/fighters/mario/src/acmd/tilts.rs
@@ -23,7 +23,7 @@ unsafe fn mario_attack_s3_hi_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 6.8, 4.5, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 6.8, 4.0, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -86,7 +86,7 @@ unsafe fn mario_attack_s3_lw_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 2.8, 6.0, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 2.8, 5.8, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {

--- a/fighters/mario/src/acmd/tilts.rs
+++ b/fighters/mario/src/acmd/tilts.rs
@@ -23,7 +23,7 @@ unsafe fn mario_attack_s3_hi_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 7, 7.5, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 6.8, 4.5, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -54,7 +54,7 @@ unsafe fn mario_attack_s3_s_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 5, 9.0, 10, -39, 154, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 4.8, 6.0, 10, -39, 154, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -86,7 +86,7 @@ unsafe fn mario_attack_s3_lw_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 3, 9.0, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 2.8, 6.0, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {

--- a/fighters/mariod/src/acmd/tilts.rs
+++ b/fighters/mariod/src/acmd/tilts.rs
@@ -23,7 +23,7 @@ unsafe fn mariod_attack_s3_hi_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 7, 7.5, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 6.8, 4.0, 30, -60, 135, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -54,7 +54,7 @@ unsafe fn mariod_attack_s3_s_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 5, 9.0, 10, -39, 154, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), 1, 4.8, 5.8, 10, -39, 154, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -86,7 +86,7 @@ unsafe fn mariod_attack_s3_lw_effect(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 3.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 3, 9.0, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc"), Hash40::new("sys_attack_arc"), Hash40::new("top"), -2, 2.8, 6.0, 5, -90, 170, 0.95, true, *EF_FLIP_YZ);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {


### PR DESCRIPTION
[mariosassets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14203084/mariosassets.zip)
Makes it so both Marios no longer appear to be floating when doing any variant of ftilt by a ledge. This slightly reduces their range.

_Before:_
![1](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/f21e9b4f-57cb-4bbf-b00b-3e198bfd554b)

_After:_
![2](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/c3f199a5-885e-4397-98af-da2e72766520)


_Before:_
![3](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/43eaf007-c372-4ec5-b085-6f4ae7a0edf9)

_After:_
![4](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/4e1b47ea-ce0f-4583-a169-7d411cf2bccb)

_Before:_
![5](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/33c33189-0f97-4128-bce0-da3855c4dd5f)

_After:_
![6](https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/3be9a0e9-cb71-4aed-82bc-be46444e6baa)
