### PR TITLE
Greninja DTaunt FAF Change

### DIFF
--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -81,3 +81,9 @@ special_air_lw:
 furafura_end:
   extra:
     cancel_frame: 10
+appeal_lw_r:
+  extra:
+    cancel_frame: 80
+appeal_lw_l:
+  extra:
+    cancel_frame: 80


### PR DESCRIPTION
Reverts Greninja's down taunt FAF from Ultimate's FAF (109) to Smash 4's FAF (80). This is obviously the most important change of all time. (Joking).

However, it actually lets you use the taunt between stocks now rather than how awful it feels in Ultimate/current HDR. 