### PR TITLE
Smashline 2 Fixes

### DIFF
--- a/fighters/buddy/src/opff.rs
+++ b/fighters/buddy/src/opff.rs
@@ -23,7 +23,7 @@ unsafe fn blue_eggs_land_cancels(fighter: &mut L2CFighterCommon) {
         // 11F of landing lag plus one extra frame to subtract from the FAF to actually get that amount of lag
         let landing_lag = 12.0;
         if MotionModule::frame(fighter.module_accessor) < (special_n_fire_cancel_frame_ground - landing_lag) {
-            MotionModule::change_motion_inherit_frame(fighter.module_accessor, Hash40::new("special_n"), 49.0 - landing_lag, 1.0, 0.0, false, false);
+            MotionModule::set_frame_sync_anim_cmd(fighter.module_accessor, 49.0 - landing_lag, true, true, false);
         }
         LANDING_EFFECT(fighter, Hash40::new("sys_landing_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0, 0, false);
         //fighter.change_status_req(*FIGHTER_STATUS_KIND_LANDING, false);

--- a/fighters/common/src/general_statuses/airdodge.rs
+++ b/fighters/common/src/general_statuses/airdodge.rs
@@ -6,11 +6,11 @@ use globals::*;
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(Pre, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_pre_EscapeAir)
-        .status(Main, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_EscapeAir)
-        .status(End, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_end_EscapeAir)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Pre, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_pre_EscapeAir)
+    //     .status(Main, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_EscapeAir)
+    //     .status(End, *FIGHTER_STATUS_KIND_ESCAPE_AIR, status_end_EscapeAir)
+    //     .install();
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {
@@ -152,9 +152,9 @@ pub unsafe fn status_end_EscapeAir(fighter: &mut L2CFighterCommon) -> L2CValue {
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_TURN);
             WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_ENABLE_LANDING_CLIFF_STOP);
         }
-        VarModule::off_flag(fighter.battle_object, vars::common::status::SHOULD_WAVELAND);
-        VarModule::off_flag(fighter.battle_object, vars::common::instance::PERFECT_WAVEDASH);
     }
+    VarModule::off_flag(fighter.battle_object, vars::common::status::SHOULD_WAVELAND);
+    VarModule::off_flag(fighter.battle_object, vars::common::instance::PERFECT_WAVEDASH);
     VarModule::on_flag(fighter.battle_object, vars::common::instance::ENABLE_AIR_ESCAPE_MAGNET);
     0.into()
 }

--- a/fighters/common/src/general_statuses/attack/attackdash.rs
+++ b/fighters/common/src/general_statuses/attack/attackdash.rs
@@ -14,9 +14,9 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 }
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(Main, *FIGHTER_STATUS_KIND_ATTACK_DASH, status_AttackDash)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Main, *FIGHTER_STATUS_KIND_ATTACK_DASH, status_AttackDash)
+    //     .install();
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_pre_AttackDash)]

--- a/fighters/common/src/general_statuses/attack/attackx4.rs
+++ b/fighters/common/src/general_statuses/attack/attackx4.rs
@@ -5,10 +5,10 @@ use globals::*;
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(End, *FIGHTER_STATUS_KIND_ATTACK_HI4_START, status_end_AttackHi4Start)
-        .status(End, *FIGHTER_STATUS_KIND_ATTACK_LW4_START, status_end_AttackLw4Start)
-        .install();
+    // Agent::new("fighter")
+    //     .status(End, *FIGHTER_STATUS_KIND_ATTACK_HI4_START, status_end_AttackHi4Start)
+    //     .status(End, *FIGHTER_STATUS_KIND_ATTACK_LW4_START, status_end_AttackLw4Start)
+    //     .install();
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {

--- a/fighters/common/src/general_statuses/damageflyreflect.rs
+++ b/fighters/common/src/general_statuses/damageflyreflect.rs
@@ -4,14 +4,14 @@ use globals::*;
 // This file contains code for ceiling/wall/ground bounces
 
 pub fn install() {
-    Agent::new("fighter")
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY, damage_fly_end)
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D, damage_fly_reflect_d_end)
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_JUMP_BOARD, damage_fly_reflect_jump_board_end)
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR, damage_fly_reflect_lr_end)
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL, damage_fly_roll_end)
-        .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR, damage_fly_meteor_end)
-        .install();
+    // Agent::new("fighter")
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY, damage_fly_end)
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_D, damage_fly_reflect_d_end)
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_JUMP_BOARD, damage_fly_reflect_jump_board_end)
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_REFLECT_LR, damage_fly_reflect_lr_end)
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_ROLL, damage_fly_roll_end)
+    //     .status(End, *FIGHTER_STATUS_KIND_DAMAGE_FLY_METEOR, damage_fly_meteor_end)
+    //     .install();
     skyline::nro::add_hook(nro_hook);
 }
 

