### PR TITLE
Diddy Kong Specials Adjustments

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -449,6 +449,9 @@ pub mod vars {
             // flags
             pub const SPECIAL_S_ENABLE_ATTACK: i32 = 0x1100;
             pub const SPECIAL_S_ENABLE_JUMP: i32 = 0x1101;
+
+            // floats
+            pub const SPECIAL_HI_INITIAL_POWER: i32 = 0x1100;
         }
 
         pub const SPECIAL_N_CANCEL_TYPE_NONE: i32 = 0x0;

--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -445,6 +445,10 @@ pub mod vars {
         pub mod status {
             // ints
             pub const SPECIAL_N_CANCEL_TYPE: i32 = 0x1100;
+
+            // flags
+            pub const SPECIAL_S_ENABLE_ATTACK: i32 = 0x1100;
+            pub const SPECIAL_S_ENABLE_JUMP: i32 = 0x1101;
         }
 
         pub const SPECIAL_N_CANCEL_TYPE_NONE: i32 = 0x0;

--- a/fighters/diddy/src/acmd/specials.rs
+++ b/fighters/diddy/src/acmd/specials.rs
@@ -84,8 +84,11 @@ unsafe extern "C" fn game_specialsstick(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_specialairsjump(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 1.0);
-    FT_MOTION_RATE(agent, 0.4);
+    frame(lua_state, 16.0);
+    if is_excute(agent) {
+        VarModule::on_flag(agent.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_ATTACK);
+        VarModule::on_flag(agent.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_JUMP);
+    }
 }
 
 unsafe extern "C" fn game_specialairskick(agent: &mut L2CAgentBase) {

--- a/fighters/diddy/src/acmd/specials.rs
+++ b/fighters/diddy/src/acmd/specials.rs
@@ -118,6 +118,43 @@ unsafe extern "C" fn game_specialairhistart(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn game_specialairhijump(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        JostleModule::set_status(boma, false);
+        WorkModule::on_flag(boma, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_BOBY_ROLL_START);
+        GroundModule::select_cliff_hangdata(boma, *FIGHTER_DIDDY_CLIFF_HANG_DATA_SPECIAL_HI as u32);
+    }
+    frame(lua_state, 1.0);
+    if is_excute(agent) {
+        let power = VarModule::get_float(agent.battle_object, vars::diddy::status::SPECIAL_HI_INITIAL_POWER);
+        ATTACK(agent, 0, 0, Hash40::new("waist"), power, 361, 100, 0, 30, 4.0, -3.0, 0.0, -5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+        ATTACK(agent, 1, 0, Hash40::new("waist"), power, 361, 100, 0, 30, 4.0, -3.0, 0.0, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+    }
+    frame(lua_state, 4.0);
+    if is_excute(agent) {
+        ATTACK(agent, 0, 0, Hash40::new("waist"), 10.0, 55, 100, 0, 30, 3.2, -3.0, 0.0, -5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+        ATTACK(agent, 1, 0, Hash40::new("waist"), 10.0, 55, 100, 0, 30, 3.2, -3.0, 0.0, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+    }
+    wait(lua_state, 4.0);
+    if is_excute(agent) {
+        ATTACK(agent, 0, 0, Hash40::new("waist"), 8.0, 60, 100, 0, 20, 2.8, -3.0, 0.0, -5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+        ATTACK(agent, 1, 0, Hash40::new("waist"), 8.0, 60, 100, 0, 20, 2.8, -3.0, 0.0, 5.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_POS, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_fire"), *ATTACK_SOUND_LEVEL_M, *COLLISION_SOUND_ATTR_FIRE, *ATTACK_REGION_OBJECT);
+    }
+    wait(lua_state, 19.0);
+    if is_excute(agent) {
+        AttackModule::clear_all(boma);
+    }
+    frame(lua_state, 44.0);
+    if is_excute(agent) {
+        WorkModule::off_flag(boma, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_BOBY_ROLL_START);
+        WorkModule::on_flag(boma, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_ROLL_COMP_START);
+        JostleModule::set_status(boma, true);
+        GroundModule::select_cliff_hangdata(boma, *FIGHTER_CLIFF_HANG_DATA_DEFAULT as u32);
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_specialncancel", game_specialncancel, Priority::Low);
     agent.acmd("effect_specialncancel", acmd_stub, Priority::Low);
@@ -135,4 +172,6 @@ pub fn install(agent: &mut Agent) {
     agent.acmd("game_specialairskick", game_specialairskick, Priority::Low);
 
     agent.acmd("game_specialairhistart", game_specialairhistart, Priority::Low);
+
+    agent.acmd("game_specialairhijump", game_specialairhijump, Priority::Low);
 }

--- a/fighters/diddy/src/barreljet/acmd.rs
+++ b/fighters/diddy/src/barreljet/acmd.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("game_fly", acmd_stub, Priority::Low);
+
+    agent.acmd("game_explosion", acmd_stub, Priority::Low);
+}

--- a/fighters/diddy/src/barreljet/mod.rs
+++ b/fighters/diddy/src/barreljet/mod.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+mod acmd;
+
+pub fn install() {
+    let agent = &mut Agent::new("diddy_barreljet");
+    acmd::install(agent);
+    agent.install();
+}

--- a/fighters/diddy/src/lib.rs
+++ b/fighters/diddy/src/lib.rs
@@ -7,6 +7,8 @@ pub mod acmd;
 pub mod opff;
 pub mod status;
 
+mod barreljet;
+
 use smash::{
     lib::{
         L2CValue,
@@ -44,5 +46,7 @@ pub fn install() {
     acmd::install(agent);
     opff::install(agent);
     status::install(agent);
-    agent.install(); 
+    agent.install();
+
+    barreljet::install();
 }

--- a/fighters/diddy/src/status/mod.rs
+++ b/fighters/diddy/src/status/mod.rs
@@ -8,6 +8,7 @@ mod special_s;
 mod special_s_jump;
 
 mod special_hi;
+mod special_hi_upper;
 
 mod jump_squat;
 
@@ -44,6 +45,7 @@ pub fn install(agent: &mut Agent) {
     special_s_jump::install(agent);
 
     special_hi::install(agent);
+    special_hi_upper::install(agent);
 
     jump_squat::install(agent);
 }

--- a/fighters/diddy/src/status/mod.rs
+++ b/fighters/diddy/src/status/mod.rs
@@ -3,9 +3,12 @@ use globals::*;
 // status script import
 
 mod special_n;
+
 mod special_s;
 mod special_s_jump;
+
 mod special_hi;
+
 mod jump_squat;
 
 // Prevents sideB from being used again if it has already been used once in the current airtime
@@ -36,8 +39,11 @@ pub fn install(agent: &mut Agent) {
     agent.on_start(on_start);
 
     special_n::install(agent);
+
     special_s::install(agent);
     special_s_jump::install(agent);
+
     special_hi::install(agent);
+
     jump_squat::install(agent);
 }

--- a/fighters/diddy/src/status/special_hi_upper.rs
+++ b/fighters/diddy/src/status/special_hi_upper.rs
@@ -1,0 +1,171 @@
+use super::*;
+
+pub unsafe extern "C" fn special_hi_upper_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let mut start_spd_y = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_jet_start_spd_y"));
+    let lr = PostureModule::lr(fighter.module_accessor);
+    let special_hi_situation = WorkModule::get_int(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_INT_SITUATION);
+    if special_hi_situation == *SITUATION_KIND_AIR {
+        let mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_jet_air_start_spd_y_mul"));
+        start_spd_y *= mul;
+    }
+
+    let charge_value = WorkModule::get_int(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_INT_CHARGE_VALUE) as f32;
+    let start_spd_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_jet_start_spd_y_mul"));
+    start_spd_y += charge_value * start_spd_y_mul;
+
+    let start_spd_y_mul_powerup = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_jet_start_spd_y_mul_powerup"));
+    start_spd_y *= start_spd_y_mul_powerup;
+
+    let start_angle = WorkModule::get_float(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_FLOAT_UPPER_START_ANGLE);
+    let radians = start_angle.to_radians();
+
+    let spd_x = start_spd_y * radians.cos() * lr;
+    let spd_y = start_spd_y * radians.sin();
+
+    WorkModule::set_float(fighter.module_accessor, start_angle, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_FLOAT_UPPER_ANGLE);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        ENERGY_GRAVITY_RESET_TYPE_GRAVITY,
+        0.0,
+        spd_y,
+        0.0,
+        0.0,
+        0.0
+    );
+
+    sv_kinetic_energy!(
+        enable,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY
+    );
+
+    let air_accel_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_accel_y"), 0);
+    sv_kinetic_energy!(
+        set_accel,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        -air_accel_y
+    );
+
+    let air_speed_y_stable = WorkModule::get_param_float(fighter.module_accessor, hash40("air_speed_y_stable"), 0);
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        air_speed_y_stable
+    );
+
+    let air_brake_y = WorkModule::get_param_float(fighter.module_accessor, hash40("air_brake_y"), 0);
+    sv_kinetic_energy!(
+        set_brake,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        air_brake_y
+    );
+
+    let air_speed_y_limit = WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("air_speed_y_limit"));
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+        air_speed_y_limit
+    );
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        ENERGY_STOP_RESET_TYPE_AIR,
+        spd_x,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    );
+
+    sv_kinetic_energy!(
+        enable,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP
+    );
+
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        air_speed_y_stable
+    );
+
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        air_speed_y_limit
+    );
+
+    if let Some(target) = smashline::api::get_target_function("lua2cpp_diddy.nrs", 0xba40) {
+        let special_hi_upper_momentum: fn(&mut L2CValue, &mut L2CFighterCommon) = std::mem::transmute(target);
+        let angle_x = &mut L2CValue::F32(0.0);
+        special_hi_upper_momentum(angle_x, fighter);
+        WorkModule::set_float(fighter.module_accessor, angle_x.get_f32(), *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_FLOAT_ANGLE_X);
+    }
+
+    fighter.sub_fighter_cliff_check(GROUND_CLIFF_CHECK_KIND_ALWAYS_BOTH_SIDES.into());
+
+    MotionModule::change_motion(
+        fighter.module_accessor,
+        Hash40::new("special_air_hi_jump"),
+        0.0,
+        1.0,
+        false,
+        0.0,
+        false,
+        false
+    );
+
+    fighter.main_shift(special_hi_upper_main_loop)
+}
+
+unsafe extern "C" fn special_hi_upper_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return 1.into();
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL_SPECIAL.into(), false.into());
+        return 0.into();
+    }
+
+    // <HDR>
+    if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {
+        fighter.change_status(FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL.into(), false.into());
+        return 0.into();
+    }
+    // </HDR>
+
+    let sum_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let sum_speed_y = KineticModule::get_sum_speed_y(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let explosion_speed = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_ground_hit_explosion_speed"));
+    let speed_length = sv_math::vec2_length(sum_speed_x, sum_speed_y);
+    if explosion_speed < speed_length {
+        if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_FALL_START)
+        && sum_speed_y < 0.0 {
+            WorkModule::on_flag(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_FALL_START);
+        }
+        if WorkModule::is_flag(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_FLAG_ROLL_COMP_START) {
+            StatusModule::change_status_request(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_KIND_SPECIAL_HI_FALL_ROLL, false);
+        }
+    }
+    // else {
+        // usually has stuff about bonking but we're just going to completely ignore that
+    // }
+
+    0.into()
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_DIDDY_STATUS_KIND_SPECIAL_HI_UPPER, special_hi_upper_main);
+}

