### PR TITLE
Random Hotfixes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -910,6 +910,7 @@ pub mod vars {
         pub mod instance {
             // flags
             pub const SPECIAL_HI_CANCEL_ESCAPE_AIR: i32 = 0x0100;
+            pub const SPECIAL_S_PIKMIN_DETONATE_IS_DETACH_FOR_DETONATE: i32 = 0x0101;
         }
         pub mod status {
             // flags

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -63,7 +63,7 @@ unsafe fn get_damage_frame_mul(ctx: &mut skyline::hooks::InlineCtx) {
     }
 }
 
-#[skyline::hook(offset = 0x406bd4, inline)]
+#[skyline::hook(offset = 0x406bf4, inline)]
 unsafe fn get_hitstop_frame_add(ctx: &mut skyline::hooks::InlineCtx) {
     match utils::game_modes::get_custom_mode() {
         Some(modes) => {

--- a/fighters/common/src/function_hooks/fighterspecializer/jack.rs
+++ b/fighters/common/src/function_hooks/fighterspecializer/jack.rs
@@ -3,7 +3,7 @@ use super::*;
 #[skyline::from_offset(0xb2f820)]
 extern "C" fn jack_customizer(module_accessor: *mut BattleObjectModuleAccessor, customize_to: u32);
 
-#[skyline::hook(offset = 0xb30934, inline)]
+#[skyline::hook(offset = 0xb30954, inline)]
 unsafe fn check_doyle_summon_dispatch_hook(ctx: &mut skyline::hooks::InlineCtx) {
     let module_accessor = *ctx.registers[21].x.as_ref() as *mut BattleObjectModuleAccessor;
     WorkModule::off_flag(module_accessor, *FIGHTER_JACK_INSTANCE_WORK_ID_FLAG_DOYLE_EXIST);

--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -16,30 +16,27 @@ pub fn install() {
     //skyline::nro::add_hook(item_nro_hook);
 }
 
-static INT_OFFSET: usize = 0x4e5380; // 12.0.0
-static FLOAT_OFFSET: usize = 0x4e53C0; // 12.0.0
 
+// #[skyline::hook(offset=0x720540)]
+// unsafe fn get_offset(arg0: u64, arg1: u64) {
+//     static mut ONCE: bool = true;
+//     if ONCE {
+//         ONCE = false;
+//         //debug::dump_trace();
+//     }
+//     original!()(arg0, arg1);
+// }
 
-#[skyline::hook(offset=0x720540)]
-unsafe fn get_offset(arg0: u64, arg1: u64) {
-    static mut ONCE: bool = true;
-    if ONCE {
-        ONCE = false;
-        //debug::dump_trace();
-    }
-    original!()(arg0, arg1);
-}
+// #[skyline::hook(offset=0x1f8810c, inline)]
+// unsafe fn get_inline_offset(ctx: &InlineCtx) {
+//     static mut ONCE: bool = true;
+//     if ONCE {
+//         ONCE = false;
+//         println!("{:#x}", ctx.registers[3].x.as_ref() - getRegionAddress(Region::Text) as u64);
+//     }
+// }
 
-#[skyline::hook(offset=0x1f8810c, inline)]
-unsafe fn get_inline_offset(ctx: &InlineCtx) {
-    static mut ONCE: bool = true;
-    if ONCE {
-        ONCE = false;
-        println!("{:#x}", ctx.registers[3].x.as_ref() - getRegionAddress(Region::Text) as u64);
-    }
-}
-
-#[skyline::hook(offset=INT_OFFSET)]
+#[skyline::hook(offset=0x4E53A0)]
 pub unsafe fn get_param_int_hook(x0: u64, x1: u64, x2 :u64) -> i32 {
     let mut boma = *((x0 as *mut u64).offset(1)) as *mut BattleObjectModuleAccessor;
     let boma_reference = &mut *boma;
@@ -122,7 +119,7 @@ pub unsafe fn get_param_int_hook(x0: u64, x1: u64, x2 :u64) -> i32 {
     original!()(x0, x1, x2)
 }
 
-#[skyline::hook(offset=FLOAT_OFFSET)]
+#[skyline::hook(offset=0x4E53E0)]
 pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 /*param_hash*/: u64) -> f32 {
     let mut boma = *((x0 as *mut u64).offset(1)) as *mut BattleObjectModuleAccessor;
     let boma_reference = &mut *boma;

--- a/fighters/common/src/function_hooks/hitstun.rs
+++ b/fighters/common/src/function_hooks/hitstun.rs
@@ -1,5 +1,5 @@
 
-#[skyline::hook(offset=0x6a70e0)]
+#[skyline::hook(offset=0x6a7100)] // unadjusted for 13.0.2?
 pub fn stub_kill_screen() {}
 
 pub fn install() {

--- a/fighters/common/src/function_hooks/shotos.rs
+++ b/fighters/common/src/function_hooks/shotos.rs
@@ -6,7 +6,7 @@ pub fn install() {
     disable_negative_edge,
     // enable_terry_inputs_for_shotos
   );
-  skyline::patching::Patch::in_text(0x10d45a4).data(0x14000014u32); // enables terry's command inputs for shotos
+  skyline::patching::Patch::in_text(0x10D45C4).data(0x14000014u32); // enables terry's command inputs for shotos
 }
 
 // disables negative edge check for both shotos

--- a/fighters/common/src/function_hooks/stage_hazards.rs
+++ b/fighters/common/src/function_hooks/stage_hazards.rs
@@ -10,11 +10,11 @@ extern "C" {
 
 #[skyline::hook(offset = 0x30F6DE0)]
 unsafe fn stub(arg: u64) {
-    if get_stage_id() == 0x8f && get_current_stage_alt() == 0 {
+    // if get_stage_id() == 0x8f && get_current_stage_alt() == 0 {
         return;
-    } else {
-        call_original!(arg);
-    }
+    // } else {
+    //     call_original!(arg);
+    // }
 }
 
 #[skyline::hook(offset = 0x5209c0)]
@@ -23,9 +23,10 @@ unsafe fn area_manager_process(manager: *const u64) {
     let end = *manager.add(2);
     while start != end {
         let current = *(start as *const u64);
-        if *(current as *mut u8).add(0x20) == 0x1b
-            && (get_stage_id() == 0x8f && get_current_stage_alt() == 0)
-        {
+        // if *(current as *mut u8).add(0x20) == 0x1b
+        //     && (get_stage_id() == 0x8f && get_current_stage_alt() == 0)
+        // {
+        if *(current as *mut u8).add(0x20) == 0x1b && get_stage_id() == 0x8f {
             *(current as *mut bool).add(0x21) = false;
             *((current + 0x40) as *mut f32) = 0.0;
             *((current + 0x40) as *mut f32).add(1) = 0.0;
@@ -57,9 +58,10 @@ static HAZARDLESS_STAGE_IDS: &[u32] = &[
 #[skyline::hook(offset = 0x178ab60, inline)]
 unsafe fn init_stage(ctx: &mut skyline::hooks::InlineCtx) {
     let stage_id = *ctx.registers[1].w.as_ref();
-    let is_alt_haz_off = ([0x59].contains(&stage_id) && get_current_stage_alt() == 0)
-        || (stage_id == 0x68 && get_current_stage_alt() == 0);
-    if HAZARDLESS_STAGE_IDS.contains(&stage_id) || is_alt_haz_off {
+    // let is_alt_haz_off = ([0x59].contains(&stage_id) && get_current_stage_alt() == 0)
+    //     || (stage_id == 0x68 && get_current_stage_alt() == 0);
+    // if HAZARDLESS_STAGE_IDS.contains(&stage_id) || is_alt_haz_off {
+    if HAZARDLESS_STAGE_IDS.contains(&stage_id) || stage_id == 0x68 || stage_id == 0x59 {
         *ctx.registers[3].w.as_mut() = 0;
     }
 }
@@ -76,9 +78,10 @@ unsafe fn handle_movement_grav_update(ctx: &mut skyline::hooks::InlineCtx) {
 unsafe fn fix_hazards_for_online(ctx: &skyline::hooks::InlineCtx) {
     let ptr = *ctx.registers[1].x.as_ref();
     let stage_id = *(ptr as *const u16) as u32;
-    let is_alt_haz_off = ([0x59].contains(&stage_id) && get_current_stage_alt() == 0)
-        || (stage_id == 0x68 && get_current_stage_alt() == 0);
-    if HAZARDLESS_STAGE_IDS.contains(&stage_id) || is_alt_haz_off {
+    // let is_alt_haz_off = ([0x59].contains(&stage_id) && get_current_stage_alt() == 0)
+    //     || (stage_id == 0x68 && get_current_stage_alt() == 0);
+    // if HAZARDLESS_STAGE_IDS.contains(&stage_id) || is_alt_haz_off {
+    if HAZARDLESS_STAGE_IDS.contains(&stage_id) || stage_id == 0x68 || stage_id == 0x59 {
         *(ptr as *mut bool).add(0x10) = false;
     }
 }
@@ -97,11 +100,11 @@ unsafe fn lylat_no_rot(ctx: &mut skyline::hooks::InlineCtx) {
 // 0x4 - default haz off space
 #[skyline::hook(offset = 0x297D68C, inline)]
 unsafe fn lylat_set_form_hazards_off(ctx: &mut skyline::hooks::InlineCtx) {
-    if get_current_stage_alt() == 0 {
-        *ctx.registers[8].x.as_mut() = 0x2;
-    } else {
+    // if get_current_stage_alt() == 0 {
+    //     *ctx.registers[8].x.as_mut() = 0x2;
+    // } else {
         *ctx.registers[8].x.as_mut() = 0x4;
-    }
+    // }
 }
 
 pub fn install() {

--- a/fighters/common/src/general_statuses/shield/misc.rs
+++ b/fighters/common/src/general_statuses/shield/misc.rs
@@ -425,6 +425,13 @@ pub unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
         return true.into();
     }
 
+    // check parry
+    if fighter.is_parry_input() {
+        fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), true.into());
+        VarModule::on_flag(fighter.object(), vars::common::instance::IS_PARRY_FOR_GUARD_OFF);
+        return true.into();
+    }
+
     // check jump
     if
         fighter.sub_check_button_jump().get_bool() ||
@@ -449,13 +456,6 @@ pub unsafe fn sub_guard_cont(fighter: &mut L2CFighterCommon) -> L2CValue {
             return true.into();
         }
     } else if check_grab_oos(fighter).get_bool() {
-        return true.into();
-    }
-
-    // check parry
-    if fighter.is_parry_input() {
-        fighter.change_status(FIGHTER_STATUS_KIND_GUARD_OFF.into(), true.into());
-        VarModule::on_flag(fighter.object(), vars::common::instance::IS_PARRY_FOR_GUARD_OFF);
         return true.into();
     }
 

--- a/fighters/lucario/src/status/special_hi.rs
+++ b/fighters/lucario/src/status/special_hi.rs
@@ -246,7 +246,7 @@ unsafe extern "C" fn lucario_special_hi_metered_cancel(fighter: &mut L2CFighterC
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_AIR);
     if fighter.sub_transition_group_check_air_attack().get_bool() {
         KineticModule::mul_speed(fighter.module_accessor, &Vector3f{x: 0.5, y: 0.5, z: 0.5}, *FIGHTER_KINETIC_ENERGY_ID_STOP);
-        MeterModule::drain_direct(fighter.object(), MeterModule::meter_per_level(fighter.object()) * 2.0);
+        MeterModule::drain_direct(fighter.battle_object, MeterModule::meter_per_level(fighter.battle_object));
         let frames = 120.max(VarModule::get_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME));
         VarModule::set_int(fighter.object(), vars::lucario::instance::METER_PAUSE_REGEN_FRAME, frames);
         VarModule::on_flag(fighter.object(), vars::lucario::instance::IS_USPECIAL_ATTACK_CANCEL);

--- a/fighters/marth/src/acmd/aerials.rs
+++ b/fighters/marth/src/acmd/aerials.rs
@@ -123,19 +123,18 @@ unsafe fn marth_attack_air_hi_game(fighter: &mut L2CAgentBase) {
     frame(lua_state, 3.0);
     if is_excute(fighter) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
-        FT_MOTION_RATE(fighter, 2.0 / 2.5);
     }
-    frame(lua_state, 5.45);
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE_RANGE(fighter, 5.0, 13.0, 6.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 5.0 / 6.0);
         ATTACK(fighter, 0, 0, Hash40::new("sword1"), 13.0, 90, 70, 0, 45, 4.0, 0.0, 0.0, 7.75, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_MARTH_SWORD, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 1, 0, Hash40::new("sword1"), 10.0, 80, 70, 0, 30, 4.0, 0.0, 0.0, 3.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 2, 0, Hash40::new("armr"), 9.0, 80, 70, 0, 20, 3.5, 0.0, 1.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
         ATTACK(fighter, 3, 0, Hash40::new("claviclel"), 9.0, 80, 70, 0, 18, 3.5, 0.0, 0.0, 0.0, None, None, None, 0.8, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
     }
-    frame(lua_state, 11.45);
+    frame(lua_state, 13.0);
+    FT_MOTION_RATE(fighter, 1.0);
     if is_excute(fighter) {
-        FT_MOTION_RATE(fighter, 1.0);
         AttackModule::clear_all(boma);
     }
     frame(lua_state, 38.0);

--- a/fighters/pikmin/src/pikmin/acmd/specials.rs
+++ b/fighters/pikmin/src/pikmin/acmd/specials.rs
@@ -7,22 +7,24 @@ unsafe fn game_spsremved(fighter: &mut L2CAgentBase) {
     let boma = fighter.boma();
     let variation = WorkModule::get_int(boma, *WEAPON_PIKMIN_PIKMIN_INSTANCE_WORK_ID_INT_VARIATION);
     let p = PikminInfo::from(variation);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-        let dmg = 4.8;
-        // special case for yellow pikmin
-        // reduces the length of the paralyze effect
-        let hitlag = if variation == 1 {
-            0.4
-        } else {
-            1.0
-        };
-        ATTACK(fighter, 0, 0, Hash40::new("waist"), dmg * p.dmg, 90, 105, 0, 65, 6.0, 0.0, 0.0, 0.0, None, None, None, hitlag * p.hitlag, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, dmg * p.shield_dmg, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, p.attr_special, *ATTACK_SOUND_LEVEL_L, p.sound, *ATTACK_REGION_PIKMIN);
-    }
-    frame(lua_state, 6.0);
-    if is_excute(fighter) {
-        AttackModule::clear_all(boma);
-        fighter.change_status_req(WEAPON_PIKMIN_PIKMIN_STATUS_KIND_DEATH.into(), false.into());
+    if VarModule::is_flag(fighter.battle_object, vars::pikmin::instance::SPECIAL_S_PIKMIN_DETONATE_IS_DETACH_FOR_DETONATE) {
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+            let dmg = 4.8;
+            // special case for yellow pikmin
+            // reduces the length of the paralyze effect
+            let hitlag = if variation == 1 {
+                0.4
+            } else {
+                1.0
+            };
+            ATTACK(fighter, 0, 0, Hash40::new("waist"), dmg * p.dmg, 90, 105, 0, 65, 6.0, 0.0, 0.0, 0.0, None, None, None, hitlag * p.hitlag, 0.5, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, dmg * p.shield_dmg, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, p.attr_special, *ATTACK_SOUND_LEVEL_L, p.sound, *ATTACK_REGION_PIKMIN);
+        }
+        frame(lua_state, 6.0);
+        if is_excute(fighter) {
+            AttackModule::clear_all(boma);
+            fighter.change_status_req(WEAPON_PIKMIN_PIKMIN_STATUS_KIND_DEATH.into(), false.into());
+        }
     }
 }
 

--- a/fighters/rockman/src/vtable_hook.rs
+++ b/fighters/rockman/src/vtable_hook.rs
@@ -304,7 +304,7 @@ pub fn install(is_runtime: bool) {
     skyline::patching::Patch::in_text(0x1083cd0).nop();
     skyline::patching::Patch::in_text(0x1083ce4).nop();
     // Enable
-    skyline::patching::Patch::in_text(0x10838e0).nop();
+    skyline::patching::Patch::in_text(0x1083900).nop();
     skyline::patching::Patch::in_text(0x1083900).nop();
     skyline::patching::Patch::in_text(0x1083928).nop();
     skyline::patching::Patch::in_text(0x1083944).nop();

--- a/fighters/rockman/src/vtable_hook.rs
+++ b/fighters/rockman/src/vtable_hook.rs
@@ -304,7 +304,7 @@ pub fn install(is_runtime: bool) {
     skyline::patching::Patch::in_text(0x1083cd0).nop();
     skyline::patching::Patch::in_text(0x1083ce4).nop();
     // Enable
-    skyline::patching::Patch::in_text(0x1083900).nop();
+    skyline::patching::Patch::in_text(0x10838e0).nop();
     skyline::patching::Patch::in_text(0x1083900).nop();
     skyline::patching::Patch::in_text(0x1083928).nop();
     skyline::patching::Patch::in_text(0x1083944).nop();


### PR DESCRIPTION
- Adjusted Marth's UAir animation timing to fix the effects not aligning with the hitboxes
  - FAF 43 --> 42
- Fixed a bug which caused pikmin to detonate immediately if hit while latching during SSpecial
- Fixed a bug which cause Lucario's USpecial cancel to cost twice as much as expected
- Fixed a bug which caused Smash 64 mode to have lower shield stun
- Fixed a bug which caused Smash 64 mode to have higher landing lag
- Fixed a bug which caused Smash 64 mode to have higher hitlag (fixes #2274)
- Fixed a bug which caused Smash 64 mode to have higher gravity
- Fixed a bug which caused Smash 64 mode to have higher fall speed
- Fixed a bug which caused Ken and Ryu to crash on load
- Fixed a bug which caused Piranha Plant's Ptooie to have the wrong lifetime
- Fixed a bug which caused Lucario's Aura Bomb to have a the wrong lifetime
- Fixed a bug which caused Lucario's Aura Bomb to travel at the same speed as Aura Sphere
- Fixed a bug which caused Joker's Arsene Recall to behave incorrectly
- Fixed a bug which caused the killscreen zoom to sometimes occur
- Fixed a bug which caused parry inputs to sometimes cause platdrops, roll, or spotdodge
- Temporarily forces hazards off for Lylat Cruise, Warioware Inc., and Ganon's Tower/Pirate Ship.