### PR TITLE
v0.46.3 PreRelease

### DIFF
--- a/utils/src/game_modes.rs
+++ b/utils/src/game_modes.rs
@@ -125,10 +125,12 @@ pub unsafe fn open_modes_session() {
 unsafe fn once_per_game_frame(game_state_ptr: u64) {
 
     // check the current match mode
+    let match_mode = utils_dyn::util::get_match_mode().0;
+
     // 1 is regular smash, 45 is online arena match, 58 is local wireless
-    if utils_dyn::util::get_match_mode().0 != 1 
-    && utils_dyn::util::get_match_mode().0 != 45
-    && utils_dyn::util::get_match_mode().0 != 58 {
+    if match_mode != 1 
+    && match_mode != 45
+    && match_mode != 58 {
         //println!("mode is {}, so not running custom game modes.", utils_dyn::util::get_match_mode().0);
         CURRENT_CUSTOM_MODES = None;
     }
@@ -147,7 +149,19 @@ unsafe fn once_per_game_frame(game_state_ptr: u64) {
     match get_custom_mode() {
         Some(modes) => {
             if modes.contains(&CustomMode::SmashballTag) {
-                tag::update();
+                // Smash tag doesn't work on local wireless (Switch or emulator)
+                if match_mode == 58 {
+                    let mut modes_enabled = HashSet::new();
+                    for mode in modes {
+                        if mode != CustomMode::SmashballTag {
+                            modes_enabled.insert(mode);
+                        }
+                    }
+                    CURRENT_CUSTOM_MODES = Some(modes_enabled);
+                }
+                else {
+                    tag::update();
+                }
             }
             // if modes.contains(&CustomMode::TurboMode) {
             //     turbo::update();

--- a/utils/src/game_modes.rs
+++ b/utils/src/game_modes.rs
@@ -61,7 +61,7 @@ fn detect_new_game(game_state_ptr: u64) -> bool {
 unsafe fn on_rule_select_hook(_: &skyline::hooks::InlineCtx) {
     unsafe { // Ryujinx handle separately
         let text_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
-        if text_addr == 0x8504000 || text_addr == 0x80004000 {
+        if text_addr == 0x8504000 {
             if ninput::any::is_down(ninput::Buttons::R) && ninput::any::is_down(ninput::Buttons::L) {
                 let mut modes = HashSet::new();
                 modes.insert(CustomMode::SmashballTag);


### PR DESCRIPTION
# Custom Gamemodes
- (*) Removed a restriction preventing compatible emulators from running custom gamemodes
- (*) Added the ability to select custom gamemodes in local wireless matches
  - To trigger custom game modes in local wireless, the host must **hold R** when opening the room (similar to regular local play)
  - Anyone who joins the room must **press DPad Down** to select the same mode(s) **before joining** the room (similar to an online arena)
  - *Smash Tag is not allowed on local wireless, due to breaking issues*

Thank you to @BrianAllred for resolving these issues