### PR TITLE
Improve Parry Input

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -318,6 +318,7 @@ bitflags! {
         const Parry = 0x100000;
         const CStickOverride = 0x200000;
         const RivalsWallJump = 0x400000;
+        const ParryManual = 0x800000;
 
         const SpecialAll  = 0x20802;
         const AttackAll   = 0x201;
@@ -1297,8 +1298,28 @@ impl BomaExt for BattleObjectModuleAccessor {
     }
 
     unsafe fn is_parry_input(&mut self) -> bool {
-        let buffer = if self.is_prev_status(*FIGHTER_STATUS_KIND_GUARD_DAMAGE) { 1 } else { 5 };
-        return InputModule::get_trigger_count(self.object(), Buttons::Parry) < buffer;
+        let buffer = if self.is_prev_status(*FIGHTER_STATUS_KIND_GUARD_DAMAGE) { 1 } else { 5 } as i128;
+        // actual parry button -- if this is in buffer, it's a parry
+        let parry_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Parry) as i128;
+        if parry_trigger_count < buffer {
+            return true;
+        }
+
+        let guard_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Guard) as i128;
+        let guard_release_count = InputModule::get_release_count(self.object(), Buttons::Guard) as i128;
+        let guard_start = guard_trigger_count;
+        let guard_end = if guard_trigger_count < guard_release_count { -1 } else { guard_release_count };
+
+        // special checks for manual parry
+        // - manual parry button must be in the buffer window
+        // - manual parry button must have been pressed while shield was pressed/held
+        let parry_manual_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::ParryManual) as i128;
+        if parry_manual_trigger_count < buffer 
+        && parry_manual_trigger_count <= guard_start
+        && dbg!(parry_manual_trigger_count) > dbg!(guard_end) {
+            return true;
+        }
+        return false;
     }
 }
 

--- a/dynamic/src/modules/input.rs
+++ b/dynamic/src/modules/input.rs
@@ -34,6 +34,9 @@ extern "Rust" {
     #[link_name = "InputModule__get_trigger_count"]
     fn InputModule__get_trigger_count(object: *mut BattleObject, button: Buttons) -> usize;
 
+    #[link_name = "InputModule__get_release_count"]
+    fn InputModule__get_release_count(object: *mut BattleObject, button: Buttons) -> usize;
+
     #[link_name = "InputModule__is_persist"]
     fn InputModule__is_persist(object: *mut BattleObject) -> bool;
 
@@ -220,5 +223,15 @@ pub mod InputModule {
     /// The frame count since the button was pressed
     pub fn get_trigger_count(object: *mut BattleObject, button: Buttons) -> usize {
         unsafe { InputModule__get_trigger_count(object, button) }
+    }
+
+    /// Tracks how many frames have elapsed since a button was released
+    /// # Arguments
+    /// * `object` - Owning `BattleObject` instance
+    /// * `button` - The button in question
+    /// # Returns
+    /// The frame count since the button was released
+    pub fn get_release_count(object: *mut BattleObject, button: Buttons) -> usize {
+        unsafe { InputModule__get_release_count(object, button) }
     }
 }

--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -868,18 +868,19 @@ unsafe fn map_controls_hook(
         (*out).buttons |= Buttons::RivalsWallJump;
     }
 
-    let (parry, hold) = if is_parry_taunt {
+    let (parry_manual, hold) = if is_parry_taunt {
         (Buttons::AppealAll, Buttons::Special)
     } else {
         (Buttons::Special, Buttons::AppealAll)
     };
 
-    if (*out).buttons.intersects(Buttons::Guard) {
-        if (*out).buttons.intersects(parry) {
-            (*out).buttons |= Buttons::Parry
-        } else if (*out).buttons.intersects(hold) {
-            (*out).buttons |= Buttons::GuardHold;
-        }
+    if (*out).buttons.intersects(parry_manual) {
+        (*out).buttons |= Buttons::ParryManual;
+    }
+
+    if (*out).buttons.intersects(Buttons::Guard) 
+    && (*out).buttons.intersects(hold) {
+        (*out).buttons |= Buttons::GuardHold;
     }
 
     // Check if the button combos are being pressed and then force Stock Share + AttackRaw/SpecialRaw depending on input


### PR DESCRIPTION
## Changelog
- prevents shield+special and shield+taunt parries from activating when the special/taunt button is outside of the buffer window
- prevents shield+special and shield+taunt parries from activating when shield was pressed after special/taunt

these changes notably fix issues on Snake, Villager, and any other character that can shield cancel their special moves. previously, shield canceling a special move while holding special on shield+special parry would always cause parry

## For Devs
- adds a new `Buttons::ParryManual` button, which represents whichever of special/taunt is selected as the manual parry button
- the existing `Buttons::Parry` button now only represents the dedicated parry button
- updated `is_parry_input` with new logic -- use this function if you need to detect a valid parry
- added `InputModule::get_release_count` which tracks the last frame a given button was released (compare to `InputModule::get_trigger_count`