### PR TITLE
Mario Tweaks Part 2 (+ new throws)

### DIFF
--- a/fighters/mario/src/acmd/smashes.rs
+++ b/fighters/mario/src/acmd/smashes.rs
@@ -77,8 +77,8 @@ unsafe fn mario_attack_hi4_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, attack_start_frame);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, motion_rate);
-        ATTACK(fighter, 0, 0, Hash40::new("head"), 14.0, 83, 95, 0, 32, 4.7, 2.5, 1.1, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
-        ATTACK(fighter, 1, 0, Hash40::new("bust"), 14.0, 83, 95, 0, 32, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 0, 0, Hash40::new("head"), 14.0, 83, 97, 0, 32, 4.7, 2.5, 1.1, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
+        ATTACK(fighter, 1, 0, Hash40::new("bust"), 14.0, 83, 97, 0, 32, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_PUNCH, *ATTACK_REGION_HEAD);
         HIT_NODE(fighter, Hash40::new("head"), *HIT_STATUS_XLU);
     }
     frame(lua_state, attack_end_frame);
@@ -107,7 +107,7 @@ unsafe fn mario_attack_hi4_effect(fighter: &mut L2CAgentBase) {
     }
     frame(lua_state, 10.0);
     if is_excute(fighter) {
-        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("mario_smash_arc"), Hash40::new("mario_smash_arc"), Hash40::new("top"), 1.0, 7.0, 0.0, -30, -100, -80, 0.95, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("mario_smash_arc"), Hash40::new("mario_smash_arc"), Hash40::new("top"), 1.0, 7.0, 0.0, -30, -100, -80, 0.90, true, *EF_FLIP_YZ);
         LAST_EFFECT_SET_RATE(fighter, 1.5);
     }
     frame(lua_state, 13.0);

