### PR TITLE
Implement knockback-based hitlag scaling

### DIFF
--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -81,10 +81,63 @@ unsafe fn get_hitstop_frame_add(ctx: &mut skyline::hooks::InlineCtx) {
     }
 }
 
+// Only applies 0.67 crouch cancel hitlag multiplier to defender
+#[skyline::hook(offset = 0x46b648, inline)]
+unsafe fn get_hitstop_mul(ctx: &mut skyline::hooks::InlineCtx) {
+    if *ctx.registers[1].w.as_ref() == 0x2 {
+        let hitstop_mul: f32 = 1.0;
+        asm!("fmov s0, w8", in("w8") hitstop_mul)
+    }
+}
+
+// This runs directly after knockback is calculated
+#[skyline::hook(offset = 0x402f04, inline)]
+unsafe fn post_calc_reaction(ctx: &mut skyline::hooks::InlineCtx) {
+    let id = *ctx.registers[27].w.as_ref();
+    let boma = &mut *(sv_battle_object::module_accessor(id));
+    if boma.is_fighter() {
+        let fighter = get_fighter_common_from_accessor(boma);
+        let object = sv_system::battle_object(fighter.lua_state_agent);
+        let fighta : *mut Fighter = std::mem::transmute(object);
+    
+        let mut kb: f32;
+        asm!("fmov w8, s0", out("w8") kb);
+        let hitlag = *(((fighta as u64) + 0xf70c) as *mut i32);
+        // Set hitlag for attacker
+        *(((fighta as u64) + 0xf70c) as *mut i32) = (hitlag as f32 * (0.63 * std::f32::consts::E.powf(0.00462 * kb)).clamp(1.0, 2.0)).round() as i32;
+        asm!("fmov s0, w8", in("w8") kb)
+    }
+}
+
+// This runs immediately before hitlag is set for attacking articles
+#[skyline::hook(offset = 0x33a9d90, inline)]
+unsafe fn set_weapon_hitlag(ctx: &mut skyline::hooks::InlineCtx) {
+    let opponent_boma = &mut *(*ctx.registers[24].x.as_ref() as *mut BattleObjectModuleAccessor);
+
+    let hitlag = *ctx.registers[21].w.as_ref();
+    let kb = DamageModule::reaction(opponent_boma, 0);
+    // Set hitlag for attacking article
+    *ctx.registers[21].w.as_mut() = (hitlag as f32 * (0.63 * std::f32::consts::E.powf(0.00462 * kb)).clamp(1.0, 2.0)).round() as u32;
+}
+
+// This runs immediately before hitlag is set for the defender
+#[skyline::hook(offset = 0x404658, inline)]
+unsafe fn set_fighter_hitlag(ctx: &mut skyline::hooks::InlineCtx) {
+    let boma = &mut *(*ctx.registers[19].x.as_ref() as *mut BattleObjectModuleAccessor);
+
+    let hitlag = *ctx.registers[0].w.as_ref();
+    let kb = DamageModule::reaction(boma, 0);
+    // Set hitlag for defender
+    *ctx.registers[0].w.as_mut() = (hitlag as f32 * (0.63 * std::f32::consts::E.powf(0.00462 * kb)).clamp(1.0, 2.0)).round() as u32;
+}
+
 pub fn install() {
     skyline::install_hooks!(
         attack_module_set_attack,
         get_damage_frame_mul,
-        get_hitstop_frame_add
+        get_hitstop_frame_add,
+        post_calc_reaction,
+        set_weapon_hitlag,
+        set_fighter_hitlag
     );
 }

--- a/fighters/common/src/function_hooks/attack.rs
+++ b/fighters/common/src/function_hooks/attack.rs
@@ -81,15 +81,6 @@ unsafe fn get_hitstop_frame_add(ctx: &mut skyline::hooks::InlineCtx) {
     }
 }
 
-// Only applies 0.67 crouch cancel hitlag multiplier to defender
-#[skyline::hook(offset = 0x46b648, inline)]
-unsafe fn get_hitstop_mul(ctx: &mut skyline::hooks::InlineCtx) {
-    if *ctx.registers[1].w.as_ref() == 0x2 {
-        let hitstop_mul: f32 = 1.0;
-        asm!("fmov s0, w8", in("w8") hitstop_mul)
-    }
-}
-
 static mut IS_KB_CALC_EARLY: bool = false;
 static mut KB: f32 = 0.0;
 


### PR DESCRIPTION
When calculating a move's hitlag, the knockback the move will deal will now be factored in. As knockback increases, so will hitlag. Thus, using the same move on an opponent at 100% will deal more hitlag than on an opponent at 0%.

This adds a new multiplier to the hitlag formula, which can range from 1.0-2.0.

This aims to give deadly blows more impact while leaving combo game unaffected.

Demonstration:

https://github.com/HDR-Development/HewDraw-Remix/assets/47401664/a37bee28-cdfa-467a-b84b-d0bb33949dd8