--- a/fighters/diddy/src/status/special_hi_upper.rs
+++ b/fighters/diddy/src/status/special_hi_upper.rs
@@ -9,7 +9,11 @@ pub unsafe extern "C" fn special_hi_upper_main(fighter: &mut L2CFighterCommon) -
         start_spd_y *= mul;
     }
 
+    let charge_value_max = WorkModule::get_param_int(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_charge_frame_max")) as f32;
     let charge_value = WorkModule::get_int(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_SPECIAL_HI_WORK_INT_CHARGE_VALUE) as f32;
+    let power = 10.0 + (10.0 * charge_value / charge_value_max);
+    VarModule::set_float(fighter.battle_object, vars::diddy::status::SPECIAL_HI_INITIAL_POWER, power);
+
     let start_spd_y_mul = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("special_hi_jet_start_spd_y_mul"));
     start_spd_y += charge_value * start_spd_y_mul;
 

--- a/fighters/diddy/src/status/special_s_jump.rs
+++ b/fighters/diddy/src/status/special_s_jump.rs
@@ -65,6 +65,15 @@ unsafe extern "C" fn special_s_jump_substatus(fighter: &mut L2CFighterCommon, pa
     if param_1.get_bool() {
         WorkModule::inc_int(fighter.module_accessor, *FIGHTER_DIDDY_STATUS_MONKEY_FLIP_WORK_INT_KICK_FRAME);
     }
+    if VarModule::is_flag(fighter.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_ATTACK) {
+        VarModule::off_flag(fighter.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_ATTACK);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_AIR);
+    }
+    if VarModule::is_flag(fighter.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_JUMP) {
+        VarModule::off_flag(fighter.battle_object, vars::diddy::status::SPECIAL_S_ENABLE_JUMP);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL);
+        WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_JUMP_AERIAL_BUTTON);
+    }
     0.into()
 }
 
