### PR TITLE
Global aerial FAF ledgegrab

### DIFF
--- a/fighters/common/src/opff/ledges.rs
+++ b/fighters/common/src/opff/ledges.rs
@@ -101,12 +101,13 @@ unsafe fn tether_trump_landing(boma: &mut BattleObjectModuleAccessor, status_kin
     */
 }
 
-// Allow all special moves to grab ledge after their FAF
+// Allow all aerials and special moves to grab ledge after their FAF
 // rather than after their animation completes
 unsafe fn global_faf_ledgegrab(fighter: &mut L2CFighterCommon) {
-    // If a special move has a defined FAF (!= 0)
+    // If an aerial or special move has a defined FAF (!= 0)
     // then we allow it to grab ledge
-    if StatusModule::status_kind(fighter.module_accessor) > 0x1DB  // only applies to special moves
+    if (StatusModule::status_kind(fighter.module_accessor) > 0x1DB  // only applies to special moves
+    || fighter.is_status(*FIGHTER_STATUS_KIND_ATTACK_AIR))
     && fighter.is_situation(*SITUATION_KIND_AIR)
     && {let motion_kind = MotionModule::motion_kind(fighter.module_accessor);
         FighterMotionModuleImpl::get_cancel_frame(fighter.module_accessor, Hash40::new_raw(motion_kind), true) > 0.0}


### PR DESCRIPTION
Allows all aerials to grab ledge once their FAF is reached, rather than when their animation completes. The difference this makes will largely vary between each character and move, as it depends on how many frames exist between the move's FAF and the end of its animation.