--- a/fighters/common/src/general_statuses/jump.rs
+++ b/fighters/common/src/general_statuses/jump.rs
@@ -6,10 +6,10 @@ use globals::*;
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(Main, *FIGHTER_STATUS_KIND_JUMP, status_Jump)
-        .status(Pre, *FIGHTER_STATUS_KIND_JUMP, status_pre_Jump)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Main, *FIGHTER_STATUS_KIND_JUMP, status_Jump)
+    //     .status(Pre, *FIGHTER_STATUS_KIND_JUMP, status_pre_Jump)
+    //     .install();
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {

--- a/fighters/common/src/general_statuses/jumpsquat.rs
+++ b/fighters/common/src/general_statuses/jumpsquat.rs
@@ -6,11 +6,11 @@ use utils::game_modes::CustomMode;
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(Exec, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_exec_JumpSquat)
-        .status(End, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_end_JumpSquat)
-        .status(Main, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_JumpSquat)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Exec, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_exec_JumpSquat)
+    //     .status(End, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_end_JumpSquat)
+    //     .status(Main, *FIGHTER_STATUS_KIND_JUMP_SQUAT, status_JumpSquat)
+    //     .install();
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {
@@ -25,6 +25,7 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
             sub_jump_squat_uniq_check_sub_mini_attack,
             sub_status_JumpSquat_check_stick_lr_update,
             status_JumpSquat,
+            bind_address_call_status_end_JumpSquat,
             status_end_JumpSquat,
         );
     }
@@ -182,7 +183,11 @@ unsafe fn status_JumpSquat_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
 }
 
 // end status stuff
-// no symbol since you can't call `fighter.status_end_JumpSquat()`, and replacing `bind_call_...` makes no sense here
+#[skyline::hook(replace = L2CFighterCommon_bind_address_call_status_end_JumpSquat)]
+unsafe fn bind_address_call_status_end_JumpSquat(fighter: &mut L2CFighterCommon, _agent: &mut L2CAgent) -> L2CValue {
+    fighter.status_end_JumpSquat()
+}
+
 #[skyline::hook(replace = L2CFighterCommon_status_end_JumpSquat)]
 unsafe fn status_end_JumpSquat(fighter: &mut L2CFighterCommon) -> L2CValue {
     InputModule::disable_persist(fighter.battle_object);

--- a/fighters/common/src/general_statuses/run.rs
+++ b/fighters/common/src/general_statuses/run.rs
@@ -218,11 +218,11 @@ fn nro_info(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_info);
-    Agent::new("fighter")
-        .status(Pre, *FIGHTER_STATUS_KIND_RUN, status_pre_run)
-        .status(Main, *FIGHTER_STATUS_KIND_RUN, status_run)
-        .status(Main, *FIGHTER_STATUS_KIND_RUN_BRAKE, status_runbrake)
-        .status(Main, *FIGHTER_STATUS_KIND_TURN_RUN_BRAKE, status_turnrunbrake)
-        .status(Main, *FIGHTER_STATUS_KIND_TURN_RUN, status_turnrun)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Pre, *FIGHTER_STATUS_KIND_RUN, status_pre_run)
+    //     .status(Main, *FIGHTER_STATUS_KIND_RUN, status_run)
+    //     .status(Main, *FIGHTER_STATUS_KIND_RUN_BRAKE, status_runbrake)
+    //     .status(Main, *FIGHTER_STATUS_KIND_TURN_RUN_BRAKE, status_turnrunbrake)
+    //     .status(Main, *FIGHTER_STATUS_KIND_TURN_RUN, status_turnrun)
+    //     .install();
 }

--- a/fighters/common/src/general_statuses/turn.rs
+++ b/fighters/common/src/general_statuses/turn.rs
@@ -205,8 +205,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
-    Agent::new("fighter")
-        .status(Main, *FIGHTER_STATUS_KIND_TURN, status_turn)
-        .status(End, *FIGHTER_STATUS_KIND_TURN, status_end_turn)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Main, *FIGHTER_STATUS_KIND_TURN, status_turn)
+    //     .status(End, *FIGHTER_STATUS_KIND_TURN, status_end_turn)
+    //     .install();
 }

--- a/fighters/common/src/general_statuses/walk.rs
+++ b/fighters/common/src/general_statuses/walk.rs
@@ -139,8 +139,8 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
 
-    Agent::new("fighter")
-        .status(Pre, *FIGHTER_STATUS_KIND_WALK, status_pre_walk)
-        .status(Main, *FIGHTER_STATUS_KIND_WALK, status_walk)
-        .install();
+    // Agent::new("fighter")
+    //     .status(Pre, *FIGHTER_STATUS_KIND_WALK, status_pre_walk)
+    //     .status(Main, *FIGHTER_STATUS_KIND_WALK, status_walk)
+    //     .install();
 }

--- a/fighters/inkling/src/opff.rs
+++ b/fighters/inkling/src/opff.rs
@@ -162,4 +162,7 @@ pub fn install() {
     smashline::Agent::new("inkling")
         .on_line(Main, inkling_frame_wrapper)
         .install();
+    skyline::install_hooks!(
+        get_ink_colors
+    );
 }

