### PR TITLE
Substitute Hotfix

### DIFF
--- a/fighters/gekkouga/src/acmd/specials.rs
+++ b/fighters/gekkouga/src/acmd/specials.rs
@@ -39,7 +39,7 @@ unsafe extern "C" fn sound_speciallwjump(agent: &mut L2CAgentBase) {
 }
 
 pub fn install(agent: &mut Agent) {
-    // agent.acmd("game_speciallw", game_speciallw, Priority::Low);
+    agent.acmd("game_speciallw", acmd_stub, Priority::Low);
     agent.acmd("effect_speciallw", effect_speciallw, Priority::Low);
 
     agent.acmd("game_speciallwjump", game_speciallwjump, Priority::Low);


### PR DESCRIPTION
# Changelog

## Greninja

### Substitute (Down Special)
- (*) Fixed an oversight that gave Greninja's head and left leg intangibility during startup.