### PR TITLE
Change Shadow Sneak Smash Attack Cancel to A Jump Cancel

### DIFF
--- a/fighters/gekkouga/src/opff.rs
+++ b/fighters/gekkouga/src/opff.rs
@@ -11,20 +11,12 @@ unsafe fn max_water_shuriken_dc(boma: &mut BattleObjectModuleAccessor, status_ki
     }
 }
 
-// Greninja Shadow Sneak Smash Attack Cancel
-unsafe fn shadow_sneak_smash_attack_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
+// Greninja Shadow Sneak Jump Cancel
+unsafe fn shadow_sneak_jump_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK {
         if boma.status_frame() < 6 {
             if situation_kind == *SITUATION_KIND_GROUND {
-                if boma.is_cat_flag(Cat1::AttackS4) {
-                    StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_S4_START, false);
-                }
-                if boma.is_cat_flag(Cat1::AttackHi4) {
-                    StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_HI4_START, false);
-                }
-                if boma.is_cat_flag(Cat1::AttackLw4) {
-                    StatusModule::change_status_request_from_script(boma, *FIGHTER_STATUS_KIND_ATTACK_LW4_START, false);
-                }
+                boma.check_jump_cancel(false, false);
             }
         }
     }
@@ -87,7 +79,7 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     max_water_shuriken_dc(boma, status_kind, situation_kind, cat[0], frame);
-    shadow_sneak_smash_attack_cancel(boma, status_kind, situation_kind, cat[0], frame);
+    shadow_sneak_jump_cancel(boma, status_kind, situation_kind, cat[0], frame);
     //dair_jc(boma, situation_kind, cat[0], motion_kind, frame);
     fastfall_specials(fighter);
 }

--- a/fighters/gekkouga/src/opff.rs
+++ b/fighters/gekkouga/src/opff.rs
@@ -14,7 +14,7 @@ unsafe fn max_water_shuriken_dc(boma: &mut BattleObjectModuleAccessor, status_ki
 // Greninja Shadow Sneak Jump Cancel
 unsafe fn shadow_sneak_jump_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK {
-        if boma.status_frame() > 1 && boma.status_frame() < 7
+        if boma.status_frame() > 1 && boma.status_frame() < 6
         {
             if situation_kind == *SITUATION_KIND_GROUND {
                 boma.check_jump_cancel(false, false);

--- a/fighters/gekkouga/src/opff.rs
+++ b/fighters/gekkouga/src/opff.rs
@@ -14,7 +14,8 @@ unsafe fn max_water_shuriken_dc(boma: &mut BattleObjectModuleAccessor, status_ki
 // Greninja Shadow Sneak Jump Cancel
 unsafe fn shadow_sneak_jump_cancel(boma: &mut BattleObjectModuleAccessor, status_kind: i32, situation_kind: i32, cat1: i32, frame: f32) {
     if status_kind == *FIGHTER_GEKKOUGA_STATUS_KIND_SPECIAL_S_ATTACK {
-        if boma.status_frame() < 6 {
+        if boma.status_frame() > 1 && boma.status_frame() < 7
+        {
             if situation_kind == *SITUATION_KIND_GROUND {
                 boma.check_jump_cancel(false, false);
             }


### PR DESCRIPTION
Self-explanatory. Gets rid of the weird round-about-ness that currently exists with shadow sneak where people would smash attack and then jump cancel the smash attack. Now it's simply a jump cancel input, like Ike's side b.

https://github.com/HDR-Development/HewDraw-Remix/assets/167844127/8d99a1b0-9264-486e-a5ce-64975c45a0f6

