### PR TITLE
Various Dedede Bugfixes

### DIFF
--- a/fighters/dedede/src/acmd/other.rs
+++ b/fighters/dedede/src/acmd/other.rs
@@ -291,7 +291,8 @@ unsafe extern "C" fn dedede_gordo_special_s_attack_game(fighter: &mut L2CAgentBa
         WorkModule::set_int(boma, 300, *WEAPON_INSTANCE_WORK_ID_INT_LIFE);
         /* below grabs the boma of the opponent hitting gordo, the attack data of that hit, and adjusts the speed accordingly */
         let num_players = Fighter::get_fighter_entry_count(); 
-        if StopModule::is_hit(boma){ 
+        if StopModule::is_hit(boma)
+        && !StopModule::is_hit(owner_module_accessor) { 
             for i in 0..num_players{
                 let opponent_boma = sv_battle_object::module_accessor(Fighter::get_id_from_entry_id(i));
 

--- a/fighters/dedede/src/acmd/specials.rs
+++ b/fighters/dedede/src/acmd/specials.rs
@@ -307,6 +307,32 @@ unsafe extern "C" fn dedede_special_air_s_get_effect(fighter: &mut L2CAgentBase)
     }
 }
 
+unsafe extern "C" fn dedede_special_s_get_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ItemModule::set_have_item_visibility(boma, false, 0);
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_attackl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
+unsafe extern "C" fn dedede_special_air_s_get_expression(fighter: &mut L2CAgentBase) {
+    let lua_state = fighter.lua_state_agent;
+    let boma = fighter.boma();
+    if is_excute(fighter) {
+        ItemModule::set_have_item_visibility(boma, false, 0);
+        slope!(fighter, *MA_MSC_CMD_SLOPE_SLOPE, *SLOPE_STATUS_LR);
+    }
+    frame(lua_state, 18.0);
+    if is_excute(fighter) {
+        ControlModule::set_rumble(boma, Hash40::new("rbkind_attackl"), 0, false, *BATTLE_OBJECT_ID_INVALID as u32);
+    }
+}
+
 unsafe extern "C" fn dedede_special_lw_start_game(fighter: &mut L2CAgentBase) {
     let lua_state = fighter.lua_state_agent;
     let boma = fighter.boma();
@@ -569,6 +595,8 @@ pub fn install() {
         .acmd("game_specialairsget", dedede_special_air_s_get_game)
         .acmd("effect_specialsget", dedede_special_s_get_effect)
         .acmd("effect_specialairsget", dedede_special_air_s_get_effect)
+        .acmd("expression_specialsget", dedede_special_s_get_expression)
+        .acmd("expression_specialairsget", dedede_special_air_s_get_expression)
         .acmd("game_speciallwstart", dedede_special_lw_start_game)
         .acmd("game_specialairlwstart", dedede_special_lw_start_game)
         .acmd("game_specialairlwstart", dedede_special_air_lw_start_game)

--- a/fighters/dedede/src/opff.rs
+++ b/fighters/dedede/src/opff.rs
@@ -116,7 +116,7 @@ unsafe fn gordo_recatch(boma: &mut BattleObjectModuleAccessor, frame: f32, fight
         //Prevents B reversing when we are in the dash
         if StatusModule::status_kind(boma) == *FIGHTER_STATUS_KIND_SPECIAL_S 
         && VarModule::is_flag(fighter.battle_object, vars::dedede::instance::IS_DASH_GORDO){
-            if fighter.status_frame() < 5{
+            if fighter.status_frame() > 1 && fighter.status_frame() < 4{
                 ControlModule::reset_main_stick(boma);
             }
         }


### PR DESCRIPTION
- Fixes a bug where hitting a gordo back and having that gordo hit Dedede on the same frame would cause the gordo to turn black for the rest of the game
- Fixes a bug where gordo dash was still using vanilla expression scripts
- Fixes a bug where Dedede would be able to reverse the gordo dash