### PR TITLE
Platdrop Momentum Rewrite

### DIFF
--- a/fighters/common/src/general_statuses/pass.rs
+++ b/fighters/common/src/general_statuses/pass.rs
@@ -193,8 +193,9 @@ unsafe extern "C" fn sub_set_pass(fighter: &mut L2CFighterCommon) {
     let air_speed_x_stable = fighter.get_param_float("air_speed_x_stable", "");
     if curr_speed_x.abs() > air_speed_x_stable {
         let jump_speed_x_mul = fighter.get_param_float("jump_speed_x_mul", "").sqrt(); // normalized
-        let new_speed_x = (curr_speed_x.abs() * jump_speed_x_mul).clamp(air_speed_x_stable, air_speed_x_stable * 1.7) * curr_speed_x.signum();
-        let adjust_speed_x = (new_speed_x - curr_speed_x) * PostureModule::lr(fighter.module_accessor);
+        let pass_air_speed_x_max_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "pass_air_speed_x_max_mul");
+        let new_speed_x = (curr_speed_x.abs() * jump_speed_x_mul).clamp(air_speed_x_stable, dbg!(air_speed_x_stable * pass_air_speed_x_max_mul)) * curr_speed_x.signum();
+        let adjust_speed_x = (dbg!(new_speed_x) - curr_speed_x) * PostureModule::lr(fighter.module_accessor);
         KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(adjust_speed_x, 0.0, 0.0));
     }
 }

--- a/fighters/common/src/general_statuses/pass.rs
+++ b/fighters/common/src/general_statuses/pass.rs
@@ -1,21 +1,36 @@
 use super::*;
 use globals::*;
 
-pub fn install() {
-    skyline::nro::add_hook(nro_hook);
-}
-
-fn nro_hook(info: &skyline::nro::NroInfo) {
-    if info.name == "common" {
-        skyline::install_hooks!(
-            status_pass_common,
-            status_Pass_Main_sub_hook,
-        );
-    }
+#[skyline::hook(replace = L2CFighterCommon_status_pre_Pass)]
+unsafe extern "C" fn status_pre_Pass(fighter: &mut L2CFighterCommon) {
+	StatusModule::init_settings(
+        fighter.module_accessor,
+        SituationKind(*SITUATION_KIND_GROUND),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_ON_DROP_BOTH_SIDES),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_NONE_FLOAT,
+        0
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_ENABLE,
+        false,
+        false,
+        true,
+        0,
+        (*FIGHTER_STATUS_ATTR_DISABLE_GROUND_FRICTION) as u32,
+        0,
+        0
+    );
 }
 
 #[skyline::hook(replace = L2CFighterCommon_status_Pass_common)]
