### PR TITLE
Uncapped G2A Floats

### DIFF
--- a/fighters/common/src/general_statuses/float/pre.rs
+++ b/fighters/common/src/general_statuses/float/pre.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[no_mangle]
 unsafe fn float_pre_common(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
     if fighter.global_table[PREV_STATUS_KIND].get_i32() != *FIGHTER_STATUS_KIND_ATTACK_AIR {
         VarModule::off_flag(fighter.battle_object, vars::common::status::FLOAT_INHERIT_AERIAL);
     }

--- a/fighters/daisy/src/status/uniq_float.rs
+++ b/fighters/daisy/src/status/uniq_float.rs
@@ -3,8 +3,15 @@ use super::*;
 // FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START
 
 extern "Rust" {
+    #[link_name = "peach_float_start_pre_common"]
+    fn peach_float_start_pre_common(fighter: &mut L2CFighterCommon) -> L2CValue;
+
     #[link_name = "peach_float_start_main_common"]
     fn peach_float_start_main_common(fighter: &mut L2CFighterCommon) -> L2CValue;
+}
+
+unsafe extern "C" fn uniq_float_start_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    peach_float_start_pre_common(fighter)
 }
 
 unsafe extern "C" fn uniq_float_start_main(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -23,6 +30,7 @@ unsafe extern "C" fn uniq_float_main(fighter: &mut L2CFighterCommon) -> L2CValue
 }
 
 pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START, uniq_float_start_pre);
     agent.status(Main, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START, uniq_float_start_main);
     agent.status(Main, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT, uniq_float_main);
 }

--- a/fighters/peach/src/status/uniq_float_start.rs
+++ b/fighters/peach/src/status/uniq_float_start.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 #[no_mangle]
+pub unsafe fn peach_float_start_pre_common(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::on_flag(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_JUMP_NO_LIMIT_ONCE);
+    smashline::original_status(Pre, fighter, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START)(fighter)
+}
+
+#[no_mangle]
 unsafe fn peach_float_start_main_common(fighter: &mut L2CFighterCommon) -> L2CValue {
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_LANDING_ATTACK_AIR);
     WorkModule::enable_transition_term(fighter.module_accessor, *FIGHTER_PEACH_STATUS_UNIQ_FLOAT_TRANS_ID_FALL_CONTROL);
@@ -228,10 +234,15 @@ pub unsafe fn peach_float_main_loop_common(fighter: &mut L2CFighterCommon) -> L2
 
 // FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START
 
+unsafe extern "C" fn uniq_float_start_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    peach_float_start_pre_common(fighter)
+}
+
 unsafe extern "C" fn uniq_float_start_main(fighter: &mut L2CFighterCommon) -> L2CValue {
     peach_float_start_main_common(fighter)
 }
 
 pub fn install(agent: &mut Agent) {
+    agent.status(Pre, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START, uniq_float_start_pre);
     agent.status(Main, *FIGHTER_PEACH_STATUS_KIND_UNIQ_FLOAT_START, uniq_float_start_main);
 }


### PR DESCRIPTION
Makes floats have uncapped motion transfer the same way aerials do, rather than instantly dropping to the air speed cap. Mostly affects Daisy but has been done to all floats.  