### PR TITLE
(Even More) Copy Ability Adjustments

### DIFF
--- a/fighters/kirby/src/opff/copy.rs
+++ b/fighters/kirby/src/opff/copy.rs
@@ -1270,6 +1270,28 @@ unsafe fn packun_ptooie_scale(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
+unsafe fn ken_hado_landcancel(boma: &mut BattleObjectModuleAccessor, frame: f32) {
+    if !boma.is_status_one_of(&[
+        *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N,
+        *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N_COMMAND,
+        *FIGHTER_KIRBY_STATUS_KIND_RYU_SPECIAL_N2_COMMAND,
+        *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N,
+        *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N_COMMAND,
+        *FIGHTER_KIRBY_STATUS_KIND_KEN_SPECIAL_N2_COMMAND,
+    ]) {
+        return;
+    }
+
+    if boma.is_situation(*SITUATION_KIND_GROUND) 
+    && boma.is_prev_situation(*SITUATION_KIND_AIR) {
+        if frame < 70.0 { // the autocancel frame
+            WorkModule::set_float(boma, 14.0, *FIGHTER_INSTANCE_WORK_ID_FLOAT_LANDING_FRAME);
+            boma.change_status_req(*FIGHTER_STATUS_KIND_LANDING_FALL_SPECIAL, false);
+        }
+    }
+}
+
+
 pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     let inhaledstatus = StatusModule::status_kind(fighter.module_accessor);
     // enable copying flags when inhaling an opponent
@@ -1291,6 +1313,7 @@ pub unsafe fn kirby_copy_handler(fighter: &mut L2CFighterCommon, boma: &mut Batt
         0x3D => {
             check_special_cancels(fighter, boma, status_kind, situation_kind, motion_kind, frame);
             ken_air_hado_distinguish(fighter, boma, frame);
+            ken_hado_landcancel(boma, frame)
         },
         // Lucario
         0x2C => magic_series_lucario(fighter, boma, id, cat, status_kind, situation_kind, motion_kind, stick_x, stick_y, facing, frame),

--- a/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/kirby/motion/body/motion_patch.yaml
@@ -150,24 +150,9 @@ special_air_hi_h:
     intangible_end_frame: 0
     cancel_frame: 0
     freeze_during_hitstop: false
-elight_special_n2:
-  extra:
-    cancel_frame: 71
-elight_special_n:
-  extra:
-    cancel_frame: 71
-elight_special_air_n:
-  extra:
-    cancel_frame: 71
 tantan_special_n_end:
   extra:
     cancel_frame: 40
-elight_special_air_n2:
-  extra:
-    cancel_frame: 71
-demon_special_air_n_hi:
-  extra:
-    cancel_frame: 110
 koopa_special_n_max:
   game_script: game_koopaspecialnmax
   flags:
@@ -193,7 +178,7 @@ koopa_special_n_max:
   extra:
     xlu_start: 0
     xlu_end: 0
-    cancel_frame: 60
+    cancel_frame: 65
     no_stop_intp: false
 koopa_special_air_n_max:
   game_script: game_koopaspecialairnmax
@@ -220,7 +205,7 @@ koopa_special_air_n_max:
   extra:
     xlu_start: 0
     xlu_end: 0
-    cancel_frame: 60
+    cancel_frame: 65
     no_stop_intp: false
 mewtwo_special_n_shoot:
   extra:
@@ -295,12 +280,6 @@ tantan_special_air_n_end:
 mewtwo_special_air_n_shoot:
   extra:
     cancel_frame: 28
-dedede_special_n_shot_object_spit:
-  extra:
-    cancel_frame: 22
-dedede_special_air_n_shot_object_spit:
-  extra:
-    cancel_frame: 22
 zelda_special_n:
   extra:
     intangible_start_frame: 5
@@ -311,6 +290,21 @@ zelda_special_air_n:
     intangible_start_frame: 0
     intangible_end_frame: 0
     cancel_frame: 64
+bayonetta_special_air_n_end_h:
+  extra:
+    cancel_frame: 58
+bayonetta_special_n_end_h:
+  extra:
+    cancel_frame: 58
+bayonetta_special_air_n_end_f:
+  extra:
+    cancel_frame: 48
+bayonetta_special_n_end_f:
+  extra:
+    cancel_frame: 48
+brave_special_n_cancel:
+  extra:
+    cancel_frame: 8
 brave_special_air_n_cancel:
   extra:
     cancel_frame: 8
@@ -449,6 +443,14 @@ chrom_special_air_n_end2:
 chrom_special_air_n_end_max:
   extra:
     cancel_frame: 38
+daisy_special_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+daisy_special_air_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 diddy_special_n_cancel:
   game_script: game_diddyspecialncancel
   flags:
@@ -518,10 +520,10 @@ donkey_special_air_n_cancel:
     cancel_frame: 9
 edge_special_n1:
   extra:
-    cancel_frame: 46
+    cancel_frame: 44
 edge_special_air_n1:
   extra:
-    cancel_frame: 46
+    cancel_frame: 44
 edge_special_n2:
   extra:
     cancel_frame: 60
@@ -630,18 +632,27 @@ kamui_special_n_end_1:
 kamui_special_air_n_end_1:
   extra:
     cancel_frame: 45
+ken_special_air_n:
+  extra:
+    cancel_frame: 70
+ken_special_air_n_empty:
+  extra:
+    cancel_frame: 70
 koopajr_special_n_shoot:
   extra:
     cancel_frame: 32
 koopajr_special_air_n_shoot:
   extra:
     cancel_frame: 32
+link_special_n_start:
+  flags:
+    move: false
 lucario_special_n_cancel:
   extra:
-    cancel_frame: 7
+    cancel_frame: 9
 lucario_special_air_n_cancel:
   extra:
-    cancel_frame: 7
+    cancel_frame: 9
 lucina_special_n_end:
   extra:
     cancel_frame: 45
@@ -891,15 +902,29 @@ palutena_special_n:
 palutena_special_air_n:
   extra:
     cancel_frame: 43
+peach_special_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
+peach_special_air_n:
+  extra:
+    xlu_start: 0
+    xlu_end: 0
 pit_special_n_fire_s:
   extra:
     cancel_frame: 30
+pit_special_air_n_fire_s:
+  extra:
+    cancel_frame: 32
 pit_special_n_fire_hi:
   extra:
     cancel_frame: 30
 pit_special_air_n_fire_hi:
   extra:
     cancel_frame: 30
+reflet_special_n_start:
+  flags:
+    move: false
 reflet_special_n_cancel:
   extra:
     cancel_frame: 8
@@ -907,9 +932,13 @@ reflet_special_air_n_cancel:
   extra:
     cancel_frame: 8
 richter_special_air_n:
+  flags:
+    move: false
   extra:
     cancel_frame: 37
 richter_special_n:
+  flags:
+    move: false
   extra:
     cancel_frame: 37
 ridley_special_n_shoot:
@@ -1006,6 +1035,12 @@ rockman_special_air_n_turn:
 rockman_special_air_n_turn_empty:
   extra:
     cancel_frame: 35
+ryu_special_n:
+  flags:
+    move: false
+ryu_special_n_empty:
+  flags:
+    move: false
 samus_special_n_c:
   extra:
     cancel_frame: 9
@@ -1021,6 +1056,9 @@ samusd_special_n_c:
 samusd_special_air_n_c:
   extra:
     cancel_frame: 9
+sheiik_special_n_start:
+  flags:
+    move: false
 sheik_special_air_n_end:
   extra:
     cancel_frame: 32
@@ -1030,6 +1068,72 @@ sheik_special_n_cancel:
 sheik_special_air_n_cancel:
   extra:
     cancel_frame: 8
+shizue_special_n:
+  extra:
+    xlu_start: 5
+    xlu_end: 8
+shizue_special_air_n:
+  extra:
+    xlu_start: 5
+    xlu_end: 8
+shulk_special_n_end:
+  extra:
+    cancel_frame: 10
+shulk_special_n_jump:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_n_speed:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_n_shield:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_n_buster:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_n_smash:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_end:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_jump:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_speed:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_shield:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_buster:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
+shulk_special_air_n_smash:
+  extra:
+    cancel_frame: 10
+    xlu_start: 0
+    xlu_end: 0
 simon_special_n:
   extra:
     cancel_frame: 60
@@ -1068,12 +1172,21 @@ sonic_special_n_hit:
 szerosuit_special_n_landing:
   extra:
     cancel_frame: 15
+wario_special_n_bite_end:
+  extra:
+    cancel_frame: 27
+wario_special_air_n_bite_end:
+  extra:
+    cancel_frame: 27
 wiifit_special_n_cancel:
   extra:
     cancel_frame: 8
 wiifit_special_air_n_cancel:
   extra:
     cancel_frame: 8
+younglink_special_n_start:
+  flags:
+    move: false
 younglink_special_n_end:
   extra:
     cancel_frame: 23


### PR DESCRIPTION
Mostly updates to motion_list.yml.
Note that not all values may be exact due to potential motion rating, but being net nerfs or buffs still hold true.

Mythra (Lightning Buster)
- [+] FAF, Level 1 & 2: 71 -> 69

Kazuya
- [+] FAF, Angled Up, (Air): 110 -> 55

Bowser
- [-] FAF, Fireball Shot: 60 -> 65

King Dedede (Inhale)
- [-] FAF, Spitting Out Inhaled Object: 22 -> 26

Bayonetta
- [+] FAF, Hand Shooting: 65 -> 58
- [+] FAF, Foot Shooting: 65 -> 48
- The in-game value is exactly the same for both of these due to different motion rating.

Hero (Frizz)
- [-] FAF, Cancel Animation (Ground): 6 -> 8

Peach & Daisy
- [-] Removed all intangibility

Sephiroth (Flare)
- [+] FAF, Flare: 46 -> 44

Ken (Hadouken)
- [-] FAF: 58 -> 70
- [+] Now land cancels with 14 frames of lag.

Link & Young Link 
- Trans bone movement disabled on start (ground)

Lucario (Aura Sphere)
- [-] FAF, Shield Cancel: 7 -> 9

Pit
- [-] FAF, Front Firing (Air): 30 -> 32

Robin (Thunder)
- Trans bone movement disabled on start (ground)

Richter (Knife Throw)
- Trans bone movement disabled

Ryu (Hadouken)
- Trans bone movement disabled

Sheik (Needles)
- Trans bone movement disabled on start (ground)

Isabelle (Pocket)
- [-] Intangibility frames, nothing yet in Pocket: 5-12 -> 5-8

Shulk (Monado Arts)
- [-] FAF, No Activation: 1 -> 10
- [-] Removed all intangibility on All Activations & No Activation

Wario (Chomp)
- [-] FAF, Throw: 20 -> 27

To Do: Look into Ryu and Ken's Empty Shot, separate from nightly to beta changes