### PR TITLE
Lower dash end speed multiplier

### DIFF
--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -35,7 +35,7 @@
     <float hash="moonwalk_disable_dashback_stick_y">-0.5</float>
     <float hash="wavedash_speed_mul">0.8945</float>
     <float hash="dashback_stick_x">-0.5673</float>
-    <float hash="dash_end_speed_mul">0.225</float>
+    <float hash="dash_end_speed_mul">0</float>
     <float hash="escape_air_slide_speed_mul">0.9</float>
     <int hash="escape_air_slide_fall_frame">28</int>
     <int hash="tether_trump_landing_lag">30</int>


### PR DESCRIPTION
0.225 -> 0.0

The speed multiplier when performing the following actions out of dash:
- Dashback
- Pivot
- Grounded normals
- Grounded specials
- Item throws

is currently 0.225 to emulate Melee's behavior. Upon further consideration, there is no reason why this value shouldn't simply be 0, halting all momentum out of dash. This makes for slightly snappier dash dancing, and further differentiates performing actions out of dash vs. run.