### PR TITLE
SDI change

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -55,8 +55,8 @@
   <float hash="escape_fb_stick_x">0.7386</float>
   <float hash="escape_air_slide_landing_speed_max">4</float>
   <int hash="hit_stop_delay_flick">2</int>
-  <float hash="hit_stop_delay_flick_mul">5</float>
-  <int hash="hit_stop_delay_flick_frame">2</int>
+  <float hash="hit_stop_delay_flick_mul">7</float>
+  <int hash="hit_stop_delay_flick_frame">4</int>
   <int hash="hit_stop_delay_flick_max_count">50</int>
   <float hash="hit_stop_delay_auto_mul">2.5</float>
   <float hash="damage_reaction_mul_max">1</float>


### PR DESCRIPTION
Changes the maximum distance of an SDI pulse from 5 -> 7 units.
Changes the minimum time in between SDI pulses from 2 -> 4 frames.

This aims to make "good" SDI less strenuous on the hands/controller, by requiring less frequent waggling to achieve "good" SDI.