### PR TITLE
Shield Followup Adjustments

### DIFF
--- a/fighters/common/src/general_statuses/shield/fighter_status_guard/mod.rs
+++ b/fighters/common/src/general_statuses/shield/fighter_status_guard/mod.rs
@@ -49,29 +49,20 @@ pub unsafe fn check_hit_stop_delay(fighter: &mut L2CFighterCommon, arg: L2CValue
     if !arg.get_bool() {
         return false.into();
     }
-    let stick_x = ControlModule::get_stick_x(fighter.module_accessor).abs();
-    let hit_stop_delay_stick = WorkModule::get_param_float(
-        fighter.module_accessor,
-        hash40("common"),
-        hash40("hit_stop_delay_stick")
-    );
-    if hit_stop_delay_stick <= stick_x {
-        let mut pos = *PostureModule::pos(fighter.module_accessor);
-        let auto_mul = WorkModule::get_param_float(
-            fighter.module_accessor,
-            hash40("common"),
-            hash40("hit_stop_delay_stick_auto_mul")
-        );
-        let delay_mul = WorkModule::get_float(
-            fighter.module_accessor,
-            *FIGHTER_STATUS_GUARD_ON_WORK_FLOAT_DELAY_MUL
-        );
-        pos.x += stick_x * auto_mul * delay_mul;
-        PostureModule::set_pos(fighter.module_accessor, &pos);
-        true.into()
-    } else {
-        false.into()
+
+    let stick_x = ControlModule::get_stick_x(fighter.module_accessor);
+    let hit_stop_delay_stick = fighter.get_param_float("common", "hit_stop_delay_stick");
+    if stick_x.abs() < hit_stop_delay_stick {
+        return false.into();
     }
+
+    let hit_stop_delay_auto_mul = fighter.get_param_float("common","hit_stop_delay_auto_mul");
+    let hit_stop_delay_guard_mul = fighter.get_param_float("common", "hit_stop_delay_guard_mul");
+    let attack_sdi_mul = fighter.get_float(*FIGHTER_STATUS_GUARD_ON_WORK_FLOAT_DELAY_MUL);
+    let mut pos = *PostureModule::pos(fighter.module_accessor);
+    pos.x += stick_x * hit_stop_delay_auto_mul * hit_stop_delay_guard_mul * attack_sdi_mul;
+    PostureModule::set_pos(fighter.module_accessor, &pos);
+    return true.into();
 }
 
 #[skyline::hook(replace = L2CFighterCommon_FighterStatusGuard__check_hit_stop_delay_flick)]
@@ -79,41 +70,26 @@ pub unsafe fn check_hit_stop_delay_flick(
     fighter: &mut L2CFighterCommon,
     user_mul: L2CValue
 ) -> L2CValue {
-    let stick_x = ControlModule::get_stick_x(fighter.module_accessor).abs();
-    let sub_x = ControlModule::get_flick_sub_x(fighter.module_accessor) as f32;
-    let hit_stop_delay_stick = WorkModule::get_param_float(
-        fighter.module_accessor,
-        hash40("common"),
-        hash40("hit_stop_delay_stick")
-    );
-    if
-        !WorkModule::is_flag(
-            fighter.module_accessor,
-            *FIGHTER_STATUS_GUARD_ON_WORK_FLAG_DISABLE_HIT_STOP_DELAY_STICK
-        ) &&
-        StopModule::is_hit(fighter.module_accessor) &&
-        sub_x < hit_stop_delay_stick &&
-        hit_stop_delay_stick <= stick_x
-    {
-        let mut pos = *PostureModule::pos(fighter.module_accessor);
-        let flick_mul = WorkModule::get_param_float(
-            fighter.module_accessor,
-            hash40("common"),
-            hash40("hit_stop_delay_flick_mul")
-        );
-        let guard_mul = WorkModule::get_param_float(
-            fighter.module_accessor,
-            hash40("common"),
-            hash40("hit_stop_delay_guard_mul")
-        );
-        let user_mul = WorkModule::get_float(fighter.module_accessor, user_mul.get_i32());
-        pos.x += stick_x * flick_mul * guard_mul * user_mul;
-        PostureModule::set_pos(fighter.module_accessor, &pos);
-        ControlModule::reset_flick_sub_x(fighter.module_accessor);
-        true.into()
-    } else {
-        false.into()
+    if !StopModule::is_hit(fighter.module_accessor)
+    || fighter.is_flag(*FIGHTER_STATUS_GUARD_ON_WORK_FLAG_DISABLE_HIT_STOP_DELAY_STICK) {
+        return false.into();
     }
+
+    let stick_x = ControlModule::get_stick_x(fighter.module_accessor);
+    let flick_sub_x = ControlModule::get_flick_sub_x(fighter.module_accessor) as f32;
+    let hit_stop_delay_stick = fighter.get_param_float("common", "hit_stop_delay_stick");
+    if  flick_sub_x.abs() >= hit_stop_delay_stick || stick_x.abs() < hit_stop_delay_stick {
+        return false.into();
+    }
+
+    let hit_stop_delay_flick_mul = fighter.get_param_float("common", "hit_stop_delay_flick_mul");
+    let hit_stop_delay_guard_mul = fighter.get_param_float("common", "hit_stop_delay_guard_mul");
+    let attack_sdi_mul = fighter.get_float(user_mul.get_i32());
+    let mut pos = *PostureModule::pos(fighter.module_accessor);
+    pos.x += stick_x * hit_stop_delay_flick_mul * hit_stop_delay_guard_mul * attack_sdi_mul;
+    PostureModule::set_pos(fighter.module_accessor, &pos);
+    ControlModule::reset_flick_sub_x(fighter.module_accessor);
+    return true.into();
 }
 
 #[skyline::hook(replace = L2CFighterCommon_FighterStatusGuard__is_continue_just_shield_count)]

--- a/fighters/common/src/general_statuses/shield/furafura/mod.rs
+++ b/fighters/common/src/general_statuses/shield/furafura/mod.rs
@@ -14,6 +14,7 @@ unsafe fn status_FuraFura(fighter: &mut L2CFighterCommon) -> L2CValue {
 unsafe fn status_FuraFura_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
     if !fighter.is_situation(*SITUATION_KIND_GROUND) {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         return true.into();
     }
 

--- a/fighters/common/src/general_statuses/shield/furafura/mod.rs
+++ b/fighters/common/src/general_statuses/shield/furafura/mod.rs
@@ -1,0 +1,44 @@
+use interpolation::Lerp;
+
+use super::*;
+
+#[skyline::hook(replace = L2CFighterCommon_status_FuraFura)]
+unsafe fn status_FuraFura(fighter: &mut L2CFighterCommon) -> L2CValue {
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("furafura"), 0.0, 1.0, false, 0.0, false, false);
+    ControlModule::end_clatter_motion_rate(fighter.module_accessor);
+    fighter.sub_shift_status_main(L2CValue::Ptr(status_FuraFura_Main as *const () as _))
+}
+
+#[skyline::hook(replace = L2CFighterCommon_status_FuraFura_Main)]
+unsafe fn status_FuraFura_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if !fighter.is_situation(*SITUATION_KIND_GROUND) {
+        fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        return true.into();
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        MotionModule::change_motion(fighter.module_accessor, Hash40::new("furafura"), 0.0, 1.0, false, 0.0, false, false);
+    }
+
+    // let lerp_start = 0.0;
+    // let lerp_end = 100.0;
+    // let lerp_min = 1.0;
+    // let lerp_max = 2.0;
+    // let damage = DamageModule::damage(fighter.module_accessor, 0).clamp(lerp_start, lerp_end);
+    // let ratio = (damage - lerp_start) / (lerp_end - lerp_start);
+    // let end_mul = Lerp::lerp(&lerp_min, &lerp_max, &ratio);
+    let end_frame = dbg!(fighter.get_param_float("common", "furafura_frame"));
+    if fighter.status_frame() as f32 >= end_frame {
+        fighter.change_status(FIGHTER_STATUS_KIND_FURAFURA_END.into(), false.into());
+        return false.into();
+    }
+
+    return false.into();
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        status_FuraFura,
+        status_FuraFura_Main
+    );
+}