-unsafe extern "C" fn status_pass_common(fighter: &mut L2CFighterCommon) {
+unsafe extern "C" fn status_Pass_common(fighter: &mut L2CFighterCommon) {
     fighter.sub_air_check_fall_common_pre();
     let transitions = [
         *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_ATTACK_LW3,
@@ -45,7 +60,7 @@ unsafe extern "C" fn status_pass_common(fighter: &mut L2CFighterCommon) {
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_Pass_Main_sub)]
-pub unsafe fn status_Pass_Main_sub_hook(fighter: &mut L2CFighterCommon, arg1: L2CValue) -> L2CValue {
+unsafe fn status_Pass_Main_sub(fighter: &mut L2CFighterCommon, arg1: L2CValue) -> L2CValue {
     let pass_frame = fighter.get_int(*FIGHTER_STATUS_PASS_WORK_INT_FRAME);
     if pass_frame == 0 {
         if !fighter.is_flag(*FIGHTER_STATUS_PASS_FLAG_IS_SET_PASS) {
@@ -158,4 +173,49 @@ pub unsafe fn status_Pass_Main_sub_hook(fighter: &mut L2CFighterCommon, arg1: L2
         return 1.into();
     }
     return 0.into();
+}
+
+#[skyline::hook(replace = L2CFighterCommon_sub_set_pass)]
+unsafe extern "C" fn sub_set_pass(fighter: &mut L2CFighterCommon) {
+    ControlModule::reset_flick_y(fighter.module_accessor);
+    ControlModule::reset_flick_sub_y(fighter.module_accessor);
+    fighter.global_table[FLICK_Y].assign(&0xFE.into());
+
+    GroundModule::pass_floor(fighter.module_accessor);
+    StatusModule::set_situation_kind(fighter.module_accessor, SituationKind(*SITUATION_KIND_AIR), false);
+    let prev_situation_kind = fighter.global_table[SITUATION_KIND].get_i32();
+    fighter.global_table[PREV_SITUATION_KIND].assign(&L2CValue::I32(prev_situation_kind));
+    fighter.global_table[SITUATION_KIND].assign(&L2CValue::I32(*SITUATION_KIND_AIR));
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+
+    let pass_speed_y = fighter.get_param_float("common", "pass_speed_y");
+    KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(0.0, pass_speed_y, 0.0));
+
+    // if entering platdrop with more than max horizontal air speed
+    // multiply horizontal speed by horizontal jump speed multiplier
+    // then clamp it to between max horizontal air speed and 1.8 times max horizontal air speed
+    let curr_speed_x = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+    let air_speed_x_stable = fighter.get_param_float("air_speed_x_stable", "");
+    if curr_speed_x.abs() > air_speed_x_stable {
+        let jump_speed_x_mul = fighter.get_param_float("jump_speed_x_mul", "");
+        let new_speed_x = (curr_speed_x.abs() * jump_speed_x_mul).clamp(air_speed_x_stable, 1.8 * air_speed_x_stable) * curr_speed_x.signum();
+        let adjust_speed_x = (new_speed_x - curr_speed_x) * PostureModule::lr(fighter.module_accessor);
+        KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(adjust_speed_x, 0.0, 0.0));
+    }
+
+}
+
+fn nro_hook(info: &skyline::nro::NroInfo) {
+    if info.name == "common" {
+        skyline::install_hooks!(
+            status_pre_Pass,
+            status_Pass_common,
+            status_Pass_Main_sub,
+            sub_set_pass
+        );
+    }
+}
+
+pub fn install() {
+    skyline::nro::add_hook(nro_hook);
 }

--- a/fighters/common/src/general_statuses/pass.rs
+++ b/fighters/common/src/general_statuses/pass.rs
@@ -194,8 +194,8 @@ unsafe extern "C" fn sub_set_pass(fighter: &mut L2CFighterCommon) {
     if curr_speed_x.abs() > air_speed_x_stable {
         let jump_speed_x_mul = fighter.get_param_float("jump_speed_x_mul", "").sqrt(); // normalized
         let pass_air_speed_x_max_mul = ParamModule::get_float(fighter.object(), ParamType::Shared, "pass_air_speed_x_max_mul");
-        let new_speed_x = (curr_speed_x.abs() * jump_speed_x_mul).clamp(air_speed_x_stable, dbg!(air_speed_x_stable * pass_air_speed_x_max_mul)) * curr_speed_x.signum();
-        let adjust_speed_x = (dbg!(new_speed_x) - curr_speed_x) * PostureModule::lr(fighter.module_accessor);
+        let new_speed_x = (curr_speed_x.abs() * jump_speed_x_mul).clamp(air_speed_x_stable, air_speed_x_stable * pass_air_speed_x_max_mul) * curr_speed_x.signum();
+        let adjust_speed_x = (new_speed_x - curr_speed_x) * PostureModule::lr(fighter.module_accessor);
         KineticModule::add_speed(fighter.module_accessor, &Vector3f::new(adjust_speed_x, 0.0, 0.0));
     }
 }

--- a/romfs/source/fighter/common/hdr/param/fighter_param.xml
+++ b/romfs/source/fighter/common/hdr/param/fighter_param.xml
@@ -6,564 +6,658 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="1">
       <hash40 hash="fighter_kind">DONKEY</hash40>
       <float hash="attack_dash_fall_speed_mul">0.25</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="2">
       <hash40 hash="fighter_kind">LINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="3">
       <hash40 hash="fighter_kind">SAMUS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="4">
       <hash40 hash="fighter_kind">SAMUSD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="5">
       <hash40 hash="fighter_kind">YOSHI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="6">
       <hash40 hash="fighter_kind">KIRBY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="7">
       <hash40 hash="fighter_kind">FOX</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="8">
       <hash40 hash="fighter_kind">PIKACHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.85</float>
       <float hash="dacds_mul">0.85</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="9">
       <hash40 hash="fighter_kind">LUIGI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">2.65</float>
     </struct>
     <struct index="10">
       <hash40 hash="fighter_kind">NESS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="11">
       <hash40 hash="fighter_kind">CAPTAIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="12">
       <hash40 hash="fighter_kind">PURIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="13">
       <hash40 hash="fighter_kind">PEACH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="14">
       <hash40 hash="fighter_kind">DAISY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="15">
       <hash40 hash="fighter_kind">KOOPA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="16">
       <hash40 hash="fighter_kind">SHEIK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="17">
       <hash40 hash="fighter_kind">ZELDA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="18">
       <hash40 hash="fighter_kind">MARIOD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="19">
       <hash40 hash="fighter_kind">PICHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="20">
       <hash40 hash="fighter_kind">FALCO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="21">
       <hash40 hash="fighter_kind">MARTH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="22">
       <hash40 hash="fighter_kind">LUCINA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="23">
       <hash40 hash="fighter_kind">YOUNGLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="24">
       <hash40 hash="fighter_kind">GANON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="25">
       <hash40 hash="fighter_kind">MEWTWO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="26">
       <hash40 hash="fighter_kind">ROY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.8</float>
       <float hash="dacds_mul">0.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="27">
       <hash40 hash="fighter_kind">CHROM</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="28">
       <hash40 hash="fighter_kind">GAMEWATCH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.8</float>
       <float hash="dacds_mul">0.8</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="29">
       <hash40 hash="fighter_kind">METAKNIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="30">
       <hash40 hash="fighter_kind">PIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="31">
       <hash40 hash="fighter_kind">PITB</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="32">
       <hash40 hash="fighter_kind">SZEROSUIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">0.95</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="33">
       <hash40 hash="fighter_kind">WARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="34">
       <hash40 hash="fighter_kind">SNAKE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="35">
       <hash40 hash="fighter_kind">IKE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="36">
       <hash40 hash="fighter_kind">PZENIGAME</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="37">
       <hash40 hash="fighter_kind">PFUSHIGISOU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="38">
       <hash40 hash="fighter_kind">PLIZARDON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="39">
       <hash40 hash="fighter_kind">DIDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="40">
       <hash40 hash="fighter_kind">LUCAS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="41">
       <hash40 hash="fighter_kind">SONIC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="42">
       <hash40 hash="fighter_kind">DEDEDE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="43">
       <hash40 hash="fighter_kind">PIKMIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="44">
       <hash40 hash="fighter_kind">LUCARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="45">
       <hash40 hash="fighter_kind">ROBOT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="46">
       <hash40 hash="fighter_kind">TOONLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="47">
       <hash40 hash="fighter_kind">WOLF</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="48">
       <hash40 hash="fighter_kind">MURABITO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="49">
       <hash40 hash="fighter_kind">ROCKMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="50">
       <hash40 hash="fighter_kind">WIIFIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="51">
       <hash40 hash="fighter_kind">ROSETTA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="52">
       <hash40 hash="fighter_kind">LITTLEMAC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.775</float>
       <float hash="dacds_mul">0.825</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="53">
       <hash40 hash="fighter_kind">GEKKOUGA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="54">
       <hash40 hash="fighter_kind">PALUTENA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="55">
       <hash40 hash="fighter_kind">PACMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="56">
       <hash40 hash="fighter_kind">REFLET</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="57">
       <hash40 hash="fighter_kind">SHULK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="58">
       <hash40 hash="fighter_kind">KOOPAJR</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="59">
       <hash40 hash="fighter_kind">DUCKHUNT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="60">
       <hash40 hash="fighter_kind">RYU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="61">
       <hash40 hash="fighter_kind">KEN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="62">
       <hash40 hash="fighter_kind">CLOUD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="63">
       <hash40 hash="fighter_kind">KAMUI</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="64">
       <hash40 hash="fighter_kind">BAYONETTA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="65">
       <hash40 hash="fighter_kind">INKLING</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.875</float>
       <float hash="dacds_mul">0.875</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="66">
       <hash40 hash="fighter_kind">RIDLEY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="67">
       <hash40 hash="fighter_kind">SIMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="68">
       <hash40 hash="fighter_kind">RICHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="69">
       <hash40 hash="fighter_kind">KROOL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="70">
       <hash40 hash="fighter_kind">SHIZUE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="71">
       <hash40 hash="fighter_kind">GAOGAEN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="72">
       <hash40 hash="fighter_kind">MIIFIGHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.75</float>
       <float hash="dacds_mul">0.75</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="73">
       <hash40 hash="fighter_kind">MIISWORDSMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="74">
       <hash40 hash="fighter_kind">MIIGUNNER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="75">
       <hash40 hash="fighter_kind">POPO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="76">
       <hash40 hash="fighter_kind">NANA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="77">
       <hash40 hash="fighter_kind">KOOPAG</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="78">
       <hash40 hash="fighter_kind">MIIENEMYF</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="79">
       <hash40 hash="fighter_kind">MIIENEMYS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="80">
       <hash40 hash="fighter_kind">MIIENEMYG</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="81">
       <hash40 hash="fighter_kind">PACKUN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="82">
       <hash40 hash="fighter_kind">JACK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="83">
       <hash40 hash="fighter_kind">BRAVE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="84">
       <hash40 hash="fighter_kind">BUDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="85">
       <hash40 hash="fighter_kind">DOLLY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="86">
       <hash40 hash="fighter_kind">MASTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.875</float>
       <float hash="dacds_mul">0.875</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="87">
       <hash40 hash="fighter_kind">TANTAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="88">
       <hash40 hash="fighter_kind">PICKEL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="89">
       <hash40 hash="fighter_kind">EDGE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">0.95</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="90">
       <hash40 hash="fighter_kind">EFLAME</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="91">
       <hash40 hash="fighter_kind">ELIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="92">
       <hash40 hash="fighter_kind">DEMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">0.8</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
     <struct index="93">
       <hash40 hash="fighter_kind">TRAIL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.925</float>
       <float hash="dacds_mul">0.925</float>
+      <float hash="pass_air_speed_x_max_mul">1.7</float>
     </struct>
   </list>
 </struct>


### PR DESCRIPTION
Rewrote horizontal momentum retention when entering platdrop:

- Removed ground friction during grounded platdrop frames (lasts 2F for most characters, 3F for Ken, Ryu, Terry)
  - Improves **pre-adjustment** platdrop momentum for everyone, especially high-friction characters
  - Ground friction is *doubled* if moving faster than the max walk speed, so this effectively removes 4F ground friction
- If entering platdrop with more than max horizontal air speed (`air_speed_x_stable`):
  - Multiply horizontal speed by the square root of the horizontal jump speed multiplier (`jump_speed_x_mul`)
  - Then clamp it to between max horizontal air speed and a multiplier\* of the max horizontal air speed
    - \*For Luigi, this multiplier is 2.65x. For everyone else, it's 1.7x, subject to future balance adjustments

In effect, these changes align platdrop momentum with the design of a characters aerial stats - characters intended to be mobile on the ground but slow in the air will no longer have wavedrops that sidestep their weakness in aerial stats. Generally wavedrop speeds are lower on average, but some high-friction characters have better wavedrops than before. The highest new wavedrop speeds are much lower than the highest old wavedrop speeds.