### PR TITLE
Mewtwo fixes + Float Input Adjustment

### DIFF
--- a/fighters/common/src/general_statuses/attack/attackair.rs
+++ b/fighters/common/src/general_statuses/attack/attackair.rs
@@ -87,7 +87,8 @@ unsafe extern "C" fn status_attackair_main_common(fighter: &mut L2CFighterCommon
         let mut dive_cont_value = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("dive_cont_value"));
         let mut dive_flick_frame_value = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dive_flick_frame_value"));
         if fighter.left_stick_y() <= dive_cont_value
-        && VarModule::get_int(fighter.battle_object, vars::common::instance::LEFT_STICK_FLICK_Y) < dive_flick_frame_value {
+        //&& VarModule::get_int(fighter.battle_object, vars::common::instance::LEFT_STICK_FLICK_Y) < dive_flick_frame_value 
+        {
             let status_kind = VarModule::get_int(fighter.battle_object, vars::common::instance::FLOAT_STATUS_KIND);
             if status_kind != 0 {
                 VarModule::on_flag(fighter.battle_object, vars::common::status::FLOAT_INHERIT_AERIAL);

--- a/fighters/kirby/src/opff/copy.rs
+++ b/fighters/kirby/src/opff/copy.rs
@@ -723,16 +723,10 @@ unsafe fn sheik_nspecial_cancels(fighter: &mut L2CFighterCommon, boma: &mut Batt
 }
 
 // Mewtwo
-unsafe fn mewtwo_nspecial_cancels(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32) {
-    if status_kind == *FIGHTER_KIRBY_STATUS_KIND_MEWTWO_SPECIAL_N_CANCEL {
-        if situation_kind == *SITUATION_KIND_AIR {
-            if WorkModule::get_int(boma, *FIGHTER_MEWTWO_SPECIAL_N_STATUS_WORK_ID_INT_CANCEL_STATUS) == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
-                WorkModule::set_int(boma, *STATUS_KIND_NONE, *FIGHTER_MEWTWO_SPECIAL_N_STATUS_WORK_ID_INT_CANCEL_STATUS);
-            }
-            if MotionModule::is_end(boma) {
-                StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_FALL_AERIAL, false);
-            }
-        }
+unsafe fn mewtwo_nspecial_cancels(boma: &mut BattleObjectModuleAccessor) {
+    if boma.is_motion(Hash40::new("mewtwo_special_air_n_cancel")) 
+    && WorkModule::get_int(boma, *FIGHTER_MEWTWO_SPECIAL_N_STATUS_WORK_ID_INT_CANCEL_STATUS) == *FIGHTER_STATUS_KIND_ESCAPE_AIR {
+        WorkModule::set_int(boma, *STATUS_KIND_NONE, *FIGHTER_MEWTWO_SPECIAL_N_STATUS_WORK_ID_INT_CANCEL_STATUS);
     }
 }
 
@@ -1130,7 +1124,7 @@ pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut Batt
         // Sheik
         0x10 => sheik_nspecial_cancels(fighter, boma, status_kind, situation_kind),
         // Mewtwo
-        0x19 => mewtwo_nspecial_cancels(boma, status_kind, situation_kind),
+        0x19 => mewtwo_nspecial_cancels(boma),
         // Squirtle
         0x24 => pzenigame_nspecial_cancels(boma, status_kind, situation_kind, cat[1]),
         // Lucario

--- a/fighters/mewtwo/src/acmd/aerials.rs
+++ b/fighters/mewtwo/src/acmd/aerials.rs
@@ -138,9 +138,8 @@ unsafe extern "C" fn effect_attackairb(agent: &mut L2CAgentBase) {
             7 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("top"), 0, 13, -6.2, 180, 35, 90, 0.98, true, *EF_FLIP_YZ),
             _ => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), 0, 13, -6.2, 180, 35, 90, 0.98, true, *EF_FLIP_YZ),
         };
-        LAST_EFFECT_SET_RATE(agent, 0.84);
     }