--- a/fighters/mario/src/acmd/specials.rs
+++ b/fighters/mario/src/acmd/specials.rs
@@ -254,6 +254,7 @@ unsafe fn mario_special_air_s_game(fighter: &mut L2CAgentBase) {
         if !VarModule::is_flag(fighter.battle_object, vars::mario::instance::SPECIAL_S_DISABLE_STALL) {
             WorkModule::on_flag(boma, *FIGHTER_MARIO_STATUS_SPECIAL_S_FLAG_SPECIAL_FALL);
             VarModule::on_flag(fighter.battle_object, vars::mario::instance::SPECIAL_S_DISABLE_STALL);
+            VarModule::on_flag(fighter.battle_object, vars::mario::instance::DISABLE_DSPECIAL_STALL);
         }
         ATTACK(fighter, 0, 0, Hash40::new("top"), 10.0, 110, 100, 80, 0, 7.5, 0.0, 6.7, 9.7, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 4, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_turn"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MARIO_MANT, *ATTACK_REGION_OBJECT);
         ATTACK(fighter, 1, 0, Hash40::new("top"), 10.0, 110, 100, 80, 0, 5.0, 0.0, 6.7, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 4, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_turn"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MARIO_MANT, *ATTACK_REGION_OBJECT);
@@ -312,8 +313,8 @@ unsafe fn mario_special_hi_game(fighter: &mut L2CAgentBase) {
         frame(lua_state, 17.0);
         if is_excute(fighter) {
             AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 60, 125, 0, 50, 6.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 60, 125, 0, 50, 6.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 65, 130, 0, 50, 6.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 65, 130, 0, 50, 6.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_mario_local_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_LOCAL_COIN_LAST, *ATTACK_REGION_PUNCH);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {
@@ -363,8 +364,8 @@ unsafe fn mario_special_hi_game(fighter: &mut L2CAgentBase) {
         frame(lua_state, 17.0);
         if is_excute(fighter) {
             AttackModule::clear_all(boma);
-            ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 60, 125, 0, 50, 6.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
-            ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 60, 125, 0, 50, 6.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 0, 0, Hash40::new("top"), 5.0, 65, 130, 0, 50, 6.5, 0.0, 9.5, 8.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
+            ATTACK(fighter, 1, 0, Hash40::new("top"), 5.0, 65, 130, 0, 50, 6.5, 0.0, 9.5, 2.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_coin"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_MARIO_COIN_LAST, *ATTACK_REGION_PUNCH);
         }
         wait(lua_state, 2.0);
         if is_excute(fighter) {

--- a/fighters/mario/src/acmd/throws.rs
+++ b/fighters/mario/src/acmd/throws.rs
@@ -6,7 +6,7 @@ unsafe fn mario_grab(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     frame(lua_state, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.200);
+        FT_MOTION_RATE(fighter, 1.000);
     }
     frame(lua_state, 5.0);
     if is_excute(fighter) {
@@ -15,7 +15,7 @@ unsafe fn mario_grab(fighter: &mut L2CAgentBase) {
     frame(lua_state, 6.0);
     if is_excute(fighter) {
         FT_MOTION_RATE(fighter, 1.000);
-        CATCH(fighter, 0, Hash40::new("top"), 4.5, 0.0, 6.6, 0.0, Some(0.0), Some(6.6), Some(9.2), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
+        CATCH(fighter, 0, Hash40::new("top"), 3.5, 0.0, 6.6, 0.0, Some(0.0), Some(6.6), Some(9.2), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);
     }
     game_CaptureCutCommon(fighter);
     wait(lua_state, 2.0);
@@ -27,7 +27,7 @@ unsafe fn mario_grab(fighter: &mut L2CAgentBase) {
     
 }
 
-#[acmd_script( agent = "mario", script = "game_catchdash" , category = ACMD_GAME , low_priority)]
+/*#[acmd_script( agent = "mario", script = "game_catchdash" , category = ACMD_GAME , low_priority)]
 unsafe fn mario_dashgrab(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -69,26 +69,78 @@ unsafe fn mario_pivotgrab(fighter: &mut L2CAgentBase) {
         GrabModule::set_rebound(boma, false);
     }
     
-}
+}*/
 
 #[acmd_script( agent = "mario", script = "game_throwf", category = ACMD_GAME, low_priority )]
 unsafe fn mario_throw_f_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 8.0, 45, 65, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 4.0, 45, 105, 0, 55, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
-    frame(lua_state, 12.0);
+    frame(lua_state, 9.0);
     if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("footr"), 4.0, 361, 100, 0, 30, 5.0, 3.5, -2.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KAMEHIT, *ATTACK_REGION_KICK);
+        AttackModule::set_catch_only_all(boma, true, false);
         CHECK_FINISH_CAMERA(fighter, 13, 2);
     }
-    frame(lua_state, 13.0);
+    frame(lua_state, 10.0);
     if is_excute(fighter) {
-        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
-        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
-        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
-        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "mario", script = "effect_throwf" , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_throw_f_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 8.0);
+    if is_excute(fighter) {
+        EFFECT_FLIP(fighter, Hash40::new("sys_attack_line"), Hash40::new("sys_attack_line"), Hash40::new("footr"), -4.1, -0.5, 1, 0, 0, 0, 1.1, 0, 1, 0, 0, 0, 0, false, *EF_FLIP_YZ);
+    }
+    frame(lua_state, 10.0);
+    if is_excute(fighter) {
+        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("sys_smash_flash_s"), Hash40::new("throw"), 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+    }
+}
+
+#[acmd_script( agent = "mario", script = "sound_throwf" , category = ACMD_SOUND , low_priority)]
+unsafe fn mario_throw_f_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_01"));
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_02"));
+        PLAY_SE(fighter, Hash40::new("se_common_kick_hit_m"));
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_mario_rnd_attack"))
+    }
+}
+
+#[acmd_script( agent = "mario", script = "expression_throwf" , category = ACMD_EXPRESSION , low_priority)]
+unsafe fn mario_throw_f_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        fighter.clear_lua_stack();
+        lua_args!(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, *CAMERA_QUAKE_KIND_NONE);
+        sv_animcmd::FT_ATTACK_ABS_CAMERA_QUAKE(lua_state);
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 9.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_NONE);
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
+    }
+    frame(lua_state, 30.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 3);
     }
 }
 
@@ -127,19 +179,73 @@ unsafe fn mario_throw_hi_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 90, 90, 0, 70, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 3.0, 90, 145, 0, 60, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
     }
     frame(lua_state, 17.0);
     if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("footr"), 3.0, 361, 100, 0, 30, 5.0, 0.0, -2.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KAMEHIT, *ATTACK_REGION_KICK);
