### PR TITLE
Fix Accidental Parry/ZAir After Reset/Runback

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -1298,25 +1298,24 @@ impl BomaExt for BattleObjectModuleAccessor {
     }
 
     unsafe fn is_parry_input(&mut self) -> bool {
-        let buffer = if self.is_prev_status(*FIGHTER_STATUS_KIND_GUARD_DAMAGE) { 1 } else { 5 } as i128;
+        let buffer = if self.is_prev_status(*FIGHTER_STATUS_KIND_GUARD_DAMAGE) { 1 } else { ControlModule::get_command_life_count_max(self) } as usize;
         // actual parry button -- if this is in buffer, it's a parry
-        let parry_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Parry) as i128;
+        let parry_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Parry);
         if parry_trigger_count < buffer {
             return true;
         }
 
-        let guard_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Guard) as i128;
-        let guard_release_count = InputModule::get_release_count(self.object(), Buttons::Guard) as i128;
-        let guard_start = guard_trigger_count;
-        let guard_end = if guard_trigger_count < guard_release_count { -1 } else { guard_release_count };
+        let guard_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::Guard);
+        let guard_release_count = InputModule::get_release_count(self.object(), Buttons::Guard);
+        let is_guard_held = ControlModule::check_button_on(self, *CONTROL_PAD_BUTTON_GUARD);
 
         // special checks for manual parry
         // - manual parry button must be in the buffer window
         // - manual parry button must have been pressed while shield was pressed/held
-        let parry_manual_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::ParryManual) as i128;
+        let parry_manual_trigger_count = InputModule::get_trigger_count(self.object(), Buttons::ParryManual);
         if parry_manual_trigger_count < buffer 
-        && parry_manual_trigger_count <= guard_start
-        && dbg!(parry_manual_trigger_count) > dbg!(guard_end) {
+        && parry_manual_trigger_count <= guard_trigger_count
+        && (is_guard_held || parry_manual_trigger_count > guard_release_count) {
             return true;
         }
         return false;

--- a/fighters/common/src/general_statuses/mod.rs
+++ b/fighters/common/src/general_statuses/mod.rs
@@ -214,29 +214,28 @@ unsafe fn sub_transition_group_check_air_lasso(fighter: &mut L2CFighterCommon) -
         return false.into();
     }
     
-    let buffer = ControlModule::get_command_life_count_max(fighter.module_accessor) as i128;
+    let buffer = ControlModule::get_command_life_count_max(fighter.module_accessor) as usize;
 
     // actual grab button
-    let catch_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::Catch) as i128;
+    let catch_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::Catch);
     if catch_trigger_count < buffer {
         fighter.change_status(FIGHTER_STATUS_KIND_AIR_LASSO.into(), true.into());
         return true.into();
     }
 
-    let guard_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::Guard) as i128;
-    let guard_release_count = InputModule::get_release_count(fighter.battle_object, Buttons::Guard) as i128;
-    let guard_start = guard_trigger_count;
-    let guard_end = if guard_trigger_count < guard_release_count { -1 } else { guard_release_count };
+    let guard_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::Guard);
+    let guard_release_count = InputModule::get_release_count(fighter.battle_object, Buttons::Guard);
+    let is_guard_held = ControlModule::check_button_on(fighter.module_accessor, *CONTROL_PAD_BUTTON_GUARD);
 
     // special checks for air_lasso
     // - attack button must be in the buffer window
     // - shield button must be in the buffer window
     // - attack button must have been pressed while shield was pressed/held
-    let attack_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::AttackAll) as i128;
+    let attack_trigger_count = InputModule::get_trigger_count(fighter.battle_object, Buttons::AttackAll);
     if attack_trigger_count < buffer 
     && guard_trigger_count < buffer
-    && attack_trigger_count <= guard_start
-    && attack_trigger_count > guard_end {
+    && attack_trigger_count <= guard_trigger_count
+    && (is_guard_held || attack_trigger_count > guard_release_count) {
         fighter.change_status(FIGHTER_STATUS_KIND_AIR_LASSO.into(), true.into());
         return true.into();
     }

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -139,17 +139,17 @@ pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {
     }
 }
 
-pub unsafe fn taunt_parry_forgiveness(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_APPEAL])
-    && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
-    && fighter.global_table[CURRENT_FRAME].get_i32() <= 1
-    && fighter.is_parry_input()
-    {
-        EffectModule::kill_all(fighter.module_accessor, *EFFECT_SUB_ATTRIBUTE_NONE as u32, true, false);
-        SoundModule::stop_all_sound(fighter.module_accessor);
-        fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());
-    }
-}
+// pub unsafe fn taunt_parry_forgiveness(fighter: &mut L2CFighterCommon) {
+//     if fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_APPEAL])
+//     && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_GROUND
+//     && fighter.global_table[CURRENT_FRAME].get_i32() <= 1
+//     && fighter.is_parry_input()
+//     {
+//         EffectModule::kill_all(fighter.module_accessor, *EFFECT_SUB_ATTRIBUTE_NONE as u32, true, false);
+//         SoundModule::stop_all_sound(fighter.module_accessor);
+//         fighter.change_status(FIGHTER_STATUS_KIND_GUARD_ON.into(), true.into());
+//     }
+// }
 
 pub extern "C" fn decrease_knockdown_bounce_heights(fighter: &mut L2CFighterCommon) {
     unsafe {
@@ -376,7 +376,7 @@ pub unsafe fn run(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleA
     cliff_xlu_frame_counter(fighter);
     ecb_shift_disabled_motions(fighter);
     faf_ac_debug(fighter);
-    taunt_parry_forgiveness(fighter);
+    // taunt_parry_forgiveness(fighter);
     custom_dash_anim_support(fighter);
     kill_screen_handler(fighter);
 }


### PR DESCRIPTION
fixes a bug in parry/zair detection code that make it possible to parry (during run brake) or ZAir without pressing shield, immediately after a training mode reset or salty runback

also removed the parry taunt forgiveness functionality, which wasn't doing anything anyways