### PR TITLE
PK Freeze Effect Hotfix

### DIFF
--- a/fighters/lucas/src/pkfire/acmd.rs
+++ b/fighters/lucas/src/pkfire/acmd.rs
@@ -40,7 +40,7 @@ unsafe extern "C" fn effect_pillar(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     if is_excute(agent) {
-        EFFECT_FOLLOW_FLIP(agent, Hash40::new("lucas_pkfi_start"), Hash40::new("lucas_pkfi_start"), Hash40::new("top"), -0.5, 0, 0, 0, 0, 0, 1, true, *EF_FLIP_YZ);
+        EFFECT_FOLLOW_FLIP(agent, Hash40::new("lucas_pkfr_start"), Hash40::new("lucas_pkfr_start"), Hash40::new("top"), -0.5, 0, 0, 0, 0, 0, 1, true, *EF_FLIP_YZ);
         EFFECT(agent, Hash40::new("lucas_pkfr_bomb_max"), Hash40::new("top"), 0, -4.5, -2.7, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
     }
     /*


### PR DESCRIPTION
I didn't think to replace the effect name on the pillar anim for pk freeze, fixed to remove the fire effect on-hit