### PR TITLE
Enable hitfalling for King K Rool

### DIFF
--- a/fighters/krool/src/opff.rs
+++ b/fighters/krool/src/opff.rs
@@ -102,6 +102,7 @@ pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectMod
     armored_charge(fighter, motion_kind);
     var_reset(fighter);
     fastfall_specials(fighter);
+    fighter.check_hitfall();
 }
 
 pub extern "C" fn krool_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {


### PR DESCRIPTION
_This idea came to me in a dream_

King K Rool's kit intuitively seems like it would work well with hitfalling, mainly due to how his Uair works. Giving it additional utility by letting it serve better as a combo tool instead of how it works now as only a finisher should open up the character more. His other aerials should benefit as well, but that was the main inspiration.

He is generally regarded as a bottom 3 character, as well as relatively inflexible in playstyle. This seems like it could be an interesting way to open him up and make him more viable at the same time.