+        AttackModule::set_catch_only_all(boma, true, false);
         CHECK_FINISH_CAMERA(fighter, 5, 7);
     }
     frame(lua_state, 18.0);
     if is_excute(fighter) {
-        let target = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT);
-        let target_group = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP);
-        let target_no = WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO);
-        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), target, target_group, target_no);
+        ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
+        AttackModule::clear_all(boma);
+    }
+}
+
+#[acmd_script( agent = "mario", script = "effect_throwhi" , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_throw_hi_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        FOOT_EFFECT(fighter, Hash40::new("null"), Hash40::new("top"), -2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 16.0);
+    if is_excute(fighter) {
+        EFFECT_FOLLOW_FLIP(fighter, Hash40::new("sys_attack_arc_b"), Hash40::new("sys_attack_arc_b"), Hash40::new("top"), -8.5, 8.5, 4.5, 0, -25, 80, 0.8, true, *EF_FLIP_YZ);
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        EFFECT_FLIP(fighter, Hash40::new("sys_smash_flash_s"), Hash40::new("sys_smash_flash_s"), Hash40::new("throw"), 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, true, *EF_FLIP_YZ);
+    }
+    frame(lua_state, 33.0);
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke_s"), Hash40::new("top"), 1.4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
+#[acmd_script( agent = "mario", script = "sound_throwhi" , category = ACMD_SOUND , low_priority)]
+unsafe fn mario_throw_hi_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_01"));
+    }
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_02"));
+        PLAY_SE(fighter, Hash40::new("se_common_kick_hit_m"));
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_mario_rnd_attack"))
+    }
+}
+
+#[acmd_script( agent = "mario", script = "expression_throwhi" , category = ACMD_EXPRESSION , low_priority)]
+unsafe fn mario_throw_hi_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        fighter.clear_lua_stack();
+        lua_args!(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, *CAMERA_QUAKE_KIND_NONE);
+        sv_animcmd::FT_ATTACK_ABS_CAMERA_QUAKE(lua_state);
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+        QUAKE(fighter, *CAMERA_QUAKE_KIND_M);
     }
 }
 
@@ -148,28 +254,118 @@ unsafe fn mario_throw_lw_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
     if is_excute(fighter) {
-        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 6.0, 90, 95, 0, 58, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
+        ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, 0, 3.0, 90, 155, 0, 45, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
         ATTACK_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_CATCH, 0, 3.0, 361, 100, 0, 40, 0.0, 1.0, *ATTACK_LR_CHECK_F, 0.0, true, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_THROW);
-    }
-    frame(lua_state, 17.0);
-    if is_excute(fighter) {
-        CHECK_FINISH_CAMERA(fighter, 4.0, 0.0);
     }
     frame(lua_state, 18.0);
     if is_excute(fighter) {
+        CHECK_FINISH_CAMERA(fighter, 0, 0);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        ATTACK(fighter, 0, 0, Hash40::new("hip"), 3.0, 270, 100, 0, 30, 5.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HIP);
+        AttackModule::set_catch_only_all(boma, true, false);
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
         ATK_HIT_ABS(fighter, *FIGHTER_ATTACK_ABSOLUTE_KIND_THROW, Hash40::new("throw"), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_OBJECT), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_GROUP), WorkModule::get_int64(boma, *FIGHTER_STATUS_THROW_WORK_INT_TARGET_HIT_NO));
