### PR TITLE
Improve Wavedrop Max Speeds

### DIFF
--- a/romfs/source/fighter/common/hdr/param/fighter_param.xml
+++ b/romfs/source/fighter/common/hdr/param/fighter_param.xml
@@ -6,35 +6,35 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="1">
       <hash40 hash="fighter_kind">DONKEY</hash40>
       <float hash="attack_dash_fall_speed_mul">0.25</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="2">
       <hash40 hash="fighter_kind">LINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="3">
       <hash40 hash="fighter_kind">SAMUS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="4">
       <hash40 hash="fighter_kind">SAMUSD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="5">
       <hash40 hash="fighter_kind">YOSHI</hash40>
@@ -48,21 +48,21 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="7">
       <hash40 hash="fighter_kind">FOX</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="8">
       <hash40 hash="fighter_kind">PIKACHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.85</float>
       <float hash="dacds_mul">0.85</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="9">
       <hash40 hash="fighter_kind">LUIGI</hash40>
@@ -76,7 +76,7 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="11">
       <hash40 hash="fighter_kind">CAPTAIN</hash40>
@@ -90,63 +90,63 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="13">
       <hash40 hash="fighter_kind">PEACH</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="14">
       <hash40 hash="fighter_kind">DAISY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="15">
       <hash40 hash="fighter_kind">KOOPA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="16">
       <hash40 hash="fighter_kind">SHEIK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="17">
       <hash40 hash="fighter_kind">ZELDA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="18">
       <hash40 hash="fighter_kind">MARIOD</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="19">
       <hash40 hash="fighter_kind">PICHU</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="20">
       <hash40 hash="fighter_kind">FALCO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="21">
       <hash40 hash="fighter_kind">MARTH</hash40>
@@ -167,21 +167,21 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="24">
       <hash40 hash="fighter_kind">GANON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="25">
       <hash40 hash="fighter_kind">MEWTWO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="26">
       <hash40 hash="fighter_kind">ROY</hash40>
@@ -202,49 +202,49 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.8</float>
       <float hash="dacds_mul">0.8</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="29">
       <hash40 hash="fighter_kind">METAKNIGHT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="30">
       <hash40 hash="fighter_kind">PIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="31">
       <hash40 hash="fighter_kind">PITB</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="32">
       <hash40 hash="fighter_kind">SZEROSUIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">0.95</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="33">
       <hash40 hash="fighter_kind">WARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="34">
       <hash40 hash="fighter_kind">SNAKE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="35">
       <hash40 hash="fighter_kind">IKE</hash40>
@@ -265,70 +265,70 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="38">
       <hash40 hash="fighter_kind">PLIZARDON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="39">
       <hash40 hash="fighter_kind">DIDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="40">
       <hash40 hash="fighter_kind">LUCAS</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="41">
       <hash40 hash="fighter_kind">SONIC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="42">
       <hash40 hash="fighter_kind">DEDEDE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="43">
       <hash40 hash="fighter_kind">PIKMIN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="44">
       <hash40 hash="fighter_kind">LUCARIO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="45">
       <hash40 hash="fighter_kind">ROBOT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="46">
       <hash40 hash="fighter_kind">TOONLINK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="47">
       <hash40 hash="fighter_kind">WOLF</hash40>
@@ -342,56 +342,56 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="49">
       <hash40 hash="fighter_kind">ROCKMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="50">
       <hash40 hash="fighter_kind">WIIFIT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="51">
       <hash40 hash="fighter_kind">ROSETTA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="52">
       <hash40 hash="fighter_kind">LITTLEMAC</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.775</float>
       <float hash="dacds_mul">0.825</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="53">
       <hash40 hash="fighter_kind">GEKKOUGA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="54">
       <hash40 hash="fighter_kind">PALUTENA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="55">
       <hash40 hash="fighter_kind">PACMAN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="56">
       <hash40 hash="fighter_kind">REFLET</hash40>
@@ -412,14 +412,14 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="59">
       <hash40 hash="fighter_kind">DUCKHUNT</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="60">
       <hash40 hash="fighter_kind">RYU</hash40>
@@ -454,63 +454,63 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="65">
       <hash40 hash="fighter_kind">INKLING</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.875</float>
       <float hash="dacds_mul">0.875</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="66">
       <hash40 hash="fighter_kind">RIDLEY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="67">
       <hash40 hash="fighter_kind">SIMON</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="68">
       <hash40 hash="fighter_kind">RICHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="69">
       <hash40 hash="fighter_kind">KROOL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="70">
       <hash40 hash="fighter_kind">SHIZUE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="71">
       <hash40 hash="fighter_kind">GAOGAEN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="72">
       <hash40 hash="fighter_kind">MIIFIGHTER</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.75</float>
       <float hash="dacds_mul">0.75</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="73">
       <hash40 hash="fighter_kind">MIISWORDSMAN</hash40>
@@ -524,35 +524,35 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="75">
       <hash40 hash="fighter_kind">POPO</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="76">
       <hash40 hash="fighter_kind">NANA</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="77">
       <hash40 hash="fighter_kind">KOOPAG</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="78">
       <hash40 hash="fighter_kind">MIIENEMYF</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="79">
       <hash40 hash="fighter_kind">MIIENEMYS</hash40>
@@ -566,42 +566,42 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="81">
       <hash40 hash="fighter_kind">PACKUN</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.95</float>
       <float hash="dacds_mul">0.95</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="82">
       <hash40 hash="fighter_kind">JACK</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="83">
       <hash40 hash="fighter_kind">BRAVE</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="84">
       <hash40 hash="fighter_kind">BUDDY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="85">
       <hash40 hash="fighter_kind">DOLLY</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="86">
       <hash40 hash="fighter_kind">MASTER</hash40>
@@ -615,14 +615,14 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.9</float>
       <float hash="dacds_mul">0.9</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="88">
       <hash40 hash="fighter_kind">PICKEL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">1.0</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="89">
       <hash40 hash="fighter_kind">EDGE</hash40>
@@ -650,14 +650,14 @@
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">1.0</float>
       <float hash="dacds_mul">0.8</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
     <struct index="93">
       <hash40 hash="fighter_kind">TRAIL</hash40>
       <float hash="attack_dash_fall_speed_mul">-1.0</float>
       <float hash="dacus_mul">0.925</float>
       <float hash="dacds_mul">0.925</float>
-      <float hash="pass_air_speed_x_max_mul">1.7</float>
+      <float hash="pass_air_speed_x_max_mul">1.8</float>
     </struct>
   </list>
 </struct>


### PR DESCRIPTION
Max wavedrop speed mul (mul of max horizontal air speed): 1.7 -> 1.8 for all characters except:
- Yoshi
- Luigi (already 2.65)
- Captain Falcon
- Marth
- Lucina
- Roy
- Chrom
- Ike
- Squirtle
- Wolf
- Robin
- Shulk
- Ryu
- Ken
- Cloud
- Corrin
- Mii Swordfighter
- Byleth
- Sephiroth
- Pyra
- Mythra