--- a/fighters/common/src/general_statuses/shield/furafura/mod.rs
+++ b/fighters/common/src/general_statuses/shield/furafura/mod.rs
@@ -24,11 +24,13 @@ unsafe fn status_FuraFura_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
     let lerp_start = 25.0_f64;
     let lerp_end = 125.0_f64;
     let lerp_min = 1.0_f64;
-    let lerp_max = 2.0_f64;
+    let lerp_max = 5.0_f64 / 3.0_f64;
     let damage = DamageModule::damage(fighter.module_accessor, 0) as f64;
     let lerp_scalar = (damage - lerp_start) / (lerp_end - lerp_start);
-    let end_mul = dbg!(lerp_min.lerp(&lerp_max, &lerp_scalar).clamp(lerp_min, lerp_max));
+    let end_mul = lerp_min.lerp(&lerp_max, &lerp_scalar).clamp(lerp_min, lerp_max);
     let end_frame = fighter.get_param_float("common", "furafura_frame") as f64;
+    let motion_rate = 1.5 / end_mul;
+    MotionModule::set_rate(fighter.module_accessor, motion_rate as f32);
     if fighter.status_frame() as f64 >= end_frame * end_mul {
         fighter.change_status(FIGHTER_STATUS_KIND_FURAFURA_END.into(), false.into());
         return false.into();

--- a/fighters/common/src/general_statuses/shield/furafura/mod.rs
+++ b/fighters/common/src/general_statuses/shield/furafura/mod.rs
@@ -6,6 +6,7 @@ use super::*;
 unsafe fn status_FuraFura(fighter: &mut L2CFighterCommon) -> L2CValue {
     MotionModule::change_motion(fighter.module_accessor, Hash40::new("furafura"), 0.0, 1.0, false, 0.0, false, false);
     ControlModule::end_clatter_motion_rate(fighter.module_accessor);
+    ControlModule::end_clatter(fighter.module_accessor, 0);
     fighter.sub_shift_status_main(L2CValue::Ptr(status_FuraFura_Main as *const () as _))
 }
 
@@ -20,15 +21,15 @@ unsafe fn status_FuraFura_Main(fighter: &mut L2CFighterCommon) -> L2CValue {
         MotionModule::change_motion(fighter.module_accessor, Hash40::new("furafura"), 0.0, 1.0, false, 0.0, false, false);
     }
 
-    // let lerp_start = 0.0;
-    // let lerp_end = 100.0;
-    // let lerp_min = 1.0;
-    // let lerp_max = 2.0;
-    // let damage = DamageModule::damage(fighter.module_accessor, 0).clamp(lerp_start, lerp_end);
-    // let ratio = (damage - lerp_start) / (lerp_end - lerp_start);
-    // let end_mul = Lerp::lerp(&lerp_min, &lerp_max, &ratio);
-    let end_frame = dbg!(fighter.get_param_float("common", "furafura_frame"));
-    if fighter.status_frame() as f32 >= end_frame {
+    let lerp_start = 25.0_f64;
+    let lerp_end = 125.0_f64;
+    let lerp_min = 1.0_f64;
+    let lerp_max = 2.0_f64;
+    let damage = DamageModule::damage(fighter.module_accessor, 0) as f64;
+    let lerp_scalar = (damage - lerp_start) / (lerp_end - lerp_start);
+    let end_mul = dbg!(lerp_min.lerp(&lerp_max, &lerp_scalar).clamp(lerp_min, lerp_max));
+    let end_frame = fighter.get_param_float("common", "furafura_frame") as f64;
+    if fighter.status_frame() as f64 >= end_frame * end_mul {
         fighter.change_status(FIGHTER_STATUS_KIND_FURAFURA_END.into(), false.into());
         return false.into();
     }

--- a/fighters/common/src/general_statuses/shield/guard/main.rs
+++ b/fighters/common/src/general_statuses/shield/guard/main.rs
@@ -19,6 +19,7 @@ unsafe fn sub_status_guard_common(fighter: &mut L2CFighterCommon) {
 unsafe fn status_guard_common_air(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         true.into()
     } else {
         false.into()

--- a/fighters/common/src/general_statuses/shield/guard_damage/exec.rs
+++ b/fighters/common/src/general_statuses/shield/guard_damage/exec.rs
@@ -84,6 +84,8 @@ unsafe fn FighterStatusUniqProcessGuardDamage_leave_stop(
     arg1: L2CValue,
     arg2: L2CValue
 ) -> L2CValue {
+    fighter.FighterStatusGuard__check_hit_stop_delay(true.into());
+
     effect!(fighter, MA_MSC_CMD_EFFECT_EFFECT_OFF_KIND, Hash40::new("sys_shield_damage2"), false, false);
     effect!(fighter, MA_MSC_CMD_EFFECT_EFFECT_OFF_KIND, Hash40::new("sys_shield_damage3"), false, false);
 

--- a/fighters/common/src/general_statuses/shield/guard_damage/main.rs
+++ b/fighters/common/src/general_statuses/shield/guard_damage/main.rs
@@ -159,6 +159,7 @@ unsafe fn status_GuardDamage_common(fighter: &mut L2CFighterCommon, arg: L2CValu
 unsafe fn status_guard_damage_main_common_air(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         fighter.change_status(FIGHTER_STATUS_KIND_DAMAGE_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         return true.into();
     }
     return false.into();

--- a/fighters/common/src/general_statuses/shield/guard_off/main.rs
+++ b/fighters/common/src/general_statuses/shield/guard_off/main.rs
@@ -53,6 +53,7 @@ unsafe fn sub_status_guard_off_main_common_cancel(fighter: &mut L2CFighterCommon
 unsafe fn sub_status_guard_off_main_common_air(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         return true.into();
     }
     return false.into();

--- a/fighters/common/src/general_statuses/shield/guard_on/main.rs
+++ b/fighters/common/src/general_statuses/shield/guard_on/main.rs
@@ -56,6 +56,7 @@ unsafe fn sub_status_guard_on_common(fighter: &mut L2CFighterCommon) {
 unsafe fn sub_status_guard_on_main_air_common(fighter: &mut L2CFighterCommon) -> L2CValue {
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         true.into()
     } else {
         false.into()

--- a/fighters/common/src/general_statuses/shield/mod.rs
+++ b/fighters/common/src/general_statuses/shield/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 mod fighter_status_guard;
+mod furafura;
 mod guard;
 mod guard_damage;
 mod guard_off;
@@ -10,6 +11,7 @@ pub mod misc;
 fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         fighter_status_guard::install();
+        furafura::install();
         guard::install();
         guard_damage::install();
         guard_off::install();

--- a/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
+++ b/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
@@ -67,6 +67,8 @@ unsafe fn sub_status_shield_break_fly_common(fighter: &mut L2CFighterCommon, arg
 
     if arg1.get_bool(){
         SoundModule::play_se(fighter.module_accessor, Hash40::new("se_common_guardbreak"), true, false, false, false, enSEType(0));
+        SlowModule::set_whole(fighter.module_accessor, 8, 25);
+        EffectModule::req_screen(fighter.module_accessor, Hash40::new("bg_criticalhit"), false, true, true);
     }
 
     let shield_break_xlu_frame = fighter.get_param_int("common", "shield_break_xlu_frame");
@@ -96,6 +98,11 @@ unsafe fn status_ShieldBreakFly_Main(fighter: &mut L2CFighterCommon) -> L2CValue
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
         return true.into();
     }
+
+    if dbg!(fighter.status_frame()) == 8 {
+        EffectModule::remove_screen(fighter.module_accessor, Hash40::new("bg_criticalhit"), 0);
+    }
+
     if MotionModule::is_end(fighter.module_accessor) {
         WorkModule::set_flag(
             fighter.module_accessor,

--- a/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
+++ b/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
@@ -96,6 +96,7 @@ unsafe fn status_ShieldBreakFly_Main(fighter: &mut L2CFighterCommon) -> L2CValue
     }
     if !fighter.is_situation(*SITUATION_KIND_GROUND) {
         fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+        ControlModule::clear_command(fighter.module_accessor, true);
         return true.into();
     }
 

--- a/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
+++ b/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
@@ -51,8 +51,19 @@ unsafe fn sub_status_shield_break_fly_common(fighter: &mut L2CFighterCommon, arg
     
     // fighter.on_flag(*FIGHTER_STATUS_WORK_ID_FLAG_RESERVE_CHECK_DEAD_AREA_FORCE);
     HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
-    
-    MotionModule::change_motion(fighter.module_accessor, Hash40::new("damage_hi_1"), 0.0, 1.0, false, 0.0, false, false);
+
+    let shield_break_motion = Hash40::new("shield_break_fly");
+    let start_frame = 3.0;
+    let mut end_frame = FighterMotionModuleImpl::get_cancel_frame(fighter.module_accessor, shield_break_motion, true);
+    if end_frame == 0.0 {
+        end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, shield_break_motion);
+    }
+    if end_frame > start_frame {
+        end_frame -= start_frame;
+    }
+    let desired_end_frame = 30.0;
+    let rate = end_frame / desired_end_frame;
+    MotionModule::change_motion(fighter.module_accessor, shield_break_motion, start_frame, rate, false, 0.0, false, false);
 
     if arg1.get_bool(){
         SoundModule::play_se(fighter.module_accessor, Hash40::new("se_common_guardbreak"), true, false, false, false, enSEType(0));
@@ -86,37 +97,8 @@ unsafe fn status_ShieldBreakFly_Main(fighter: &mut L2CFighterCommon) -> L2CValue
         return true.into();
     }
     if MotionModule::is_end(fighter.module_accessor) {
-        let next_status = if fighter.is_cat_flag(Cat2::DownToDownStandFB) { FIGHTER_STATUS_KIND_DOWN_STAND_FB} else { FIGHTER_STATUS_KIND_DOWN_STAND };
-        fighter.change_status(next_status.into(), true.into());
+        fighter.change_status(FIGHTER_STATUS_KIND_FURAFURA_STAND.into(), true.into());
         return true.into();
-    }
-
-    if !fighter.is_motion_one_of(&[Hash40::new("down_spot_d"), Hash40::new("down_spot_u")]) {
-        let shield_break_motion = if MotionModule::is_anim_resource(fighter.module_accessor, Hash40::new("down_spot_d")) {
-            fighter.off_flag(*FIGHTER_STATUS_DOWN_FLAG_UP);
-            Hash40::new("down_spot_d")
-        } else {
-            fighter.on_flag(*FIGHTER_STATUS_DOWN_FLAG_UP);
-            Hash40::new("down_spot_u")
-        };
-
-        let start_frame = 3.0;
-        let mut end_frame = FighterMotionModuleImpl::get_cancel_frame(fighter.module_accessor, shield_break_motion, true);
-        if end_frame == 0.0 {
-            end_frame = MotionModule::end_frame_from_hash(fighter.module_accessor, shield_break_motion);
-        }
-        if end_frame > start_frame {
-            end_frame -= start_frame;
-        }
-        let desired_end_frame = fighter.get_param_float("common", "furafura_frame");
-        let rate = (2.0 * end_frame) / ((5.0 * desired_end_frame) - (3.0 * end_frame)); // doing maths because we speed the motion up midway through to make it look good
-        MotionModule::change_motion(fighter.module_accessor, shield_break_motion, start_frame, rate, false, 0.0, false, false);
-        // smash_script::macros::PLAY_STATUS(fighter, Hash40::new("se_common_dizzy"));
-        return false.into();
-    } else {
-        if fighter.motion_frame() >= MotionModule::end_frame(fighter.module_accessor) * 2.0 / 5.0 {
-            MotionModule::set_rate(fighter.module_accessor, 1.0);
-        }
     }
 
     return false.into();

--- a/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
+++ b/fighters/common/src/general_statuses/shield/shield_break_fly/mod.rs
@@ -97,6 +97,11 @@ unsafe fn status_ShieldBreakFly_Main(fighter: &mut L2CFighterCommon) -> L2CValue
         return true.into();
     }
     if MotionModule::is_end(fighter.module_accessor) {
+        WorkModule::set_flag(
+            fighter.module_accessor,
+            MotionModule::is_anim_resource(fighter.module_accessor, Hash40::new("down_spot_u")),
+            *FIGHTER_STATUS_DOWN_FLAG_UP
+        );
         fighter.change_status(FIGHTER_STATUS_KIND_FURAFURA_STAND.into(), true.into());
         return true.into();
     }

--- a/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
@@ -181,3 +181,6 @@ special_air_n_end_f:
 special_n_end_f:
   extra:
     cancel_frame: 48
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/bayonetta/motion/body/motion_patch.yaml
@@ -168,7 +168,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 special_air_n_end_h:
   extra:
     cancel_frame: 58

--- a/romfs/source/fighter/brave/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/brave/motion/body/motion_patch.yaml
@@ -77,3 +77,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/brave/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/brave/motion/body/motion_patch.yaml
@@ -76,7 +76,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
@@ -78,3 +78,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/buddy/motion/body/motion_patch.yaml
@@ -77,7 +77,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/captain/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/captain/motion/body/motion_patch.yaml
@@ -81,3 +81,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/captain/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/captain/motion/body/motion_patch.yaml
@@ -80,7 +80,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -121,3 +121,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -123,4 +123,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/chrom/motion/body/motion_patch.yaml
@@ -120,7 +120,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
@@ -84,3 +84,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/cloud/motion/body/motion_patch.yaml
@@ -83,7 +83,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/common/param/battle_object.prcxml
+++ b/romfs/source/fighter/common/param/battle_object.prcxml
@@ -18,7 +18,7 @@
   <float hash="hitstop_elec_mul">1.25</float>
   <int hash="just_shield_hitstop_frame_add">22</int>
   <int hash="just_shield_hitstop_frame_max">23</int>
-  <float hash="just_shield_reflect_attack_mul">0.5</float>
+  <float hash="just_shield_reflect_attack_mul">1.0</float>
   <float hash="just_shield_reflect_speed_mul">1.0</float>
   <float hash="just_shield_reflect_life_mul">1</float>
   <int hash="just_shield_reflect_count_max">999</int>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -154,7 +154,7 @@
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <int hash="damage_fly_reflect_disable_escape_frame">999</int>
   <float hash="dead_down_damage_speed">999</float>
-  <float hash="furafura_frame">150</float>
+  <float hash="furafura_frame">180</float>
   <float hash="furafura_clatter_frame">0</float>
   <float hash="bury_jump_y_speed_mul">1.15</float>
   <float hash="mewtwo_thrown_reaction_frame_mul">1</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -154,7 +154,7 @@
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <int hash="damage_fly_reflect_disable_escape_frame">999</int>
   <float hash="dead_down_damage_speed">999</float>
-  <float hash="furafura_frame">180</float>
+  <float hash="furafura_frame">150</float>
   <float hash="furafura_clatter_frame">0</float>
   <float hash="bury_jump_y_speed_mul">1.15</float>
   <float hash="mewtwo_thrown_reaction_frame_mul">1</float>

--- a/romfs/source/fighter/common/param/common.prcxml
+++ b/romfs/source/fighter/common/param/common.prcxml
@@ -50,7 +50,7 @@
   <int hash="shield_setoff_escape">999</int>
   <float hash="0x20d241cd64">0.85</float>
   <int hash="guard_damage_just_shield_disable_frame">1</int>
-  <int hash="shield_break_xlu_frame">24</int>
+  <int hash="shield_break_xlu_frame">30</int>
   <int hash="escape_flick_y">3</int>
   <float hash="escape_stick_y">-0.7386</float>
   <int hash="escape_fb_flick_x">3</int>
@@ -154,7 +154,8 @@
   <float hash="damage_fly_reflect_reaction_frame_mul">0.8</float>
   <int hash="damage_fly_reflect_disable_escape_frame">999</int>
   <float hash="dead_down_damage_speed">999</float>
-  <float hash="furafura_frame">120</float>
+  <float hash="furafura_frame">150</float>
+  <float hash="furafura_clatter_frame">0</float>
   <float hash="bury_jump_y_speed_mul">1.15</float>
   <float hash="mewtwo_thrown_reaction_frame_mul">1</float>
   <int hash="mewtwo_thrown_reaction_frame_max">15</int>

--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -85,3 +85,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/daisy/motion/body/motion_patch.yaml
@@ -84,7 +84,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
@@ -108,7 +108,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
@@ -111,4 +111,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dedede/motion/body/motion_patch.yaml
@@ -109,3 +109,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/demon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/demon/motion/body/motion_patch.yaml
@@ -31,7 +31,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/demon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/demon/motion/body/motion_patch.yaml
@@ -32,3 +32,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
@@ -114,7 +114,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
@@ -117,4 +117,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/diddy/motion/body/motion_patch.yaml
@@ -115,3 +115,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
@@ -48,3 +48,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/dolly/motion/body/motion_patch.yaml
@@ -47,7 +47,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -115,4 +115,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -112,7 +112,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/donkey/motion/body/motion_patch.yaml
@@ -113,3 +113,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
@@ -160,7 +160,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/duckhunt/motion/body/motion_patch.yaml
@@ -161,3 +161,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/edge/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/edge/motion/body/motion_patch.yaml
@@ -86,7 +86,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/edge/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/edge/motion/body/motion_patch.yaml
@@ -87,3 +87,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
@@ -79,7 +79,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/eflame/motion/body/motion_patch.yaml
@@ -80,3 +80,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/elight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/elight/motion/body/motion_patch.yaml
@@ -61,7 +61,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/elight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/elight/motion/body/motion_patch.yaml
@@ -62,3 +62,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/falco/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/falco/motion/body/motion_patch.yaml
@@ -252,7 +252,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/falco/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/falco/motion/body/motion_patch.yaml
@@ -253,3 +253,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/fox/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/fox/motion/body/motion_patch.yaml
@@ -73,7 +73,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/fox/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/fox/motion/body/motion_patch.yaml
@@ -74,3 +74,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
@@ -58,4 +58,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
@@ -55,7 +55,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gamewatch/motion/body/motion_patch.yaml
@@ -56,3 +56,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -278,3 +278,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -280,4 +280,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ganon/motion/body/motion_patch.yaml
@@ -277,7 +277,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
@@ -98,4 +98,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
@@ -95,7 +95,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gaogaen/motion/body/motion_patch.yaml
@@ -96,3 +96,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -80,7 +80,7 @@ special_air_lw:
     xlu_end: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 appeal_lw_r:
   extra:
     cancel_frame: 80

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -89,4 +89,4 @@ appeal_lw_l:
     cancel_frame: 80
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/gekkouga/motion/body/motion_patch.yaml
@@ -87,3 +87,6 @@ appeal_lw_r:
 appeal_lw_l:
   extra:
     cancel_frame: 80
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ike/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ike/motion/body/motion_patch.yaml
@@ -94,7 +94,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ike/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ike/motion/body/motion_patch.yaml
@@ -95,3 +95,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
@@ -79,7 +79,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/inkling/motion/body/motion_patch.yaml
@@ -80,3 +80,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -159,3 +159,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -158,7 +158,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -116,4 +116,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -114,3 +114,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kamui/motion/body/motion_patch.yaml
@@ -113,7 +113,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/ken/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ken/motion/body/motion_patch.yaml
@@ -208,7 +208,7 @@ throw_lw:
     cancel_frame: 41
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ken/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ken/motion/body/motion_patch.yaml
@@ -209,3 +209,6 @@ throw_lw:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -963,4 +963,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -960,7 +960,7 @@ younglink_special_air_n_end:
     cancel_frame: 23
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -961,3 +961,6 @@ younglink_special_air_n_end:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
@@ -381,3 +381,6 @@ appeal_hi_r:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
@@ -383,4 +383,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopa/motion/body/motion_patch.yaml
@@ -380,7 +380,7 @@ appeal_hi_r:
     cancel_frame: 70
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
@@ -96,3 +96,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/koopajr/motion/body/motion_patch.yaml
@@ -95,7 +95,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/krool/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/krool/motion/body/motion_patch.yaml
@@ -152,3 +152,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/krool/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/krool/motion/body/motion_patch.yaml
@@ -151,7 +151,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/krool/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/krool/motion/body/motion_patch.yaml
@@ -154,4 +154,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/link/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/link/motion/body/motion_patch.yaml
@@ -84,3 +84,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/link/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/link/motion/body/motion_patch.yaml
@@ -83,7 +83,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
@@ -350,7 +350,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/littlemac/motion/body/motion_patch.yaml
@@ -351,3 +351,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
@@ -207,7 +207,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucario/motion/body/motion_patch.yaml
@@ -208,3 +208,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
@@ -116,3 +116,6 @@ throw_f:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
@@ -118,4 +118,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucas/motion/body/motion_patch.yaml
@@ -115,7 +115,7 @@ throw_f:
     cancel_frame: 43
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
@@ -77,3 +77,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
@@ -79,4 +79,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/lucina/motion/body/motion_patch.yaml
@@ -76,7 +76,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
@@ -154,3 +154,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/luigi/motion/body/motion_patch.yaml
@@ -153,7 +153,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -201,3 +201,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mario/motion/body/motion_patch.yaml
@@ -200,7 +200,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
@@ -168,7 +168,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mariod/motion/body/motion_patch.yaml
@@ -169,3 +169,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -85,3 +85,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -87,4 +87,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/marth/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/marth/motion/body/motion_patch.yaml
@@ -84,7 +84,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/master/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/master/motion/body/motion_patch.yaml
@@ -104,7 +104,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/master/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/master/motion/body/motion_patch.yaml
@@ -107,4 +107,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/master/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/master/motion/body/motion_patch.yaml
@@ -105,3 +105,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
@@ -135,4 +135,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
@@ -132,7 +132,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/metaknight/motion/body/motion_patch.yaml
@@ -133,3 +133,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
@@ -110,3 +110,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/mewtwo/motion/body/motion_patch.yaml
@@ -109,7 +109,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
@@ -94,7 +94,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miifighter/motion/body/motion_patch.yaml
@@ -95,3 +95,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
@@ -50,3 +50,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miigunner/motion/body/motion_patch.yaml
@@ -49,7 +49,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -118,7 +118,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/miiswordsman/motion/body/motion_patch.yaml
@@ -119,3 +119,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -36,7 +36,7 @@ fall_special:
   blend_frames: 5
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 guard_off:
   blend_frames: 4
   extra:

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -55,4 +55,4 @@ throw_lw:
     cancel_frame: 31
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/murabito/motion/body/motion_patch.yaml
@@ -53,3 +53,6 @@ throw_hi:
 throw_lw:
   extra:
     cancel_frame: 31
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/nana/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/nana/motion/body/motion_patch.yaml
@@ -60,3 +60,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/nana/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/nana/motion/body/motion_patch.yaml
@@ -62,4 +62,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/nana/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/nana/motion/body/motion_patch.yaml
@@ -59,7 +59,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/ness/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ness/motion/body/motion_patch.yaml
@@ -94,4 +94,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/ness/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ness/motion/body/motion_patch.yaml
@@ -92,3 +92,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ness/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ness/motion/body/motion_patch.yaml
@@ -91,7 +91,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/packun/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/packun/motion/body/motion_patch.yaml
@@ -261,7 +261,7 @@ attack_s3_s_a:
     no_stop_intp: false
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 appeal_hi_2:
   game_script: game_appealhi2
   flags:

--- a/romfs/source/fighter/packun/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/packun/motion/body/motion_patch.yaml
@@ -292,3 +292,6 @@ appeal_hi_2:
     xlu_end: 0
     cancel_frame: 17
     no_stop_intp: false
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
@@ -72,3 +72,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pacman/motion/body/motion_patch.yaml
@@ -71,7 +71,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
@@ -426,7 +426,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
@@ -429,4 +429,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/palutena/motion/body/motion_patch.yaml
@@ -427,3 +427,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -90,4 +90,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -87,7 +87,7 @@ throw_hi:
     cancel_frame: 42
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/peach/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/peach/motion/body/motion_patch.yaml
@@ -88,3 +88,6 @@ throw_hi:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
@@ -63,3 +63,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pfushigisou/motion/body/motion_patch.yaml
@@ -62,7 +62,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
@@ -68,3 +68,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pichu/motion/body/motion_patch.yaml
@@ -67,7 +67,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
@@ -50,4 +50,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
@@ -48,3 +48,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pickel/motion/body/motion_patch.yaml
@@ -47,7 +47,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
@@ -61,7 +61,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikachu/motion/body/motion_patch.yaml
@@ -62,3 +62,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -68,7 +68,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -69,3 +69,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pikmin/motion/body/motion_patch.yaml
@@ -71,4 +71,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pit/motion/body/motion_patch.yaml
@@ -101,4 +101,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pit/motion/body/motion_patch.yaml
@@ -98,7 +98,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pit/motion/body/motion_patch.yaml
@@ -99,3 +99,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
@@ -87,3 +87,6 @@ throw_lw:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
@@ -86,7 +86,7 @@ throw_lw:
     cancel_frame: 30
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pitb/motion/body/motion_patch.yaml
@@ -89,4 +89,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
@@ -79,3 +79,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/plizardon/motion/body/motion_patch.yaml
@@ -78,7 +78,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/popo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/popo/motion/body/motion_patch.yaml
@@ -60,3 +60,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/popo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/popo/motion/body/motion_patch.yaml
@@ -62,4 +62,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/popo/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/popo/motion/body/motion_patch.yaml
@@ -59,7 +59,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -44,7 +44,7 @@ special_air_lw:
     xlu_end: 2
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f01damageflyn.nuanmb

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -47,4 +47,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f01damageflyn.nuanmb

--- a/romfs/source/fighter/purin/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/purin/motion/body/motion_patch.yaml
@@ -45,3 +45,6 @@ special_air_lw:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
@@ -69,3 +69,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/pzenigame/motion/body/motion_patch.yaml
@@ -68,7 +68,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -80,4 +80,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -78,3 +78,6 @@ catch_turn:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/reflet/motion/body/motion_patch.yaml
@@ -77,7 +77,7 @@ catch_turn:
     cancel_frame: 42
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/richter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/richter/motion/body/motion_patch.yaml
@@ -112,7 +112,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 special_n:
   flags:
     move: false

--- a/romfs/source/fighter/richter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/richter/motion/body/motion_patch.yaml
@@ -168,3 +168,6 @@ special_air_hi:
   extra:
     intangible_start_frame: 0
     intangible_end_frame: 0
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
@@ -263,7 +263,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ridley/motion/body/motion_patch.yaml
@@ -264,3 +264,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/robot/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/robot/motion/body/motion_patch.yaml
@@ -396,4 +396,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/robot/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/robot/motion/body/motion_patch.yaml
@@ -394,3 +394,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/robot/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/robot/motion/body/motion_patch.yaml
@@ -393,7 +393,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
@@ -842,7 +842,7 @@ throw_hi:
     cancel_frame: 35
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rockman/motion/body/motion_patch.yaml
@@ -843,3 +843,6 @@ throw_hi:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
@@ -69,7 +69,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
@@ -72,4 +72,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/rosetta/motion/body/motion_patch.yaml
@@ -70,3 +70,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -239,4 +239,4 @@ special_air_s4_back:
       no_stop_intp: false
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -237,3 +237,6 @@ special_air_s4_back:
       xlu_end: 0
       cancel_frame: 47
       no_stop_intp: false
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/roy/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/roy/motion/body/motion_patch.yaml
@@ -131,7 +131,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 special_s1:
   extra:
     cancel_frame: 30

--- a/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
@@ -144,7 +144,7 @@ fall_special:
   blend_frames: 5
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 guard_off:
   blend_frames: 4
   extra:

--- a/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/ryu/motion/body/motion_patch.yaml
@@ -256,3 +256,6 @@ special_s_end:
 throw_lw:
   extra:
     cancel_frame: 41
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/samus/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samus/motion/body/motion_patch.yaml
@@ -95,3 +95,6 @@ air_catch_landing:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/samus/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samus/motion/body/motion_patch.yaml
@@ -94,7 +94,7 @@ air_catch_landing:
     cancel_frame: 19
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
@@ -113,7 +113,7 @@ air_catch_landing:
     cancel_frame: 17
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/samusd/motion/body/motion_patch.yaml
@@ -114,3 +114,6 @@ air_catch_landing:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
@@ -69,7 +69,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
@@ -72,4 +72,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sheik/motion/body/motion_patch.yaml
@@ -70,3 +70,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -64,4 +64,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -61,7 +61,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shizue/motion/body/motion_patch.yaml
@@ -62,3 +62,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -150,7 +150,7 @@ catch:
     cancel_frame: 36
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/shulk/motion/body/motion_patch.yaml
@@ -151,3 +151,6 @@ catch:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/simon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/simon/motion/body/motion_patch.yaml
@@ -90,3 +90,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/simon/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/simon/motion/body/motion_patch.yaml
@@ -89,7 +89,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/snake/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/snake/motion/body/motion_patch.yaml
@@ -317,3 +317,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/snake/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/snake/motion/body/motion_patch.yaml
@@ -316,7 +316,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -484,3 +484,6 @@ wait_4:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -483,7 +483,7 @@ wait_4:
     freeze_during_hitstop: false
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/sonic/motion/body/motion_patch.yaml
@@ -486,4 +486,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
@@ -101,7 +101,7 @@ air_catch_landing:
     cancel_frame: 15
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/szerosuit/motion/body/motion_patch.yaml
@@ -102,3 +102,6 @@ air_catch_landing:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
@@ -713,3 +713,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/tantan/motion/body/motion_patch.yaml
@@ -712,7 +712,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
@@ -69,3 +69,6 @@ air_catch_landing:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
@@ -68,7 +68,7 @@ air_catch_landing:
     cancel_frame: 16
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/toonlink/motion/body/motion_patch.yaml
@@ -71,4 +71,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/trail/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/trail/motion/body/motion_patch.yaml
@@ -69,3 +69,6 @@ special_air_lw:
   extra:
     xlu_start: 0
     xlu_end: 0
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/trail/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/trail/motion/body/motion_patch.yaml
@@ -69,6 +69,9 @@ special_air_lw:
   extra:
     xlu_start: 0
     xlu_end: 0
+furafura_end:
+  extra:
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/wario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wario/motion/body/motion_patch.yaml
@@ -91,3 +91,6 @@ throw_hi:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/wario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wario/motion/body/motion_patch.yaml
@@ -93,4 +93,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/wario/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wario/motion/body/motion_patch.yaml
@@ -90,7 +90,7 @@ throw_hi:
     cancel_frame: 85
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -53,3 +53,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -52,7 +52,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wiifit/motion/body/motion_patch.yaml
@@ -55,4 +55,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -103,3 +103,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/wolf/motion/body/motion_patch.yaml
@@ -102,7 +102,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
@@ -50,7 +50,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/yoshi/motion/body/motion_patch.yaml
@@ -51,3 +51,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
@@ -96,3 +96,6 @@ air_catch_landing:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
@@ -98,4 +98,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/younglink/motion/body/motion_patch.yaml
@@ -95,7 +95,7 @@ air_catch_landing:
     cancel_frame: 13
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
@@ -85,3 +85,6 @@ catch_attack:
 furafura_end:
   extra:
     cancel_frame: 10
+shield_break_fly:
+  animations:
+    - name: f04downspotd.nuanmb

--- a/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
@@ -87,4 +87,4 @@ furafura_end:
     cancel_frame: 10
 shield_break_fly:
   animations:
-    - name: f04downspotd.nuanmb
+    - name: f03downspotu.nuanmb

--- a/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/zelda/motion/body/motion_patch.yaml
@@ -84,7 +84,7 @@ catch_attack:
     cancel_frame: 0
 furafura_end:
   extra:
-    cancel_frame: 10
+    cancel_frame: 34
 shield_break_fly:
   animations:
     - name: f03downspotu.nuanmb


### PR DESCRIPTION
## Parry
- Reflector damage mul: 0.5 -> 1.0

## Shield
- Added Shield ASDI
  - The code for Shield ASDI was already present, but was mistakenly not used anywhere
  - Shield ASDI distance: 66% of base ASDI distance
- Fixed an issue with Shield SDI that caused players to always travel to the right of the screen, regardless of the intended direction
- When slipping off a ledge during shield, the buffer is now emptied
  - Should prevent some instances where players accidentally act out of an unintentional slip

## Shield Break
Reworked the shield break functionality again

When a shield break occurs, it now features a short slowdown and background effect

Instead of a pop-up or long crumple state, the defender will crumple over in 0.5s, then enter the normal shield break stand animation

The length of the shield break animation is no longer influenced by mashing. Instead, it's based on percent:

- 0%-25%: 2.5s
- 25%-125%: 2.5s-5s, linearly scaled
- 125%+: 5s

The dizzy animation will be slowed with percent to visually communicate the speed

Wake-up animation FAF: 10 -> 34

https://github.com/HDR-Development/HewDraw-Remix/assets/33226440/026933b7-e808-42fa-a506-15a80d99c8b8