### PR TITLE
Lucas Effect Compatibility Fix

### DIFF
--- a/fighters/lucas/src/acmd/specials.rs
+++ b/fighters/lucas/src/acmd/specials.rs
@@ -184,7 +184,7 @@ unsafe extern "C" fn effect_specialairs(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 7.0);
     if is_excute(agent) {
-        EFFECT_FOLLOW_FLIP(agent, Hash40::new("lucas_pkfi_start"), Hash40::new("lucas_pkfi_start"), Hash40::new("havel"), -0.5, 0, 0, 0, 0, 0, 1, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(agent, Hash40::new("lucas_pkfr_start"), Hash40::new("lucas_pkfr_start"), Hash40::new("havel"), -0.5, 0, 0, 0, 0, 0, 1, true, *EF_FLIP_YZ);
     }
 }
 


### PR DESCRIPTION
Moves PK Freeze to its own file so that effect mods will function. Requires removal of the pre-existing .eff file
[pk freeze.zip](https://github.com/HDR-Development/HewDraw-Remix/files/15215440/pk.freeze.zip)
