### PR TITLE
Greninja dair changes 2 electicboogaloo

### DIFF
--- a/fighters/gekkouga/src/acmd/aerials.rs
+++ b/fighters/gekkouga/src/acmd/aerials.rs
@@ -210,7 +210,7 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 75, 75, 0, 67, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 75, 75, 0, 68, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 0.5);
         AttackModule::clear(boma, 1, false);
     }

--- a/fighters/gekkouga/src/acmd/aerials.rs
+++ b/fighters/gekkouga/src/acmd/aerials.rs
@@ -210,7 +210,7 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 20.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 70, 75, 0, 60, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("top"), 8.0, 75, 75, 0, 67, 5.2, 0.0, 0.1, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
         ATK_SET_SHIELD_SETOFF_MUL(agent, 0, 0.5);
         AttackModule::clear(boma, 1, false);
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.57, z: 1.0 };
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.59, z: 1.0 }; //Y vector value determines height of dair bounce
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.59, z: 1.0 }; //Y vector value determines height of dair bounce
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.60, z: 1.0 }; //Y vector value determines height of dair bounce
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/fighters/gekkouga/src/acmd/other.rs
+++ b/fighters/gekkouga/src/acmd/other.rs
@@ -45,7 +45,7 @@ unsafe extern "C" fn game_jumpaerialback(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         if WorkModule::is_flag(boma, *FIGHTER_GEKKOUGA_INSTANCE_WORK_ID_FLAG_ATTACK_AIR_LW_BOUND){
-            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.60, z: 1.0 }; //Y vector value determines height of dair bounce
+            let bounce_speed_mul = Vector3f { x: 1.0, y: 0.57, z: 1.0 }; //Y vector value determines height of dair bounce
             KineticModule::mul_speed(boma, &bounce_speed_mul, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
         }
     }

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1815,7 +1815,7 @@
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
-      <float hash="landing_attack_air_frame_lw">18</float>
+      <float hash="landing_attack_air_frame_lw">20</float>
       <int hash="landing_heavy_frame">5</int>
       <float hash="scale">1</float>
       <float hash="shield_radius">10</float>

--- a/romfs/source/fighter/common/param/fighter_param.prcxml
+++ b/romfs/source/fighter/common/param/fighter_param.prcxml
@@ -1815,7 +1815,7 @@
       <float hash="landing_attack_air_frame_n">9</float>
       <float hash="landing_attack_air_frame_b">9</float>
       <float hash="landing_attack_air_frame_hi">12</float>
-      <float hash="landing_attack_air_frame_lw">20</float>
+      <float hash="landing_attack_air_frame_lw">18</float>
       <int hash="landing_heavy_frame">5</int>
       <float hash="scale">1</float>
       <float hash="shield_radius">10</float>


### PR DESCRIPTION
Changes in response to player feedback:

- Reverted sour dair angle to 75 
- Increased sour dair BKB from 60 -> 68
Combination of reverting the angle to a higher angle and increasing the BKB a bit more should make sour dair lead into up air drag down strings sooner. Previous BKB was a little too low, even with the lower bounce height.