--- a/fighters/koopa/src/opff.rs
+++ b/fighters/koopa/src/opff.rs
@@ -150,7 +150,6 @@ pub unsafe fn moveset(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut
     fireball_cooldown(boma,status_kind);
     koopa_ex_punch(fighter);
     fastfall_specials(fighter);
-    fastfall_specials(fighter);
 }
 
 pub extern "C" fn koopa_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {

--- a/fighters/lucario/src/status/attack_air.rs
+++ b/fighters/lucario/src/status/attack_air.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn attack_air_end(fighter: &mut L2CFighterCommon) -> L2CVa
         }
         VarModule::off_flag(fighter.object(), vars::lucario::instance::IS_USPECIAL_ATTACK_CANCEL);
     }
-    smashline::original_status(Main, fighter, *FIGHTER_STATUS_KIND_ATTACK_AIR)(fighter)
+    smashline::original_status(End, fighter, *FIGHTER_STATUS_KIND_ATTACK_AIR)(fighter)
 }
 
 pub unsafe extern "C" fn attack_air_main(fighter: &mut L2CFighterCommon) -> L2CValue {

--- a/fighters/lucario/src/status/special_hi.rs
+++ b/fighters/lucario/src/status/special_hi.rs
@@ -5,7 +5,7 @@ use globals::*;
 // FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND
 
 pub unsafe extern "C" fn special_hi_bound_end(fighter: &mut L2CFighterCommon) -> L2CValue {
-    let ret = smashline::original_status(Main, fighter, *FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND)(fighter);
+    let ret = smashline::original_status(End, fighter, *FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_BOUND)(fighter);
 
     fighter.off_flag(*FIGHTER_INSTANCE_WORK_ID_FLAG_DISABLE_LANDING_CANCEL);
     

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -278,7 +278,7 @@ unsafe fn power_cast(fighter: &mut L2CFighterCommon) {
                 //println!("and why he ourple");
             }
             else if color_2 == 3 {
-                fighter.change_status(statuses::palutena::SPECIAL_N_R.into(), false.into());
+                fighter.change_status(statuses::palutena::SPECIAL_N_G.into(), false.into());
                 //println!("i like cash from my hair to my ass");
             }
             else {

--- a/fighters/pickel/src/status.rs
+++ b/fighters/pickel/src/status.rs
@@ -365,6 +365,9 @@ extern "C" fn pickel_init(fighter: &mut L2CFighterCommon) {
     }
 }
 pub fn install() {
+    skyline::install_hooks!(
+        stuff_hook
+    );
     smashline::Agent::new("pickel")
         .status(
             Main,

--- a/fighters/tantan/src/status.rs
+++ b/fighters/tantan/src/status.rs
@@ -261,7 +261,7 @@ unsafe extern "C" fn tantan_special_hi_exec(fighter: &mut L2CFighterCommon) -> L
         fighter.change_status_req(*FIGHTER_TANTAN_STATUS_KIND_SPECIAL_HI_AIR, false);
         return 0.into();
     }
-    return smashline::original_status(Exec, fighter, *FIGHTER_STATUS_KIND_SPECIAL_HI)(fighter);
+    return smashline::original_status(Exec, fighter, *FIGHTER_TANTAN_STATUS_KIND_SPECIAL_HI_GROUND)(fighter);
 }
 
 unsafe extern "C" fn tantan_special_hi_air_pre(fighter: &mut L2CFighterCommon) -> L2CValue {

--- a/fighters/wolf/src/status/special_s.rs
+++ b/fighters/wolf/src/status/special_s.rs
@@ -442,7 +442,7 @@ pub fn install() {
         .status(Main, SPECIAL_S_END, special_s_end_main)
         .status(End, SPECIAL_S_END, special_s_end_end)
         .status(Init, SPECIAL_S_END, special_s_end_init)
-        .status(Init, SPECIAL_S_END, special_s_end_exec)
+        .status(Exec, SPECIAL_S_END, special_s_end_exec)
         .on_start(wolf_init)
         .install();
 }


### PR DESCRIPTION
A collection of fixes for (mostly) game-crashing issues found after Smashline 2 dropped in nightly.

# Changelog

## Common
- Disabled common status replacements for all statuses that use them
  - This is because Smashline 2 handles replacement of common statuses *after* fighter-specific statuses are called, rather than before.
  - Jump Squat had `bind_address_call_status_end_JumpSquat` reimplemented to call `status_end_JumpSquat`
  - This change also happens to fix Mewtwo air dodge not turning him invisible.

## Lucario
- Fixed a crash with ATTACK_AIR End
- Fixed a (potential) crash with SPECIAL_HI_BOUND

## Wolf
- Fixed Wolf Flash hanging in the air

## Palutena
- Yellow + Blue is now Green (not Red)

## Inkling
- Fixed an issue where Down Air's ink splash didn't have any color

## Banjo & Kazooie
- Neutral Special land cancel restored

## Min Min
- Fixed a crash with SPECIAL_HI_GROUND exec

## Steve
- Fixed a crash when holding Shield