@@ -78,6 +87,14 @@ unsafe extern "C" fn special_s_jump_main_loop(fighter: &mut L2CFighterCommon) ->
         || fighter.sub_air_check_fall_common().get_bool() {
             return 0.into();
         }
+    }
+
+    if fighter.sub_transition_group_check_air_attack().get_bool() {
+        return 1.into();
+    }
+
+    if fighter.sub_transition_group_check_air_jump_aerial().get_bool() {
+        return 1.into();
     }
 
     if fighter.global_table[SITUATION_KIND].get_i32() == *SITUATION_KIND_GROUND {


### PR DESCRIPTION
Done on the behalf of @Wish325 

# Changelog

## Monkey Flip (Side Special)
The purpose of these changes is to reduce his non-committal movement options.
- [-] Returned the rate of the animation to 1.0, pushing back the FAF.
- [*] Diddy Kong can now perform Double Jump and Aerials on frame 27 onwards, matching the old FAF of the move.

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/0e41d55f-88c0-4199-93cd-18db56dee455

## Rocketbarrel Boost (Up Special)
- [-] Diddy Kong no longer bonks on surfaces. Landing on the ground puts him in the LANDING_FALL_SPECIAL state with default landing lag. Whatever that is.
- [-] Rocketbarrels no longer have a hitbox when flying away.
- [+] The strength of the initial "jump" can be increased by charging the move.

https://github.com/HDR-Development/HewDraw-Remix/assets/26860994/f4204c96-fd9a-4544-998d-156c12f3214d

### New Hitbox Data
All hitbox sizes and positions stayed the same as vanilla.

Frame 1 - 3
- Damage: 10 to 20
- Angle: 361
- BKB: 30
- KBG: 100

Frame 4 - 7
- Damage: 10
- Angle: 55
- BKB: 30
- KBG: 100

Frame 8 - 27(?)
- Damage: 8
- Angle: 60
- BKB: 20
- KBG: 100