### PR TITLE
Greninja dair on hit changes

### DIFF
--- a/fighters/gekkouga/src/acmd/aerials.rs
+++ b/fighters/gekkouga/src/acmd/aerials.rs
@@ -210,7 +210,7 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 60, 75, 0, 75, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 70, 75, 0, 60, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         AttackModule::clear(boma, 1, false);
     }
     frame(lua_state, 46.0);

--- a/fighters/gekkouga/src/acmd/aerials.rs
+++ b/fighters/gekkouga/src/acmd/aerials.rs
@@ -210,7 +210,7 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 75, 75, 0, 75, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 60, 75, 0, 75, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         AttackModule::clear(boma, 1, false);
     }
     frame(lua_state, 46.0);

--- a/fighters/gekkouga/src/acmd/aerials.rs
+++ b/fighters/gekkouga/src/acmd/aerials.rs
@@ -211,14 +211,13 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     frame(lua_state, 20.0);
     if is_excute(agent) {
         ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 70, 75, 0, 60, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 0.5);
         AttackModule::clear(boma, 1, false);
     }
     frame(lua_state, 46.0);
     if is_excute(agent) {
         AttackModule::clear_all(boma);
     }
-    frame(lua_state, 50.0);
-    if is_excute(agent) {  }
     frame(lua_state, 53.0);
     if is_excute(agent) {
         WorkModule::off_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.65, z: 1.0 };
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.57, z: 1.0 };
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -49,7 +49,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }
-    frame(lua_state, 17.0);
+    frame(lua_state, 13.0);
     if is_excute(agent) {
         WorkModule::off_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND);
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.75, z: 1.0 };
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.68, z: 1.0 };
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.68, z: 1.0 };
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.65, z: 1.0 };
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -49,7 +49,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }
-    frame(lua_state, 13.0);
+    frame(lua_state, 15.0);
     if is_excute(agent) {
         WorkModule::off_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND);
     }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1815,7 +1815,7 @@
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
-      <float hash="landing_attack_air_frame_lw">16</float>
+      <float hash="landing_attack_air_frame_lw">20</float>
       <int hash="landing_heavy_frame">5</int>
       <float hash="scale">1</float>
       <float hash="shield_radius">10</float>


### PR DESCRIPTION
In Smash 4, Greninja's dair on hit had a FAF of 13 frames. This was a core aspect of his kit in Smash 4, as both sourspot and sweetspot dair hit confirm combos led to many creative combo routes, and as well as leaned into his themes of being a frog. Ultimate would go on to nerf Greninja's on hit dair FAF, making it significantly harder to combo out of, and less rewarding to hit an already-risky move to commit to.

This PR aims to adjust Greninja's dair by decreasing the on hit dair FAF back to its original 13 frames like in Smash 4, making it more rewarding to land. To compensate for this change, due to dair becoming stronger on hit, the landing lag has also been increased to discourage haphazard use and to punish users for whiffing the move. The move's bounce Y speed multiplier has also been lowered. This makes Greninja bounce less high on hit, letting him stay closer to the ground post-bounce, while also punishing him on block too.  In addition, the sourspot's angle and base knockback have been adjusted to better lend itself to the lower bounce and combos from the sourspot dair.

**CHANGELOG**
**DAIR**
- [+] FAF on hit: 17F -> 15F
- [-] Landing Lag: 16F -> 20F
- [/] Bounce Speed Y Multiplier: 0.75 -> 0.57 
- [/] Sourspot angle: 75 -> 70
- [/] Sourspot BKB: 75 -> 60
- [-] Sourspot Shieldstun Multiplier: 1.0x -> 0.5x