### PR TITLE
Kirby Thoron Fix + Rounding Error

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -706,10 +706,15 @@ pub mod vars {
             // flags
             pub const SHOULD_CYCLE_MATERIAL: i32 = 0x01F4;
             pub use super::super::ridley::instance::SPECIAL_N_EXPLODE;
-            pub use super::super::bayonetta::instance::SPECIAL_N_CANCEL_TYPE;
 
             // ints 
             pub const MATERIAL_INDEX: i32 = 0x01F5;
+            // copy ability
+            // ints
+            pub use super::super::bayonetta::instance::SPECIAL_N_CANCEL_TYPE;
+            // copy ability
+            // floats
+            pub use super::super::reflet::instance::THUNDER_CHARGE;
         }
         pub mod status {
             // copy ability
@@ -1219,11 +1224,13 @@ pub mod vars {
         }
         pub mod instance {
             // flags
-            pub const THUNDER_CHARGE: i32 = 0x0100;
-            pub const UP_SPECIAL_FREEFALL: i32 = 0x0101;
+            pub const UP_SPECIAL_FREEFALL: i32 = 0x0100;
 
             // ints
             pub const LEVIN_AERIAL_LENIENCY: i32 = 0x0100;
+
+            // floats
+            pub const THUNDER_CHARGE: i32 = 0x0100;
         }
     }
 

--- a/fighters/kirby/src/status/mod.rs
+++ b/fighters/kirby/src/status/mod.rs
@@ -17,6 +17,7 @@ mod lucas_special_n;
 mod sonic_special_n;
 mod edge_special_n;
 mod bayonetta_special_n_cancel;
+mod reflet_special_n;
 
 unsafe extern "C" fn should_use_special_hi_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.is_situation(*SITUATION_KIND_AIR) && VarModule::is_flag(fighter.battle_object, vars::kirby::instance::DISABLE_SPECIAL_HI) {
@@ -267,6 +268,6 @@ pub fn install(agent: &mut Agent) {
     lucas_special_n::install(agent);
     sonic_special_n::install(agent);
     edge_special_n::install(agent);
-
     bayonetta_special_n_cancel::install(agent);
+    reflet_special_n::install(agent);
 }

--- a/fighters/kirby/src/status/reflet_special_n.rs
+++ b/fighters/kirby/src/status/reflet_special_n.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+// FIGHTER_KIRBY_STATUS_KIND_REFLET_SPECIAL_N_TRON_START
+
+pub unsafe extern "C" fn special_n_tron_start_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::set_float(fighter.battle_object, vars::kirby::instance::THUNDER_CHARGE, fighter.get_int(*FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_N_CURRENT_POINT) as f32);
+    smashline::original_status(Init, fighter, *FIGHTER_KIRBY_STATUS_KIND_REFLET_SPECIAL_N)(fighter)
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Init, *FIGHTER_KIRBY_STATUS_KIND_REFLET_SPECIAL_N_TRON_START, special_n_tron_start_init);
+}

--- a/fighters/reflet/src/acmd/ground.rs
+++ b/fighters/reflet/src/acmd/ground.rs
@@ -119,15 +119,47 @@ unsafe extern "C" fn game_attack13(agent: &mut L2CAgentBase) {
 }
 
 unsafe extern "C" fn game_attack100(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    for _ in 0..99 {
-        if is_excute(agent) {
-            ATTACK(agent, 0, 0, Hash40::new("top"), 0.9, 65, 10, 0, 9, 8.0, 0.0, 9.0, 12.0, Some(0.0), Some(9.0), Some(8.0), 0.4, 0.4, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
-            AttackModule::set_add_reaction_frame(boma, 0, 3.0, false);
-            ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 3);
-            WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE_CHECK);
-            wait_loop_clear(agent);
-        }
+    loop {
+        FT_MOTION_RATE(agent, 1.0);
+        game_attack100sub(agent);
+        frame(lua_state, 2.0);
+        game_attack100sub(agent);
+        frame(lua_state, 5.0);
+        game_attack100sub(agent);
+        frame(lua_state, 8.0);
+        game_attack100sub(agent);
+        frame(lua_state, 11.0);
+        game_attack100sub(agent);
+        frame(lua_state, 14.0);
+        game_attack100sub(agent);
+        frame(lua_state, 17.0);
+        game_attack100sub(agent);
+        frame(lua_state, 20.0);
+        game_attack100sub(agent);
+        frame(lua_state, 23.0);
+        game_attack100sub(agent);
+        frame(lua_state, 26.0);
+        game_attack100sub(agent);
+        frame(lua_state, 29.0);
+        game_attack100sub(agent);
+        wait_loop_clear(agent);
+    }
+}
+
+unsafe extern "C" fn game_attack100sub(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        ATTACK(agent, 0, 0, Hash40::new("top"), 0.9, 55, 10, 0, 9, 8.0, 0.0, 9.0, 12.0, Some(0.0), Some(9.0), Some(8.0), 0.4, 0.4, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_MAGIC);
+        AttackModule::set_add_reaction_frame(boma, 0, 3.0, false);
+        ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 3);
+    }
+    wait(lua_state, 1.0);
+    if is_excute(agent) {
+        AttackModule::clear_all(boma);
+        agent.on_flag(*FIGHTER_STATUS_ATTACK_FLAG_100_CONTINUE_CHECK);
     }
 }
 

