### PR TITLE
Cap Maximum SDI Impulses At 11

### DIFF
--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -57,7 +57,7 @@
   <int hash="hit_stop_delay_flick">2</int>
   <float hash="hit_stop_delay_flick_mul">5.25</float>
   <int hash="hit_stop_delay_flick_frame">3</int>
-  <int hash="hit_stop_delay_flick_max_count">50</int>
+  <int hash="hit_stop_delay_flick_max_count">11</int>
   <float hash="hit_stop_delay_auto_mul">2.5</float>
   <float hash="damage_reaction_mul_max">1</float>
   <list hash="pattern_power_mul">


### PR DESCRIPTION
Recently, hitlag was capped at 30 frames, and the rate of SDI was capped at once per 3 frames. This PR changes the maximum SDI impulse cap from 50 --> 11, representing the amount of impulses that would be reached with perfect SDI on maximum hitlag. The lower cap will prevent situations in which slowdown extends the maximum possible SDI distance.