### PR TITLE
FGCs Specials Hotfix

### DIFF
--- a/fighters/common/src/function_hooks/finals.rs
+++ b/fighters/common/src/function_hooks/finals.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 pub extern "C" fn stub() -> u64 { 0 }
+/// we're misunderstanding the scope of these functions lol. 
+/// leaving out the check for final status functions prevented b-reverrse of shotos NSpecial and DSpecial.
 
 #[skyline::hook(offset = 0x62ea88, inline)]
 unsafe fn final_breverse_0(ctx: &mut skyline::hooks::InlineCtx) {
@@ -10,9 +12,22 @@ unsafe fn final_breverse_0(ctx: &mut skyline::hooks::InlineCtx) {
         *FIGHTER_KIND_KEN
     ].contains(&(*boma).kind()) {
         return;
-    } else {
-        *ctx.registers[8].x.as_mut() = stub as *const () as u64;
     }
+    if !(*boma).is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_FINAL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_AIR_END,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_FALL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_LANDING,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_AIR_END,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_FALL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_HIT,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_JUMP,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_LANDING,
+    ]) {
+        return;
+    }
+    *ctx.registers[8].x.as_mut() = stub as *const () as u64;
 }
 
 #[skyline::hook(offset = 0x68f44c, inline)]
@@ -23,9 +38,22 @@ unsafe fn final_breverse_1(ctx: &mut skyline::hooks::InlineCtx) {
         *FIGHTER_KIND_KEN
     ].contains(&(*boma).kind()) {
         return;
-    } else {
-        *ctx.registers[8].x.as_mut() = stub as *const () as u64;
     }
+    if !(*boma).is_status_one_of(&[
+        *FIGHTER_STATUS_KIND_FINAL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_AIR_END,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_FALL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL2_LANDING,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_AIR_END,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_FALL,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_HIT,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_JUMP,
+        *FIGHTER_RYU_STATUS_KIND_FINAL_LANDING,
+    ]) {
+        return;
+    }
+    *ctx.registers[8].x.as_mut() = stub as *const () as u64;
 }
 
 pub fn install() {

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -87,8 +87,8 @@
   <float hash="special_stick_x">0.5673</float>
   <float hash="special_stick_y">0.51</float>
   <int hash="special_air_n_turn_frame">13</int>
-  <byte hash="special_command_life_max">5</byte>
-  <byte hash="super_special_command_life_max">10</byte>
+  <byte hash="special_command_life_max">7</byte>
+  <byte hash="super_special_command_life_max">14</byte>
   <float hash="catch_dash_brake_mul">1</float>
   <int hash="shield_setoff_catch_frame">0</int>
   <int hash="invalid_capture_frame">1</int>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -87,8 +87,8 @@
   <float hash="special_stick_x">0.5673</float>
   <float hash="special_stick_y">0.51</float>
   <int hash="special_air_n_turn_frame">13</int>
-  <byte hash="special_command_life_max">10</byte>
-  <byte hash="super_special_command_life_max">20</byte>
+  <byte hash="special_command_life_max">5</byte>
+  <byte hash="super_special_command_life_max">10</byte>
   <float hash="catch_dash_brake_mul">1</float>
   <int hash="shield_setoff_catch_frame">0</int>
   <int hash="invalid_capture_frame">1</int>


### PR DESCRIPTION
- fixed an issue that prevented Ken and Ryu from b-reversing certain specials (introduced in the previous hotfix)
- lowered the maximum time between command input directions from 10 frames to 7 frames
- lowered the maximum time between command input directions for terry's supers from 20 frames to 14 frames