### PR TITLE
New Ganondorf run animation

### DIFF
--- a/fighters/ganon/src/acmd/other.rs
+++ b/fighters/ganon/src/acmd/other.rs
@@ -51,7 +51,7 @@ unsafe fn damageflylw_sound(fighter: &mut L2CAgentBase) {
         };
         if play_vc == 0 {PLAY_FLY_VOICE(fighter, Hash40::new("seq_ganon_rnd_futtobi01"), Hash40::new("seq_ganon_rnd_futtobi02"));}
     }
-}
+} 
 
 #[acmd_script( agent = "ganon", script = "sound_damageflyn" , category = ACMD_SOUND , low_priority)]
 unsafe fn damageflyn_sound(fighter: &mut L2CAgentBase) {


### PR DESCRIPTION
[ganondorfassets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14230609/ganondorfassets.zip)
Updated run animation to be more reminiscent of melee/pm and generally less stiff looking. Also updated turn to better transition into this run.

_Before:_

https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/0603ccd2-800a-47e9-adac-3cb0535d9897

_After:_

https://github.com/HDR-Development/HewDraw-Remix/assets/22902718/08976e7e-cc91-4d7e-addd-c20534beb75a