-    frame(lua_state, 17.5);
+    frame(lua_state, 18.5);
     if is_excute(agent) {
         EffectModule::kill_kind(boma, Hash40::new("mewtwo_tail_attack_a_01"), true, true);
         EffectModule::kill_kind(boma, Hash40::new("mewtwo_tail_attack_a_02"), true, true);
@@ -200,18 +199,19 @@ unsafe extern "C" fn effect_attackairhi(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         let color = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_COLOR);
         match color {
-            0 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            1 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            2 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            3 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            4 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            5 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            6 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            7 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
-            _ => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 9, 85, 1.08, true, *EF_FLIP_YZ),
+            0 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            1 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            2 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            3 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            4 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            5 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            6 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            7 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
+            _ => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), -1.5, 8.6, -1.8, 0, 11, 85, 1.08, true, *EF_FLIP_YZ),
         };
+        LAST_EFFECT_SET_RATE(agent, 1.1);
     }
-    frame(lua_state, 16.0);
+    frame(lua_state, 16.5);
     if is_excute(agent) {
         EffectModule::kill_kind(boma, Hash40::new("mewtwo_tail_attack_a_01"), true, true);
         EffectModule::kill_kind(boma, Hash40::new("mewtwo_tail_attack_a_02"), true, true);

--- a/fighters/mewtwo/src/acmd/tilts.rs
+++ b/fighters/mewtwo/src/acmd/tilts.rs
@@ -354,9 +354,9 @@ pub fn install(agent: &mut Agent) {
     agent.acmd("expression_attacks3lw", expression_attacks3lw, Priority::Low);
 
     agent.acmd("game_attackhi3", game_attackhi3, Priority::Low);
-    //agent.acmd("effect_attackhi3", effect_attackhi3, Priority::Low);
+    agent.acmd("effect_attackhi3", effect_attackhi3, Priority::Low);
 
     agent.acmd("game_attacklw3", game_attacklw3, Priority::Low);
-    //agent.acmd("effect_attacklw3", effect_attacklw3, Priority::Low);
+    agent.acmd("effect_attacklw3", effect_attacklw3, Priority::Low);
     agent.acmd("expression_attacklw3", expression_attacklw3, Priority::Low);
 }

--- a/fighters/reflet/src/status/float.rs
+++ b/fighters/reflet/src/status/float.rs
@@ -105,11 +105,7 @@ unsafe extern "C" fn reflet_float_main_loop(fighter: &mut L2CFighterCommon) -> L
 
     if VarModule::get_int(fighter.battle_object, vars::common::status::FLOAT_MTRANS) == 2
     && ControlModule::check_button_off(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP)
-    && {
-        let stick_y = fighter.left_stick_y();
-        let jump_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("jump_stick_y"));
-        stick_y <= jump_stick_y
-    } {
+    {
         ControlModule::clear_command_one(fighter.module_accessor, *FIGHTER_PAD_COMMAND_CATEGORY1, *FIGHTER_PAD_CMD_CAT1_FLAG_ATTACK_N);
         let cat1 = ControlModule::get_command_flag_cat(fighter.module_accessor, 0);
         fighter.global_table[CMD_CAT1].assign(&L2CValue::I32(cat1));
@@ -119,11 +115,7 @@ unsafe extern "C" fn reflet_float_main_loop(fighter: &mut L2CFighterCommon) -> L
 
     if VarModule::get_int(fighter.battle_object, vars::common::status::FLOAT_MTRANS) == 1
     && ControlModule::check_button_off(fighter.module_accessor, *CONTROL_PAD_BUTTON_JUMP)
-    && {
-        let stick_y = fighter.left_stick_y();
-        let jump_stick_y = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("jump_stick_y"));
-        stick_y <= jump_stick_y
-    } {
+    {
         fighter.change_status(FIGHTER_STATUS_KIND_ATTACK_AIR.into(), true.into());
         return 0.into();
     }


### PR DESCRIPTION
Addresses changes made in grab bag pr, and 2 complaints about float (second isn't a bug)
Assets:
[cancel.zip](https://github.com/HDR-Development/HewDraw-Remix/files/15182204/cancel.zip)

### Floats
- [*] Robin no longer has hold-up to continue floating (removed from paisy)
- [/] Hold-down input for float no longer checks stick lifetime (feels better)

### Kirby:
- [*] Mewtwo copy ability's aerial nspecial cancel fixed
### Mewtwo
### Up Tilt:
- [$] Effect reinstalled
### Down Tilt:
- [$] Effect reinstalled
### Back Air:
- [$] Effects fixed to match new arc
### Up Air:
- [$] Effects fixed to match new arc
### Neutral Special:
- [$] Cancel anim transitions into normal fall anim