### PR TITLE
Small Workflows Update

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - dev
+      - pre-release
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:

--- a/scripts/full_package.py
+++ b/scripts/full_package.py
@@ -80,19 +80,10 @@ print("creating hash files")
 hash_package.hash_folder("switch-package", "content_hashes.txt")
 hash_package.hash_folder_json("switch-package", "content_hashes.json")
 
-# make a ryujinx package too
-print("making ryujinx-package.zip")
-os.remove("switch-package/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/hdr-launcher.nro")
-os.mkdir("switch-package/sdcard")
-shutil.move("switch-package/atmosphere/", "switch-package/sdcard/")
-shutil.move("switch-package/ultimate/", "switch-package/sdcard/")
-shutil.make_archive("ryujinx-package", 'zip', 'switch-package')
-
 # move the stuff to artifacts folder
 if os.path.exists("artifacts"):
     shutil.rmtree("artifacts")
 os.mkdir("artifacts")
 shutil.move("switch-package.zip", "artifacts")
-shutil.move("ryujinx-package.zip", "artifacts")
 shutil.move("content_hashes.txt", "artifacts")
 shutil.move("content_hashes.json", "artifacts")


### PR DESCRIPTION
# Changelog

- Remove ryujinx-package (it wasn't used anyway)
- pr_build.yml now runs when a PR is made against the pre-release branch