### PR TITLE
Gordo Jank Bugfix

### DIFF
--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -306,7 +306,7 @@ unsafe fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBase) {
         WorkModule::set_int(boma, 300, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
         /* below grabs the boma of the opponent hitting gordo, the attack data of that hit, and adjusts the speed accordingly */
         let num_players = Fighter::get_fighter_entry_count(); 
-        if StopModule::is_hit(boma){ 
+        if StopModule::is_hit(boma) && !StopModule::is_damage(boma){ 
             for i in 0..num_players{
                 let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
 


### PR DESCRIPTION
Fixes a bug where gordo turns black for the rest of the game if it gets hit and hits dedede on the same frame.