### PR TITLE
Fix ZAir While Holding An Item

### DIFF
--- a/dynamic/src/modules/input.rs
+++ b/dynamic/src/modules/input.rs
@@ -37,6 +37,9 @@ extern "Rust" {
     #[link_name = "InputModule__get_release_count"]
     fn InputModule__get_release_count(object: *mut BattleObject, button: Buttons) -> usize;
 
+    #[link_name = "InputModule__reset_trigger"]
+    fn InputModule__reset_trigger(object: *mut BattleObject);
+
     #[link_name = "InputModule__is_persist"]
     fn InputModule__is_persist(object: *mut BattleObject) -> bool;
 
@@ -233,5 +236,12 @@ pub mod InputModule {
     /// The frame count since the button was released
     pub fn get_release_count(object: *mut BattleObject, button: Buttons) -> usize {
         unsafe { InputModule__get_release_count(object, button) }
+    }
+
+    /// Resets all trigger counts and release counts
+    /// # Arguments
+    /// * `object` - Owning `BattleObject` instance
+    pub fn reset_trigger(object: *mut BattleObject) {
+        unsafe { InputModule__reset_trigger(object) }
     }
 }

--- a/fighters/common/src/function_hooks/controls.rs
+++ b/fighters/common/src/function_hooks/controls.rs
@@ -1136,6 +1136,12 @@ unsafe fn reset_flick_y(boma: &mut BattleObjectModuleAccessor) {
     call_original!(boma);
 }
 
+#[skyline::hook(replace=ControlModule::reset_trigger)]
+unsafe fn reset_trigger_hook(boma: &mut BattleObjectModuleAccessor) {
+    InputModule::reset_trigger(boma.object());
+    call_original!(boma)
+}
+
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hook!(is_throw_stick);
@@ -1181,6 +1187,7 @@ pub fn install() {
         exec_command_reset_attack_air_kind_hook,
         reset_flick_x,
         reset_flick_y,
+        reset_trigger_hook
     );
     skyline::nro::add_hook(nro_hook);
 }

--- a/utils/src/modules/input.rs
+++ b/utils/src/modules/input.rs
@@ -394,6 +394,13 @@ impl InputModule {
         let module = require_input_module!(object);
         return module.release_count[button.bits().trailing_zeros() as usize];
     }
+
+    #[export_name = "InputModule__reset_trigger"]
+    pub fn reset_trigger(object: *mut BattleObject) {
+        let module = require_input_module!(object);
+        module.trigger_count = [usize::MAX; 32];
+        module.release_count = [usize::MAX; 32];
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
- implements `InputModule::reset_trigger`, which clears the `trigger_count` and `release_count` dictionaries in `InputModule`
- hooks `ControlModule::reset_trigger` to also call `InputModule::reset_trigger`
- fixes z-drops causing ZAir for ZAir characters
- may also effect other areas of code that rely on `InputModule::trigger_count` or `InputModule::release_count` shortly after `ControlModule::reset_trigger` is called