+        AttackModule::clear_all(boma);
     }
     
+}
+
+#[acmd_script( agent = "mario", script = "effect_throwlw" , category = ACMD_EFFECT , low_priority)]
+unsafe fn mario_throw_lw_effect(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 17.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_attack_speedline"), Hash40::new("hip"), 0, 0, 0, 90, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        LAST_EFFECT_SET_COLOR(fighter, 1.65, 1.65, 1.65);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        EFFECT(fighter, Hash40::new("sys_crown"), Hash40::new("top"), 0.70, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 19.0);
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_down_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 39.0);
+    if is_excute(fighter) {
+        LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke_s"), Hash40::new("top"), 1.4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
+#[acmd_script( agent = "mario", script = "sound_throwlw" , category = ACMD_SOUND , low_priority)]
+unsafe fn mario_throw_lw_sound(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    frame(lua_state, 2.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_01"));
+    }
+    frame(lua_state, 3.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_mario_jump03"));
+    }
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_01"));
+    } 
+    frame(lua_state, 15.0);
+    if is_excute(fighter) {
+        PLAY_SEQUENCE(fighter, Hash40::new("seq_mario_rnd_attack"))
+    }
+    wait(lua_state, 3.0);
+    if is_excute(fighter) {
+        PLAY_SE(fighter, Hash40::new("se_common_throw_03"));
+    }
+    wait(lua_state, 1.0);
+    if is_excute(fighter) {
+        PLAY_DOWN_SE(fighter, Hash40::new("se_common_down_soil_s"))
+    }
+}
+
+#[acmd_script( agent = "mario", script = "expression_throwlw" , category = ACMD_EXPRESSION , low_priority)]
+unsafe fn mario_throw_lw_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 6.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_NONE, 3);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        QUAKE(fighter, *CAMERA_QUAKE_KIND_L);
+        RUMBLE_HIT(fighter, Hash40::new("rbkind_attackm"), 0);
+    }
+    frame(lua_state, 33.0);
+    if is_excute(fighter) {
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE_INTP, *SLOPE_STATUS_LR, 3);
+    }
 }
 
 pub fn install() {
     install_acmd_scripts!(
         mario_grab,
-        mario_dashgrab,
-        mario_pivotgrab,
+        //mario_dashgrab,
+        //mario_pivotgrab,
         mario_throw_f_game,
+        mario_throw_f_effect,
+        mario_throw_f_sound,
+        mario_throw_f_expression,
         mario_throw_b_game,
         mario_throw_hi_game,
+        mario_throw_hi_effect,
+        mario_throw_hi_sound,
+        mario_throw_hi_expression,
         mario_throw_lw_game,
+        mario_throw_lw_effect,
+        mario_throw_lw_sound,
+        mario_throw_lw_expression,
     );
 }

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -59,10 +59,10 @@ attack_air_hi:
     cancel_frame: 30
 throw_f:
   extra:
-    cancel_frame: 28
+    cancel_frame: 25
 throw_lw:
   extra:
-    cancel_frame: 38
+    cancel_frame: 39
 throw_hi:
   extra:
     cancel_frame: 37


### PR DESCRIPTION
TO DO: PORT SMASH 4 UPTILT ANIM AND MAKE HITBOXES NOT STUPIDLY HUMONGOUS

Small revisions and additions to better flesh out changes made in the original PR.

