### PR TITLE
Kirby Specials Adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "acmd-engine"
 version = "0.1.0"
-source = "git+https://github.com/HDR-Development/smashline#f45fcf6d05314686d2c48e39fe3af7e0613a70ec"
+source = "git+https://github.com/HDR-Development/smashline#3ad6eccb0739de4d52c23cf204245ed68b73a81b"
 dependencies = [
  "hash40 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "locks",
@@ -57,9 +57,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bayonetta"
@@ -250,7 +250,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "once_cell",
  "tiny-keccak",
 ]
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "elight"
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -789,9 +789,9 @@ checksum = "d3b7357d2bbc5ee92f8e899ab645233e43d21407573cceb37fed8bc3dede2c02"
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jack"
@@ -940,8 +940,8 @@ dependencies = [
 
 [[package]]
 name = "locks"
-version = "1.2.5"
-source = "git+https://github.com/HDR-Development/smashline#f45fcf6d05314686d2c48e39fe3af7e0613a70ec"
+version = "1.2.6"
+source = "git+https://github.com/HDR-Development/smashline#3ad6eccb0739de4d52c23cf204245ed68b73a81b"
 dependencies = [
  "skyline 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -1407,7 +1407,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1614,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1909,14 +1909,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.59",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu 1.0.17",
@@ -1934,11 +1934,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "itoa",
  "ryu 1.0.17",
  "serde",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "skyline_smash"
 version = "0.1.0"
-source = "git+https://github.com/blu-dev/skyline-smash#b114106c0fa0c34ba6252ac8ef5655e3bc07fcf7"
+source = "git+https://github.com/blu-dev/skyline-smash#742efe1059c7d28a8f0e00f1f0f8faf29a8b2171"
 dependencies = [
  "compile-time-lua-bind-hash",
  "lazy_static",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "smash_script"
 version = "0.1.0"
-source = "git+https://github.com/blu-dev/smash-script?branch=development#5671cd311e46e51a5c78fa02135b3dd2dc72d426"
+source = "git+https://github.com/blu-dev/smash-script?branch=development#6567589f0eb25546d15382e1ca94ca2e54838c21"
 dependencies = [
  "skyline 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skyline_smash",
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "smashline"
 version = "0.1.0"
-source = "git+https://github.com/HDR-Development/smashline#f45fcf6d05314686d2c48e39fe3af7e0613a70ec"
+source = "git+https://github.com/HDR-Development/smashline#3ad6eccb0739de4d52c23cf204245ed68b73a81b"
 dependencies = [
  "acmd-engine",
  "locks",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "smashline-macro"
 version = "0.1.0"
-source = "git+https://github.com/HDR-Development/smashline#f45fcf6d05314686d2c48e39fe3af7e0613a70ec"
+source = "git+https://github.com/HDR-Development/smashline#3ad6eccb0739de4d52c23cf204245ed68b73a81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2234,7 +2234,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2378,7 +2378,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]

--- a/fighters/kirby/src/acmd/copy.rs
+++ b/fighters/kirby/src/acmd/copy.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod diddy;
 mod edge;
+mod falco;
 mod ganon;
 mod koopa;
 mod koopajr;
@@ -18,10 +19,12 @@ mod ridley;
 mod roy;
 mod shizue;
 mod sonic;
+mod wolf;
 
 pub fn install(agent: &mut Agent) {
     diddy::install(agent);
     edge::install(agent);
+    falco::install(agent);
     ganon::install(agent);
     koopa::install(agent);
     koopajr::install(agent);
@@ -38,4 +41,5 @@ pub fn install(agent: &mut Agent) {
     roy::install(agent);
     shizue::install(agent);
     sonic::install(agent);
+    wolf::install(agent);
 }

--- a/fighters/kirby/src/acmd/copy/falco.rs
+++ b/fighters/kirby/src/acmd/copy/falco.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+unsafe extern "C" fn sound_falcospecialnstart(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = sv_system::battle_object_module_accessor(lua_state);
+    frame(lua_state, 5.0);
+    if is_excute(agent) {
+        PLAY_SE(agent, Hash40::new("se_falco_special_n02"));
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("sound_falcospecialnstart", sound_falcospecialnstart);
+    agent.acmd("sound_falcospecialairnstart", sound_falcospecialnstart);
+}

--- a/fighters/kirby/src/acmd/copy/ridley.rs
+++ b/fighters/kirby/src/acmd/copy/ridley.rs
@@ -80,7 +80,6 @@ unsafe extern "C" fn game_ridleyspecialairnexplode(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         HIT_NODE(agent, Hash40::new("head"), *HIT_STATUS_NORMAL);
         HIT_NODE(agent, Hash40::new("mouth1"), *HIT_STATUS_NORMAL);
-        HIT_NODE(agent, Hash40::new("virtualweakpoint"), *HIT_STATUS_OFF);
         ATTACK(agent, 0, 0, Hash40::new("top"), 20.0, 361, 80, 0, 58, 9.0, 0.0, 8.0, 14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
     }
     wait(lua_state, 4.0);

--- a/fighters/kirby/src/acmd/copy/wolf.rs
+++ b/fighters/kirby/src/acmd/copy/wolf.rs
@@ -1,0 +1,76 @@
+
+
+unsafe extern "C" fn effect_wolfspecialn(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    frame(lua_state, 8.0);
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+    }
+    frame(lua_state, 14.0);
+    if is_excute(agent) {
+        AFTER_IMAGE_OFF(agent, 4);
+        EFFECT_OFF_KIND(agent, Hash40::new("wolf_bayonet"), false, false);
+    }
+    if sv_animcmd::get_value_float(agent, *SO_VAR_FLOAT_LR) < 0.0 {
+        if is_excute(agent) {
+            EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), 1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+        else {
+        if is_excute(agent) {
+            EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), -1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+        }
+    }
+    frame(lua_state, 17.0);
+    if is_excute(agent) {
+        FOOT_EFFECT(agent, Hash40::new("sys_dash_smoke"), Hash40::new("top"), -8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(lua_state, 19.0);
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+    }
+    frame(lua_state, 22.0);
+    if is_excute(agent) {
+        AFTER_IMAGE_OFF(agent, 3);
+        EFFECT_OFF_KIND(agent, Hash40::new("wolf_bayonet"), false, false);
+    }
+}
+
+unsafe extern "C" fn effect_wolfspecialairn(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    frame(lua_state, 8.0);
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+    }
+    frame(lua_state, 14.0);
+    if sv_animcmd::get_value_float(agent, *SO_VAR_FLOAT_LR) < 0.0 {
+        if is_excute(agent) {
+            EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), 1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+        else {
+        if is_excute(agent) {
+            EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), -1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        }
+        }
+    }
+    frame(lua_state, 19.0);
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+    }
+    frame(lua_state, 22.0);
+    if is_excute(agent) {
+        AFTER_IMAGE_OFF(agent, 3);
+        EFFECT_OFF_KIND(agent, Hash40::new("wolf_bayonet"), false, false);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("effect_wolfspecialn", effect_wolfspecialn);
+    agent.acmd("effect_wolfspecialairn", effect_wolfspecialairn);
+}

--- a/fighters/kirby/src/acmd/copy/wolf.rs
+++ b/fighters/kirby/src/acmd/copy/wolf.rs
@@ -1,3 +1,4 @@
+use super::*;
 
 
 unsafe extern "C" fn effect_wolfspecialn(agent: &mut L2CAgentBase) {
@@ -6,14 +7,14 @@ unsafe extern "C" fn effect_wolfspecialn(agent: &mut L2CAgentBase) {
     frame(lua_state, 8.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0.0, -0.3, 3.0, Hash40::new("haver"), 0.0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
     }
     frame(lua_state, 14.0);
     if is_excute(agent) {
         AFTER_IMAGE_OFF(agent, 4);
         EFFECT_OFF_KIND(agent, Hash40::new("wolf_bayonet"), false, false);
     }
-    if sv_animcmd::get_value_float(agent, *SO_VAR_FLOAT_LR) < 0.0 {
+    if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
         if is_excute(agent) {
             EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), 1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
         }
@@ -30,7 +31,7 @@ unsafe extern "C" fn effect_wolfspecialn(agent: &mut L2CAgentBase) {
     frame(lua_state, 19.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0.0, -0.3, 3.0, Hash40::new("haver"), 0.0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
     }
     frame(lua_state, 22.0);
     if is_excute(agent) {
@@ -45,10 +46,10 @@ unsafe extern "C" fn effect_wolfspecialairn(agent: &mut L2CAgentBase) {
     frame(lua_state, 8.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0.0, -0.3, 3.0, Hash40::new("haver"), 0.0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
     }
     frame(lua_state, 14.0);
-    if sv_animcmd::get_value_float(agent, *SO_VAR_FLOAT_LR) < 0.0 {
+    if sv_animcmd::get_value_float(lua_state, *SO_VAR_FLOAT_LR) < 0.0 {
         if is_excute(agent) {
             EFFECT(agent, Hash40::new("wolf_blaster_shot"), Hash40::new("top"), 1, 9.35, 13.6, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, true);
         }
@@ -61,7 +62,7 @@ unsafe extern "C" fn effect_wolfspecialairn(agent: &mut L2CAgentBase) {
     frame(lua_state, 19.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("wolf_bayonet"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, true);
-        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0, -0.3, 3, Hash40::new("haver"), 0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0, 0, 0, 0, 0, 0, 1, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
+        AFTER_IMAGE4_ON_arg29(agent, Hash40::new("tex_wolf_bayonet1"), Hash40::new("tex_wolf_bayonet2"), 3, Hash40::new("haver"), 0.0, -0.3, 3.0, Hash40::new("haver"), 0.0, 0.77, 6.2, true, Hash40::new("null"), Hash40::new("haver"), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0, *EFFECT_AXIS_X, 0, *TRAIL_BLEND_ALPHA, 101, *TRAIL_CULL_NONE, 1.3, 0.1);
     }
     frame(lua_state, 22.0);
     if is_excute(agent) {
@@ -70,7 +71,21 @@ unsafe extern "C" fn effect_wolfspecialairn(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn sound_wolfspecialn(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 9.0);
+    if macros::is_excute(agent) {
+        macros::PLAY_SE(agent, Hash40::new("se_wolf_special_n03"));
+    }
+    wait(agent.lua_state_agent, 6.0);
+    wait(agent.lua_state_agent, 25.0);
+    if macros::is_excute(agent) {
+        macros::PLAY_SE(agent, Hash40::new("se_wolf_special_n02"));
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("effect_wolfspecialn", effect_wolfspecialn);
     agent.acmd("effect_wolfspecialairn", effect_wolfspecialairn);
+    agent.acmd("sound_wolfspecialn", sound_wolfspecialn);
+    agent.acmd("sound_wolfspecialairn", sound_wolfspecialn);
 }

--- a/fighters/kirby/src/opff/copy.rs
+++ b/fighters/kirby/src/opff/copy.rs
@@ -1016,6 +1016,12 @@ unsafe fn packun_ptooie_scale(boma: &mut BattleObjectModuleAccessor) {
 }
 
 pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
+    let inhaledstatus = StatusModule::status_kind(fighter.module_accessor);
+    // enable copying flags when inhaling an opponent
+    if (0x1e3..0x1f1).contains(&inhaledstatus) {
+        packun_ptooie_stance(fighter, boma, status_kind);
+        return;
+    }
     if !WorkModule::is_flag(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_FLAG_COPY) {
         reset_flags(fighter, boma, status_kind, situation_kind);
         return;
@@ -1024,6 +1030,9 @@ pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut Batt
     let copy = WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA);
 
     match copy {
+        // None - if needed before copy ability is obtained
+        0xFF => packun_ptooie_stance(fighter, boma, status_kind),
+
         // Ryu
         0x3C => magic_series(boma, id, cat, status_kind, situation_kind, motion_kind, stick_x, stick_y, facing, frame),
         // Ken

--- a/fighters/kirby/src/opff/copy.rs
+++ b/fighters/kirby/src/opff/copy.rs
@@ -1030,9 +1030,6 @@ pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut Batt
     let copy = WorkModule::get_int(boma, *FIGHTER_KIRBY_INSTANCE_WORK_ID_INT_COPY_CHARA);
 
     match copy {
-        // None - if needed before copy ability is obtained
-        0xFF => packun_ptooie_stance(fighter, boma, status_kind),
-
         // Ryu
         0x3C => magic_series(boma, id, cat, status_kind, situation_kind, motion_kind, stick_x, stick_y, facing, frame),
         // Ken

--- a/fighters/kirby/src/status/ridley_special_n.rs
+++ b/fighters/kirby/src/status/ridley_special_n.rs
@@ -31,8 +31,21 @@ unsafe extern "C" fn special_n_charge_main(fighter: &mut L2CFighterCommon) -> L2
 }
 
 unsafe extern "C" fn special_n_charge_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
-    if StatusModule::is_situation_changed(fighter.module_accessor) {
-        special_n_situation_helper(fighter);
+    if !StatusModule::is_changing(fighter.module_accessor) {
+        if StatusModule::is_situation_changed(fighter.module_accessor) {
+            if fighter.is_situation(*SITUATION_KIND_GROUND) {
+                KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_GROUND_STOP);
+                GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));
+                fighter.set_situation(SITUATION_KIND_GROUND.into());
+                MotionModule::change_motion_inherit_frame(fighter.module_accessor, Hash40::new("special_n_hold"), -1.0, 1.0, 0.0, false, false);
+            }
+            else {
+                KineticModule::change_kinetic(fighter.module_accessor, *FIGHTER_KINETIC_TYPE_FALL);
+                GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+                fighter.set_situation(SITUATION_KIND_AIR.into());
+                MotionModule::change_motion_inherit_frame(fighter.module_accessor, Hash40::new("special_air_n_hold"), -1.0, 1.0, 0.0, false, false);
+            }
+        }
     }
     let mut min_weak_size = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("min_weak_size"));
     let mut max_weak_size = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_n"), hash40("max_weak_size"));
@@ -73,9 +86,8 @@ unsafe extern "C" fn special_n_charge_substatus(fighter: &mut L2CFighterCommon, 
 }
 
 // FIGHTER_KIRBY_STATUS_KIND_RIDLEY_SPECIAL_N_SHOOT
-/// Hold neutral special to explode
 
-unsafe extern "C" fn special_n_shoot_status_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+unsafe extern "C" fn special_n_shoot_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if VarModule::is_flag(fighter.object(), vars::kirby::instance::SPECIAL_N_EXPLODE) {
         VarModule::off_flag(fighter.object(), vars::kirby::instance::SPECIAL_N_EXPLODE);
         WorkModule::set_int64(fighter.module_accessor, hash40("ridley_special_n_explode") as i64, *FIGHTER_STATUS_WORK_ID_UTILITY_WORK_INT_MOT_KIND);
@@ -86,10 +98,11 @@ unsafe extern "C" fn special_n_shoot_status_main(fighter: &mut L2CFighterCommon)
         else {
             MotionModule::change_motion(fighter.module_accessor, Hash40::new("ridley_special_air_n_explode"), 0.0, 1.0, false, 0.0, false, false);
         }
-        HIT_NODE(fighter, Hash40::new("virtualweakpoint"), *HIT_STATUS_NORMAL);
+        HIT_NODE(fighter, Hash40::new("virtualweakpoint"), *HIT_STATUS_OFF);
 
         fighter.sub_shift_status_main(L2CValue::Ptr(special_n_shoot_main_loop as *const () as _))
-    } else {
+    }
+    else {
         smashline::original_status(Main, fighter, *FIGHTER_KIRBY_STATUS_KIND_RIDLEY_SPECIAL_N_SHOOT)(fighter)
     }
 }
@@ -136,5 +149,5 @@ unsafe extern "C" fn special_n_situation_helper(fighter: &mut L2CFighterCommon) 
 
 pub fn install(agent: &mut Agent) {
     agent.status(Main, *FIGHTER_KIRBY_STATUS_KIND_RIDLEY_SPECIAL_N_CHARGE, special_n_charge_main);
-    agent.status(Main, *FIGHTER_KIRBY_STATUS_KIND_RIDLEY_SPECIAL_N_SHOOT, special_n_shoot_status_main);
+    agent.status(Main, *FIGHTER_KIRBY_STATUS_KIND_RIDLEY_SPECIAL_N_SHOOT, special_n_shoot_main);
     }

--- a/fighters/ridley/src/acmd/specials.rs
+++ b/fighters/ridley/src/acmd/specials.rs
@@ -46,7 +46,6 @@ unsafe extern "C" fn game_specialnexplode(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         HIT_NODE(agent, Hash40::new("head"), *HIT_STATUS_NORMAL);
         HIT_NODE(agent, Hash40::new("mouth1"), *HIT_STATUS_NORMAL);
-        HIT_NODE(agent, Hash40::new("virtualweakpoint"), *HIT_STATUS_OFF);
         ATTACK(agent, 0, 0, Hash40::new("top"), 20.0, 361, 80, 0, 58, 9.0, 0.0, 8.0, 14.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_BOMB);
     }
     wait(lua_state, 4.0);

--- a/fighters/ridley/src/status/special_n.rs
+++ b/fighters/ridley/src/status/special_n.rs
@@ -98,7 +98,7 @@ unsafe extern "C" fn special_n_shoot_main(fighter: &mut L2CFighterCommon) -> L2C
         else {
             MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_air_n_explode"), 0.0, 1.0, false, 0.0, false, false);
         }
-        HIT_NODE(fighter, Hash40::new("virtualweakpoint"), *HIT_STATUS_NORMAL);
+        HIT_NODE(fighter, Hash40::new("virtualweakpoint"), *HIT_STATUS_OFF);
 
         fighter.sub_shift_status_main(L2CValue::Ptr(special_n_shoot_main_loop as *const () as _))
     }

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -914,6 +914,35 @@ simon_special_n:
 simon_special_air_n:
   extra:
     cancel_frame: 60
+sonic_special_n_hit:
+  game_script: game_specialnhit
+  flags:
+    turn: false
+    loop: false
+    move: true
+    fix_trans: false
+    fix_rot: false
+    fix_scale: false
+    unk_40: false
+    unk_80: true
+    unk_100: false
+    unk_200: false
+    unk_400: false
+    unk_800: false
+    unk_1000: false
+    unk_2000: false
+  blend_frames: 0
+  animations:
+  - name: d00specialnhit.nuanmb
+  scripts:
+  - expression_specialnhit
+  - sound_specialnhit
+  - effect_specialnhit
+  extra:
+    intangible_start_frame: 0
+    intangible_end_frame: 0
+    cancel_frame: 22
+    freeze_during_hitstop: false
 szerosuit_special_n_landing:
   extra:
     cancel_frame: 15


### PR DESCRIPTION
Fixes bugs with some of Kirby's copy abilities.

**Falco - Blaster**
- (R) Adjusted sfx to use HDR's instead of vanilla

**Sonic - Homing Attack**
- (+) FAF (on hit): decreased to match Sonic, will calculate later

**Wolf - Blaster**
- (R) Adjusted vfx to use HDR's instead of vanilla
- (R) Adjusted vanilla sfx to match Wolf's. Vanilla version played the blaster spawn sound earlier than normal.

**Ridley - Plasma Breath** _(also applies to Ridley)_
- (!) Fixed an issue where the "virtualweakpoint" was not being disabled during the "explode" part, which caused the user to infinitely heal infinitely when this hurtbox was hit. This results in the user taking knockback instead of recoiling when hit during "explode."

**Piranha Plant - Ptooie**
- (!) Fixed an issue where Kirby was not copying the stance Pirahna Plant has. He should now have the same stance as the copied Piranha Plant.

Also adds structure for potential future stance copy abilities if necessary.