--- a/fighters/reflet/src/status/special_n.rs
+++ b/fighters/reflet/src/status/special_n.rs
@@ -1,12 +1,12 @@
 use super::*;
 
-// FIGHTER_STATUS_KIND_SPECIAL_N
+// FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_TRON_START
 
-pub unsafe extern "C" fn special_n_init(fighter: &mut L2CFighterCommon) -> L2CValue {
-    VarModule::set_int(fighter.battle_object, vars::reflet::instance::THUNDER_CHARGE, fighter.get_int(*FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_N_CURRENT_POINT));
+pub unsafe extern "C" fn special_n_tron_start_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    VarModule::set_float(fighter.battle_object, vars::reflet::instance::THUNDER_CHARGE, fighter.get_int(*FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_N_CURRENT_POINT) as f32);
     smashline::original_status(Init, fighter, *FIGHTER_STATUS_KIND_SPECIAL_N)(fighter)
 }
 
 pub fn install(agent: &mut Agent) {
-    agent.status(Init, *FIGHTER_STATUS_KIND_SPECIAL_N, special_n_init);
+    agent.status(Init, *FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_TRON_START, special_n_tron_start_init);
 }

--- a/fighters/reflet/src/thunder/acmd.rs
+++ b/fighters/reflet/src/thunder/acmd.rs
@@ -36,17 +36,14 @@ unsafe extern "C" fn game_gigaspark(agent: &mut L2CAgentBase) {
 
 unsafe extern "C" fn game_tron0(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
-    let reflet_boma = &mut *sv_battle_object::module_accessor((WorkModule::get_int(agent.boma(), *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
-    let charge = VarModule::get_int(reflet_boma.object(), vars::reflet::instance::THUNDER_CHARGE);
-    //let damage = (1 + (charge-1)*9/14) as f32;
-    let damage = 1.5 + (charge/2) as f32;
+    let owner_module_accessor = &mut *sv_battle_object::module_accessor((WorkModule::get_int(agent.boma(), *WEAPON_INSTANCE_WORK_ID_INT_LINK_OWNER)) as u32);
     if is_excute(agent) {
-        if charge > 0 && charge <= 8 {
-            ATTACK(agent, 0, 0, Hash40::new("top"), damage, 45, 145, 0, 75, 3.0, 0.0, 0.0, 0.0, Some(0.0), Some(0.0), Some(0.0), 1.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -0.5, 0.0, 4, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_MAGIC);
-
-        } else {
-            ATTACK(agent, 0, 0, Hash40::new("top"), 5.5, 45, 145, 0, 75, 3.0, 0.0, 0.0, 0.0, Some(0.0), Some(0.0), Some(0.0), 1.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 4, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_MAGIC);
-        }
+        let damage = match owner_module_accessor.kind() {
+            0x38 => 1.5 + VarModule::get_float(owner_module_accessor.object(), vars::reflet::instance::THUNDER_CHARGE) / 2.0,
+            0x6 => 1.5 + VarModule::get_float(owner_module_accessor.object(), vars::kirby::instance::THUNDER_CHARGE) / 2.0,
+            _ => 4.0
+        };
+        ATTACK(agent, 0, 0, Hash40::new("top"), damage, 45, 145, 0, 75, 3.0, 0.0, 0.0, 0.0, Some(0.0), Some(0.0), Some(0.0), 1.0, 0.5, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, -0.5, 0.0, 4, true, true, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_elec"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_ELEC, *ATTACK_REGION_MAGIC);
         AttackModule::set_no_finish_camera(agent.boma(), 0, true, false);
     }
 }


### PR DESCRIPTION
Kirby's Thoron copy ability uses the book scaling system Robin has. In addition, odd numbered resource counts no longer round down (float handling error). Also fixes some variables that were labeled improperly.
### Robin 
### Rapid Jab:
- [*] Now written like vanilla (couldn't figure it out before), additionally fixes infinite jab when held too long
- [-] Angle: 65 -> 55 (wasn't fully tested with the lower bkb)
### Neutral Special (Thoron):
- [*] Kirby's copy ability now compatible with resource scaling system
- [/] Pocketed version now set at 4 damage (half resource rounded up)