### PR TITLE
Mewtwo Unfloat Confusion Window fix

### DIFF
--- a/fighters/common/src/opff/floats.rs
+++ b/fighters/common/src/opff/floats.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-pub unsafe fn run(fighter: &mut L2CFighterCommon, situation_kind: i32) {
-    if situation_kind != *SITUATION_KIND_AIR {
+pub unsafe fn run(fighter: &mut L2CFighterCommon, status_kind: i32, situation_kind: i32) {
+    if situation_kind == *SITUATION_KIND_GROUND || status_kind == *FIGHTER_STATUS_KIND_REBIRTH {
         VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_FLOAT);
     }
 }

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -121,7 +121,7 @@ pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
 
     // Character Moveset Changes
     // moveset_changes::run(boma, id, cat, status_kind, situation_kind, motion_kind, fighter_kind, stick_x, stick_y, facing, frame);
-    floats::run(fighter, info.situation_kind);
+    floats::run(fighter, info.status_kind, info.situation_kind);
 }
 
 pub fn install() {

--- a/fighters/mewtwo/src/status/attack_air.rs
+++ b/fighters/mewtwo/src/status/attack_air.rs
@@ -42,7 +42,11 @@ pub unsafe extern "C" fn attack_air_main(fighter: &mut L2CFighterCommon) -> L2CV
     if let Some(log) = log {
         notify_event_msc_cmd!(fighter, Hash40::new_raw(0x2b94de0d96), FIGHTER_LOG_ACTION_CATEGORY_KEEP, log);
     }
-
+    // allow fast fall during float release aerials
+    if !StopModule::is_stop(fighter.module_accessor) {
+        fighter.sub_fall_common_uniq(false.into());
+    }
+    fighter.global_table[SUB_STATUS].assign(&L2CValue::Ptr(L2CFighterCommon_sub_fall_common_uniq as *const () as _));
     // fighter.status_AttackAir_Main_common();
     WorkModule::set_int64(fighter.module_accessor, motion as i64, *FIGHTER_STATUS_ATTACK_AIR_WORK_INT_MOTION_KIND);
     fighter.sub_shift_status_main(L2CValue::Ptr(L2CFighterCommon_status_AttackAir_Main as *const () as _))

--- a/fighters/mewtwo/src/status/fall.rs
+++ b/fighters/mewtwo/src/status/fall.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 unsafe extern "C" fn mewtwo_fall_end(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if fighter.global_table[PREV_STATUS_KIND].get_i32() == statuses::mewtwo::FLOAT && fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_SPECIAL_S {
+    if fighter.global_table[PREV_STATUS_KIND].get_i32() == statuses::mewtwo::FLOAT 
+    && fighter.global_table[STATUS_KIND].get_i32() == *FIGHTER_STATUS_KIND_SPECIAL_S 
+    && fighter.global_table[CURRENT_FRAME].get_i32() <= 10 {
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_MEWTWO_INSTANCE_WORK_ID_FLAG_SPECIAL_S_BUOYANCY);
     }
     return smashline::original_status(End, fighter, *FIGHTER_STATUS_KIND_FALL)(fighter);


### PR DESCRIPTION
Forgot to add a frame window, now has a 10f window after releasing float to disable side-b stall.
Also adds float-release aerial fastfall check to mewtwo, matching others
Floats no longer restore on ledge grab