Assets:  [Mario-Assets.zip](https://github.com/HDR-Development/HewDraw-Remix/files/14327854/Mario-Assets.zip)

### **CHANGELOG**

**UPSMASH**

- [$] Adjusted VFX again (arc should now be slightly closer to Mario's head)
- [+] KBG: 95 > 97

Both percent and KBG decrease from the last PR overnerfed upsmash and made it struggle to kill at high %s unless charged. Uncharged should now kill at more reasonable %s.

**SIDE SPECIAL**

- [-] Air-stall is now mutually exclusive with Galaxy Spin's air-stall. Doing it in the air will make dspecial unpowered until refreshed

Because Jut wanted it.

**UP SPECIAL**

Finisher
- [+] Angle: 60 > 65
- [+] KBG: 125 > 130

Slightly raised angle and buffed KBG to make the move slightly better killing off the top rather than solely at the corner.

**DOWN SPECIAL**

Powered:
- [-] Air-stall is now mutually exclusive with Cape's air-stall
- [!] Can now be cancelled into wall jump on frames 23-33

Nerfed Mario's stalling capability and horizontal recovery (because Jut wanted it) for a slightly better vertical recovery and mixup capability.

**GRAB**

Standing:
- [*] Motion rate modified to vanilla's
- [+] Activity: F7-8 > F6-7
- [+] FAF: F36 > F35
- [-] Size: 4.5u > 3.5u

Before:
![GRAB OLD](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/36879661-4283-4a90-bd3c-924c98520189)
After:
![GRAB NEW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/10d1ad33-6b4a-4d0d-811e-c3aebad4c42c)

Dash:
- [-] Reverted grab data to vanilla

Before:
![DASH OLD](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/380d6715-c5eb-4ef8-8504-da0d804c49b0)
After:
![DASH NEW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/dc7102d4-271c-4c72-a8e0-8aba9b881bbd)

Pivot:
- [-] Reverted grab data to vanilla

Before:
![PIVOT OLD](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/25a45695-3e3d-4144-a66d-bec1a3607531)
After:
![PIVOT NEW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/35d9404a-f2c5-4270-88b1-0e1bf4db64c3)

Size nerfs done so that Mario has a harder time getting grabs as compensation for its increased reward from the throw sweep PR.

**FTHROW**

- [!] New animation based on the shell kick seen in 2D Mario games
- [$] VFX, SFX and expression data modified
- [!] Collateral added on foot
- [/] FAF: F28 > F25 (same frame advantage from throw release)

Collateral:
- [!] Activity: F9
- [!] Damage: 4%
- [!] Angle: 361
- [!] BKB: 30
- [!] KBG: 100

![FTHROW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/3b4bf4a7-2620-41e1-b5c6-1d2cc4708d47)

Throw Release:
- [+] Activity: F13 > F10
- [/] Damage: 8% > 4%
- [=] BKB: 60 > 55
- [=] KBG: 65 > 105
- [/] Opponents are released slightly closer to Mario and the floor

Demonstration:

https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/5b6f88b1-71f7-47d9-b9f9-bc1590cdbfae

**UPTHROW**

- [!] New animation based on the upward shell kick seen in Mario World and Wonder
- [$] VFX, SFX and expression data modified
- [!] Collateral added on foot

Collateral:
- [!] Activity: F17
- [!] Damage: 3%
- [!] Angle: 361
- [!] BKB: 30
- [!] KBG: 100

![UPTHROW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/b120274e-1b88-43e4-bda9-bf8053ee160e)

Throw Release:
- [/] Damage: 6% > 3%
- [=] BKB: 70 > 60
- [=] KBG: 90 > 145

Demonstration:

https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/29c3f1d8-d399-4988-a9cd-1e91df065d6a

**DTHROW**

- [!] New animation where Mario ground pounds the opponent
- [$] VFX, SFX and expression data modified
- [!] Collateral added on hip
- [/] FAF: F38 > F39 (same frame advantage from throw release)

Collateral:
- [!] Activity: F18
- [!] Damage: 3%
- [!] Angle: 270
- [!] BKB: 30
- [!] KBG: 100

![DTHROW](https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/1d7d98d1-fdb0-4fa7-b1d8-ada868ebc566)

Throw Release:
- [-] Activity: F18 > F19
- [/] Damage: 6% > 3%
- [=] BKB: 58 > 45
- [=] KBG: 95 > 155
- [/] Opponents are released slightly closer to Mario

Demonstration:

https://github.com/HDR-Development/HewDraw-Remix/assets/79385530/06e6d915-6569-413b-a623-f74101a437c0

Bing Bing Wahoo