### PR TITLE
Mini Misc Fixes

### DIFF
--- a/fighters/ken/src/acmd/smashes.rs
+++ b/fighters/ken/src/acmd/smashes.rs
@@ -50,6 +50,8 @@ unsafe extern "C" fn game_attackhi4(agent: &mut L2CAgentBase) {
     frame(lua_state, 11.0);
     FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
+        MeterModule::watch_damage(agent.battle_object, false);
+        MeterModule::watch_damage(agent.battle_object, true);
         ATTACK(agent, 0, 0, Hash40::new("handl"), 11.0, 80, 97, 0, 80, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_PUNCH, *ATTACK_REGION_PUNCH);
         ATTACK(agent, 1, 0, Hash40::new("arml"), 11.0, 80, 97, 0, 80, 4.5, 0.0, 0.0, 0.0, None, None, None, 1.2, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KEN_PUNCH, *ATTACK_REGION_PUNCH);
     }

--- a/fighters/koopajr/src/acmd/aerials.rs
+++ b/fighters/koopajr/src/acmd/aerials.rs
@@ -169,10 +169,12 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     frame(lua_state, 15.0);
     FT_MOTION_RATE(agent, 38.0/(60.0-15.0));
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 290, 100, 20, 0, 4.2, 0.0, 4.0, -2.0, Some(0.0), Some(4.0), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
-        ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 290, 100, 20, 0, 4.0, 0.0, -2.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
-        AttackModule::set_add_reaction_frame(boma, 0, 8.0, false);
-        AttackModule::set_add_reaction_frame(boma, 1, 8.0, false);
+        // GROUND
+        ATTACK(agent, 0, 0, Hash40::new("top"), 1.5, 290, 100, 46, 0, 4.2, 0.0, 4.0, -2.0, Some(0.0), Some(4.0), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
+        ATTACK(agent, 1, 0, Hash40::new("top"), 1.5, 290, 100, 46, 0, 4.0, 0.0, -2.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
+        // AIR
+        ATTACK(agent, 2, 0, Hash40::new("top"), 1.5, 290, 100, 20, 0, 4.2, 0.0, 4.0, -2.0, Some(0.0), Some(4.0), Some(2.0), 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
+        ATTACK(agent, 3, 0, Hash40::new("top"), 1.5, 290, 100, 20, 0, 4.0, 0.0, -2.0, 0.0, None, None, None, 0.5, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 3, false, false, false, false, true, *COLLISION_SITUATION_MASK_A, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_OBJECT);
     }
     frame(lua_state, 50.0);
     if is_excute(agent) {

--- a/fighters/palutena/src/acmd/aerials.rs
+++ b/fighters/palutena/src/acmd/aerials.rs
@@ -88,9 +88,9 @@ unsafe extern "C" fn effect_attackairf(agent: &mut L2CAgentBase) {
     frame(lua_state, 3.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light_trace"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light2"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
     frame(lua_state, 9.0);
     if is_excute(agent) {
@@ -142,9 +142,9 @@ unsafe extern "C" fn effect_attackairb(agent: &mut L2CAgentBase) {
     frame(lua_state, 3.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light_trace"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light2"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
     frame(lua_state, 7.0);
     if is_excute(agent) {
@@ -287,9 +287,9 @@ unsafe extern "C" fn effect_attackairlw(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         EFFECT_DETACH_KIND(agent, Hash40::new("sys_smash_flash"), -1);
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light_trace"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light2"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
     }
     frame(lua_state, 8.0);
     if is_excute(agent) {

--- a/fighters/palutena/src/acmd/smashes.rs
+++ b/fighters/palutena/src/acmd/smashes.rs
@@ -56,17 +56,17 @@ unsafe extern "C" fn effect_attacks4(agent: &mut L2CAgentBase) {
     frame(lua_state, 16.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_backlight"), Hash40::new("top"), 1, 21, 2.5, 0, -50, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
     frame(lua_state, 17.0);
     if is_excute(agent) {
         EFFECT(agent, Hash40::new("palutena_feather"), Hash40::new("top"), 0, 6, -3, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
     frame(lua_state, 19.0);
     if is_excute(agent) {
         EFFECT(agent, Hash40::new("palutena_feather"), Hash40::new("top"), 0, 6, -6, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
 }
 
@@ -177,17 +177,17 @@ unsafe extern "C" fn effect_attacklw4(agent: &mut L2CAgentBase) {
     frame(lua_state, 16.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_backlight"), Hash40::new("top"), 3, 13.5, 0, 0, -90, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
     }
     frame(lua_state, 19.0);
     if is_excute(agent) {
         EFFECT(agent, Hash40::new("palutena_feather"), Hash40::new("top"), 0, 3, 8, 0, 180, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
     }
     frame(lua_state, 20.0);
     if is_excute(agent) {
         EFFECT(agent, Hash40::new("palutena_feather"), Hash40::new("top"), 0, 3, -8, 0, 0, 0, 0.6, 0, 0, 0, 0, 0, 0, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.01);
         LANDING_EFFECT(agent, Hash40::new("sys_down_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.3, 0, 0, 0, 0, 0, 0, false);
     }
 }

--- a/fighters/palutena/src/acmd/tilts.rs
+++ b/fighters/palutena/src/acmd/tilts.rs
@@ -53,7 +53,7 @@ unsafe extern "C" fn effect_attacks3(agent: &mut L2CAgentBase) {
     frame(lua_state, 13.0);
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light4"), Hash40::new("stick"), 0, 8.65, 0, 0, 0, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.0);
+        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
     }
     frame(lua_state, 14.0);
     if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_COLOR) == 0 {
@@ -358,7 +358,7 @@ unsafe extern "C" fn effect_attacklw3(agent: &mut L2CAgentBase) {
     }
     if is_excute(agent) {
         EFFECT_FOLLOW(agent, Hash40::new("palutena_wand_light4"), Hash40::new("stick"), 0, 8.65, 0, 0, 180, 0, 1, true);
-        LAST_EFFECT_SET_COLOR(agent, 0.85, 0.40, 0.001);
+        LAST_EFFECT_SET_COLOR(agent, 2.0, 0.03, 0.0);
     }
     frame(lua_state, 29.0);
     if WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_COLOR) == 0 {

--- a/fighters/palutena/src/opff.rs
+++ b/fighters/palutena/src/opff.rs
@@ -166,7 +166,7 @@ unsafe fn training_mode_taunts(fighter: &mut L2CFighterCommon, id: usize, status
     if is_training_mode() {
         if (fighter.is_motion(Hash40::new("appeal_s_r")) || fighter.is_motion(Hash40::new("appeal_s_l")))
         && fighter.motion_frame() == 2.0 {
-            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 1);
+            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 3);
         }
         if (fighter.is_motion(Hash40::new("appeal_hi_r")) || fighter.is_motion(Hash40::new("appeal_hi_l")))
         && fighter.motion_frame() == 2.0 {
@@ -174,7 +174,7 @@ unsafe fn training_mode_taunts(fighter: &mut L2CFighterCommon, id: usize, status
         }
         if (fighter.is_motion(Hash40::new("appeal_lw_r")) || fighter.is_motion(Hash40::new("appeal_lw_l")))
         && fighter.motion_frame() == 2.0 {
-            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 3);
+            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 1);
         }
     }
 }
@@ -185,12 +185,12 @@ unsafe fn color_charge(fighter: &mut L2CFighterCommon) {
     && !AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_PARRY)
     && VarModule::is_flag(fighter.object(), vars::palutena::status::CAN_INCREASE_COLOR) {
         VarModule::off_flag(fighter.object(), vars::palutena::status::CAN_INCREASE_COLOR);
-        // red moves: side
+        // yellow moves: side
         if fighter.is_motion(Hash40::new("attack_s3_s"))
         || fighter.is_motion(Hash40::new("attack_s4_s"))
         || fighter.is_motion(Hash40::new("attack_air_f"))
         || fighter.is_motion(Hash40::new("attack_air_b")) {
-            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 1);
+            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 3);
         }
 
         // blue moves: up
@@ -200,11 +200,11 @@ unsafe fn color_charge(fighter: &mut L2CFighterCommon) {
             VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 2);
         }
 
-        // yellow moves: down
+        // red moves: down
         else if fighter.is_motion(Hash40::new("attack_lw3"))
         || fighter.is_motion(Hash40::new("attack_lw4"))
         || fighter.is_motion(Hash40::new("attack_air_lw")) {
-            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 3);
+            VarModule::set_int(fighter.object(), vars::palutena::instance::SET_COLOR, 1);
         }
     }
 }

--- a/romfs/source/fighter/jack/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/jack/motion/body/motion_patch.yaml
@@ -42,7 +42,7 @@ attack_13:
     cancel_frame: 28
 attack_11:
   extra:
-    cancel_frame: 16
+    cancel_frame: 18
 attack_hi4:
   extra:
     cancel_frame: 56


### PR DESCRIPTION
## Palutena
### Power Board
 - (*) Unreverted the color swap (side moves give yellow, down moves give red)

## Bowser Jr.
### Down Air
- [-] Removed 8f hitstun against aerial opponents

## Ken
### Up Smash
 - (*) fixed a bug that prevented the second hit from rewarding meter