### PR TITLE
Olimar Bugfixes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -904,6 +904,12 @@ pub mod vars {
             // flags
             pub const SPECIAL_HI_CANCEL_ESCAPE_AIR: i32 = 0x0100;
         }
+        pub mod status {
+            // flags
+            pub const SPECIAL_S_PIKMIN_DETONATE_IS_ATTACK_LAST_FRAME: i32 = 0x1100;
+            // ints
+            pub const SPECIAL_S_PIKMIN_DETONATE_TIMER: i32 = 0x1101;
+        }
     }
 
     pub mod ptrainer {

--- a/fighters/pikmin/src/pikmin/mod.rs
+++ b/fighters/pikmin/src/pikmin/mod.rs
@@ -19,7 +19,7 @@ impl From<i32> for PikminInfo {
     fn from(other: i32) -> Self {
         match other {
             0 => PikminInfo { // Red
-                dmg: 1.0,
+                dmg: 1.05,
                 shield_dmg: 0.25,
                 angle: 0,
                 hitlag: 1.0,
@@ -27,7 +27,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_fire"),
                 sound: *COLLISION_SOUND_ATTR_FIRE,
                 color: Vector3f{x: 1.0, y: 0.05, z: 0.0},
-                cling_frame: 30 * 4
+                cling_frame: 4
             },
             1 => PikminInfo { // yellow
                 dmg: 0.94,
@@ -38,7 +38,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_paralyze"),
                 sound: *COLLISION_SOUND_ATTR_ELEC,
                 color: Vector3f{x: 1.0, y: 1.0, z: 0.14},
-                cling_frame: 30 * 6
+                cling_frame: 6
             },
             2 => PikminInfo { // Blue
                 dmg: 1.0,
@@ -49,7 +49,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_water"),
                 sound: *COLLISION_SOUND_ATTR_WATER,
                 color: Vector3f{x: 0.1, y: 0.4, z: 1.0},
-                cling_frame: 30 * 4
+                cling_frame: 4
             },
             3 => PikminInfo { // White
                 dmg: 0.75,
@@ -60,7 +60,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_flower"),
                 sound: *COLLISION_SOUND_ATTR_FIRE,
                 color: Vector3f{x: 1.0, y: 1.0, z: 1.0},
-                cling_frame: 30 * 2
+                cling_frame: 2
             },
             _ => PikminInfo { // Violet (Rock), also default
                 dmg: 1.2,
@@ -71,7 +71,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_normal"),
                 sound: *COLLISION_SOUND_ATTR_KICK,
                 color: Vector3f{x: 0.36, y: 0.0, z: 1.0},
-                cling_frame: 30 * 999
+                cling_frame: 999
             },
         }
     }

--- a/fighters/pikmin/src/pikmin/mod.rs
+++ b/fighters/pikmin/src/pikmin/mod.rs
@@ -27,7 +27,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_fire"),
                 sound: *COLLISION_SOUND_ATTR_FIRE,
                 color: Vector3f{x: 1.0, y: 0.05, z: 0.0},
-                cling_frame: 4
+                cling_frame: 5
             },
             1 => PikminInfo { // yellow
                 dmg: 0.94,
@@ -38,7 +38,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_paralyze"),
                 sound: *COLLISION_SOUND_ATTR_ELEC,
                 color: Vector3f{x: 1.0, y: 1.0, z: 0.14},
-                cling_frame: 6
+                cling_frame: 7
             },
             2 => PikminInfo { // Blue
                 dmg: 1.0,
@@ -49,7 +49,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_water"),
                 sound: *COLLISION_SOUND_ATTR_WATER,
                 color: Vector3f{x: 0.1, y: 0.4, z: 1.0},
-                cling_frame: 4
+                cling_frame: 5
             },
             3 => PikminInfo { // White
                 dmg: 0.75,
@@ -60,7 +60,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_flower"),
                 sound: *COLLISION_SOUND_ATTR_FIRE,
                 color: Vector3f{x: 1.0, y: 1.0, z: 1.0},
-                cling_frame: 2
+                cling_frame: 3
             },
             _ => PikminInfo { // Violet (Rock), also default
                 dmg: 1.2,

--- a/romfs/source/fighter/pikmin/param/vl.prcxml
+++ b/romfs/source/fighter/pikmin/param/vl.prcxml
@@ -17,7 +17,7 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
-  <list hash="param_pikmin_particular">
+  <list hash="param_pikmin">
     <struct index="0">
       <int hash="special_s_lever_clatter_frame">0</int>
       <int hash="special_s_damage_remove_rate">0</int>


### PR DESCRIPTION
- Red Pikmin damage 1.0x --> 1.05x
- Fixed a bug which caused Pikmins' SSpecial detonation to occasionally activate immediately
- Fixed a bug which caused Pikmins' SSpecial pummel to depreciate in speed as individual Pikmin accrue damage, which caused detonation to activate much later than intended in most cases
- Fixed a bug which reverted USpecial speed and drift to vanilla
- Fixed a bug which reverted Blue Pikmin's health to vanilla
- Fixed a bug which reverted `cliff_hang_data` to vanilla