### PR TITLE
Misc Changes ft. Olimar

### DIFF
--- a/fighters/common/src/function_hooks/lua_bind_hook/ground.rs
+++ b/fighters/common/src/function_hooks/lua_bind_hook/ground.rs
@@ -767,12 +767,6 @@ unsafe fn check_cliff_entry_specializer(boma: &mut BattleObjectModuleAccessor) -
         }
     }
 
-    if fighter_kind == *FIGHTER_KIND_PIKMIN {
-        if status_kind == *FIGHTER_STATUS_KIND_SPECIAL_HI || status_kind == *FIGHTER_PIKMIN_STATUS_KIND_SPECIAL_HI_WAIT {
-            return 0;
-        }
-    }
-
     if fighter_kind == *FIGHTER_KIND_LUCARIO {
         if status_kind == *FIGHTER_LUCARIO_STATUS_KIND_SPECIAL_HI_RUSH {
             if frame < 17.0 {

--- a/fighters/ken/src/acmd/tilts.rs
+++ b/fighters/ken/src/acmd/tilts.rs
@@ -304,14 +304,14 @@ unsafe extern "C" fn game_attacklw3w(agent: &mut L2CAgentBase) {
         MeterModule::watch_damage(agent.battle_object, true);
         // GROUND ONLY
         // the grounded spike angle is used to push opponents away a desired distance without lifting them off the ground
-        ATTACK(agent, 0, 0, Hash40::new("legl"),  1.6 * dmg, 290, 100, 33, 0, 4.0, 2.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 1, 0, Hash40::new("kneel"), 1.6 * dmg, 290, 100, 33, 0, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 2, 0, Hash40::new("kneel"), 1.6 * dmg, 295, 100, 33, 0, 3.0, 5.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("legl"),  1.6 * dmg, 290, 100, 33, 0, 4.0, 2.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 1, 0, Hash40::new("top"), 1.6 * dmg, 290, 100, 33, 0, 3.0, 0.0, 2.5, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 2, 0, Hash40::new("top"), 1.6 * dmg, 295, 100, 33, 0, 2.5, 0.0, 2.0, 14.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         // AIR ONLY
         // the angle 365 is used to allow opponents to fall into the ground without spiking them offstage
-        ATTACK(agent, 3, 0, Hash40::new("legl"),  1.6 * dmg, 365, 100, 33, 0, 4.0, 2.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 4, 0, Hash40::new("kneel"), 1.6 * dmg, 365, 100, 33, 0, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 5, 0, Hash40::new("kneel"), 1.6 * dmg, 365, 100, 33, 0, 3.0, 5.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 3, 0, Hash40::new("legl"),  1.6 * dmg, 365, 100, 33, 0, 4.0, 2.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 4, 0, Hash40::new("top"), 1.6 * dmg, 365, 100, 33, 0, 3.0, 0.0, 2.5, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 5, 0, Hash40::new("top"), 1.6 * dmg, 365, 100, 33, 0, 2.5, 0.0, 2.0, 14.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, attr, *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KEN_KICK, *ATTACK_REGION_KICK);
         AttackModule::set_attack_height_all(boma, AttackHeight(*ATTACK_HEIGHT_LOW), false);
     }
     frame(lua_state, 4.0);
@@ -328,6 +328,17 @@ unsafe extern "C" fn game_attacklw3w(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         agent.off_flag(*FIGHTER_RYU_STATUS_ATTACK_FLAG_HIT_CANCEL);
         agent.off_flag(*FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+    }
+}
+
+unsafe extern "C" fn effect_attacklw3w(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if is_excute(agent) {
+        FOOT_EFFECT(agent, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if is_excute(agent) {
+        EFFECT_ALPHA(agent, Hash40::new("sys_attack_impact"), Hash40::new("top"), 0, 1.5, 14, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 360, true, 0.4);
     }
 }
 
@@ -380,5 +391,6 @@ pub fn install(agent: &mut Agent) {
     agent.acmd("expression_attackhi3s", expression_attackhi3s, Priority::Low);
 
     agent.acmd("game_attacklw3w", game_attacklw3w, Priority::Low);
+    agent.acmd("effect_attacklw3w", effect_attacklw3w, Priority::Low);
     agent.acmd("game_attacklw3s", game_attacklw3s, Priority::Low);
 }

--- a/fighters/pikmin/src/acmd/specials.rs
+++ b/fighters/pikmin/src/acmd/specials.rs
@@ -34,11 +34,19 @@ unsafe extern "C" fn game_speciallw(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     if is_excute(agent) {
+        if agent.is_situation(*SITUATION_KIND_AIR)
+        && !VarModule::is_flag(agent.battle_object, vars::common::instance::SPECIAL_STALL_USED) {
+            VarModule::on_flag(agent.battle_object, vars::common::instance::SPECIAL_STALL_USED);
+            if KineticModule::get_sum_speed_y(boma, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL) < 0.0 {
+                KineticModule::mul_speed(boma, &Vector3f{x: 1.0, y: 0.0, z: 1.0}, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
+            }
+        }
+
         WorkModule::on_flag(boma, *FIGHTER_PIKMIN_STATUS_SPECIAL_LW_FLAG_SORT);
         // damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_ALWAYS, 0);
         shield!(agent, *MA_MSC_CMD_REFLECTOR, *COLLISION_KIND_REFLECTOR, 0, hash40("top"), 7.5, 0.0, 7.0, -8.5, 0.0, 7.0, 8.5, 1.5, 1.0, 50, false, 0.8, *FIGHTER_REFLECTOR_GROUP_HOMERUNBAT);
     }
-    frame(lua_state, 7.0);
+    frame(lua_state, 10.0);
     if is_excute(agent) {
         // damage!(fighter, *MA_MSC_DAMAGE_DAMAGE_NO_REACTION, *DAMAGE_NO_REACTION_MODE_NORMAL, 0);
         shield!(agent, *MA_MSC_CMD_SHIELD_OFF, *COLLISION_KIND_REFLECTOR, 0, *FIGHTER_REFLECTOR_GROUP_HOMERUNBAT);

--- a/fighters/pikmin/src/pikmin/mod.rs
+++ b/fighters/pikmin/src/pikmin/mod.rs
@@ -27,7 +27,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_fire"),
                 sound: *COLLISION_SOUND_ATTR_FIRE,
                 color: Vector3f{x: 1.0, y: 0.05, z: 0.0},
-                cling_frame: 5
+                cling_frame: 4
             },
             1 => PikminInfo { // yellow
                 dmg: 0.94,
@@ -49,7 +49,7 @@ impl From<i32> for PikminInfo {
                 attr_special: Hash40::new("collision_attr_water"),
                 sound: *COLLISION_SOUND_ATTR_WATER,
                 color: Vector3f{x: 0.1, y: 0.4, z: 1.0},
-                cling_frame: 5
+                cling_frame: 4
             },
             3 => PikminInfo { // White
                 dmg: 0.75,

--- a/fighters/pikmin/src/pikmin/mod.rs
+++ b/fighters/pikmin/src/pikmin/mod.rs
@@ -20,7 +20,7 @@ impl From<i32> for PikminInfo {
         match other {
             0 => PikminInfo { // Red
                 dmg: 1.05,
-                shield_dmg: 0.25,
+                shield_dmg: 0.45,
                 angle: 0,
                 hitlag: 1.0,
                 attr: Hash40::new("collision_attr_fire"),
@@ -53,7 +53,7 @@ impl From<i32> for PikminInfo {
             },
             3 => PikminInfo { // White
                 dmg: 0.75,
-                shield_dmg: 0.75,
+                shield_dmg: 0.55,
                 angle: 0,
                 hitlag: 1.0,
                 attr: Hash40::new("collision_attr_purple"),

--- a/fighters/pikmin/src/status/attack_air.rs
+++ b/fighters/pikmin/src/status/attack_air.rs
@@ -165,6 +165,23 @@ unsafe extern "C" fn link_event_store_l2c_table(fighter: &mut L2CFighterCommon, 
     ret
 }
 
+
+pub unsafe extern "C" fn attack_air_end(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let next_status = fighter.global_table[STATUS_KIND].get_i32();
+    if [
+        *FIGHTER_STATUS_KIND_LANDING,
+        *FIGHTER_STATUS_KIND_LANDING_ATTACK_AIR
+    ].contains(&next_status) 
+    && [
+        *FIGHTER_STATUS_KIND_SPECIAL_HI, 
+        *FIGHTER_PIKMIN_STATUS_KIND_SPECIAL_HI_WAIT
+    ].contains(&StatusModule::prev_status_kind(fighter.module_accessor, 1)) {
+        fighter.change_status(FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL.into(), false.into());
+    }
+    smashline::original_status(End, fighter, *FIGHTER_STATUS_KIND_ATTACK_AIR)(fighter)
+}
+
 pub fn install(agent: &mut Agent) {
     agent.status(Main, *FIGHTER_STATUS_KIND_ATTACK_AIR, attack_air_main);
+    agent.status(End, *FIGHTER_STATUS_KIND_ATTACK_AIR, attack_air_end);
 }

--- a/fighters/ryu/src/acmd/tilts.rs
+++ b/fighters/ryu/src/acmd/tilts.rs
@@ -296,14 +296,14 @@ unsafe extern "C" fn game_attacklw3w(agent: &mut L2CAgentBase) {
         MeterModule::watch_damage(agent.battle_object, true);
         // GROUND ONLY
         // the grounded spike angle is used to push opponents away a desired distance without lifting them off the ground
-        ATTACK(agent, 0, 0, Hash40::new("legl"),  1.6, 290, 100, 33, 0, 4.0, 2.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 1, 0, Hash40::new("kneel"), 1.6, 290, 100, 33, 0, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 2, 0, Hash40::new("kneel"), 1.6, 295, 100, 33, 0, 3.0, 5.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 0, 0, Hash40::new("legl"),  1.6, 290, 100, 33, 0, 4.0, 2.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 1, 0, Hash40::new("top"), 1.6, 290, 100, 33, 0, 3.0, 0.0, 2.5, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 2, 0, Hash40::new("top"), 1.6, 295, 100, 33, 0, 2.5, 0.0, 2.0, 14.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
         // AIR ONLY
         // the angle 365 is used to allow opponents to fall into the ground without spiking them offstage
-        ATTACK(agent, 3, 0, Hash40::new("legl"),  1.6, 365, 100, 33, 0, 4.0, 2.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 4, 0, Hash40::new("kneel"), 1.6, 365, 100, 33, 0, 3.5, 1.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
-        ATTACK(agent, 5, 0, Hash40::new("kneel"), 1.6, 365, 100, 33, 0, 3.0, 5.0, 0.0, 0.0,  None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 3, 0, Hash40::new("legl"),  1.6, 365, 100, 33, 0, 4.0, 2.0, 0.0, 0.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 4, 0, Hash40::new("top"), 1.6, 365, 100, 33, 0, 3.0, 0.0, 2.5, 9.5, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
+        ATTACK(agent, 5, 0, Hash40::new("top"), 1.6, 365, 100, 33, 0, 2.5, 0.0, 2.0, 14.0, None, None, None, 1.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_RYU_KICK, *ATTACK_REGION_KICK);
         AttackModule::set_attack_height_all(boma, AttackHeight(*ATTACK_HEIGHT_LOW), false);
     }
     frame(lua_state, 4.0);
@@ -320,6 +320,17 @@ unsafe extern "C" fn game_attacklw3w(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         agent.off_flag(*FIGHTER_RYU_STATUS_ATTACK_FLAG_HIT_CANCEL);
         agent.off_flag(*FIGHTER_RYU_INSTANCE_WORK_ID_FLAG_FINAL_HIT_CANCEL);
+    }
+}
+
+unsafe extern "C" fn effect_attacklw3w(agent: &mut L2CAgentBase) {
+    frame(agent.lua_state_agent, 1.0);
+    if is_excute(agent) {
+        FOOT_EFFECT(agent, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, false);
+    }
+    frame(agent.lua_state_agent, 2.0);
+    if is_excute(agent) {
+        EFFECT_ALPHA(agent, Hash40::new("sys_attack_impact"), Hash40::new("top"), 0, 1.5, 14, 0, 0, 0, 0.8, 0, 0, 0, 0, 0, 360, true, 0.4);
     }
 }
 
@@ -362,5 +373,6 @@ pub fn install(agent: &mut Agent) {
     agent.acmd("expression_attackhi3s", expression_attackhi3s, Priority::Low);
     
     agent.acmd("game_attacklw3w", game_attacklw3w, Priority::Low);
+    agent.acmd("effect_attacklw3w", effect_attacklw3w, Priority::Low);
     agent.acmd("game_attacklw3s", game_attacklw3s, Priority::Low);
 }

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -8,6 +8,9 @@ fall_aerial:
   blend_frames: 5
 fall_special:
   blend_frames: 5
+landing_fall_special:
+  animations:
+    - name: c05landingairlw.nuanmb
 guard_off:
   blend_frames: 4
   extra:

--- a/romfs/source/fighter/pikmin/param/vl.prcxml
+++ b/romfs/source/fighter/pikmin/param/vl.prcxml
@@ -8,10 +8,14 @@
   <list hash="param_special_hi">
     <struct index="0">
       <float hash="speed_y">2</float>
+      <int hash="disable_landing_frame">10</int>
       <float hash="0x13337cb1ff">0</float>
+      <float hash="0x170ed70199">0</float>
+      <float hash="fly_accel_x_stick">0.06</float>
       <float hash="fly_accel_y_stick">0.12</float>
-      <float hash="0x132407a5bc">0.01</float>
-      <float hash="0x1c53b2d25b">0.05</float>
+      <float hash="0x132407a5bc">0</float>
+      <float hash="0x1c53b2d25b">0</float>
+      <float hash="landing_frame">25</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/pikmin/param/vl.prcxml
+++ b/romfs/source/fighter/pikmin/param/vl.prcxml
@@ -15,7 +15,7 @@
       <float hash="fly_accel_y_stick">0.12</float>
       <float hash="0x132407a5bc">0</float>
       <float hash="0x1c53b2d25b">0</float>
-      <float hash="landing_frame">12</float>
+      <float hash="landing_frame">14</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>

--- a/romfs/source/fighter/pikmin/param/vl.prcxml
+++ b/romfs/source/fighter/pikmin/param/vl.prcxml
@@ -15,7 +15,7 @@
       <float hash="fly_accel_y_stick">0.12</float>
       <float hash="0x132407a5bc">0</float>
       <float hash="0x1c53b2d25b">0</float>
-      <float hash="landing_frame">25</float>
+      <float hash="landing_frame">12</float>
     </struct>
     <hash40 index="1">dummy</hash40>
     <hash40 index="2">dummy</hash40>


### PR DESCRIPTION
# Kirby

## Copy Abilities
- (!) updated copy ability magic series for Lucario, Ryu, and Ken to properly reflect their new cancel mechanics

# Olimar

## General
- [/] swapped the total shield damage of white and red pikmin 
- Red
  - [+] detonate timer: 5 -> 4
- Blue
  - [+] detonate timer: 5 -> 4

## USpecial
- (!) can now be canceled into the end animation with any special/shield input (previously only NSpecial)
- (!) can no longer be canceled into airdodge
- (!) can now grab ledge without canceling into the end animation
- [+] can now grab ledge earlier into the end animation
- (!) when canceling into an aerial, the aerial will now have USpecial landing lag
- [+] landing lag: 30 -> 14
- [+] the number of available pikmin no longer decreases speed or acceleration
- [+] horizontal acceleration: 0.04 -> 0.06

## DSpecial
- (!) now stalls once per airtime
- [+] reflector activity: F1-6 -> F1-9

# Ryu / Ken

## DTilt
- [/] adjusted knee and foot hitbox size and positioning to lower below-ledge reach

before | after
:-------|-------:
![2024052616232800-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/b6469a85-c041-4c0e-8258-2ba8b83d933d) | ![2024052616460700-0E7DF678130F4F0FA2C88AE72B47AFDF](https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/460cbe89-9b4a-4a03-b096-ea99673e2269)
