### PR TITLE
Mewtwo Tele and Phantom Trade Hotfix

### DIFF
--- a/fighters/mewtwo/src/acmd/tilts.rs
+++ b/fighters/mewtwo/src/acmd/tilts.rs
@@ -71,6 +71,56 @@ unsafe extern "C" fn expression_attacks3(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn effect_attacks3hi(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    frame(lua_state, 8.0);
+    if is_excute(agent) {
+        let color = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_COLOR);
+        match color {
+            0 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            1 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            2 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            3 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            4 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            5 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            6 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            7 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+            _ => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), 2, 11.0, 6.4, -34, -72, 49.6, 1, true, *EF_FLIP_YZ),
+        };
+        LAST_EFFECT_SET_RATE(agent, 1.3);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(agent) {
+        FOOT_EFFECT(agent, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
+unsafe extern "C" fn effect_attacks3lw(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    frame(lua_state, 8.0);
+    if is_excute(agent) {
+        let color = WorkModule::get_int(boma, *FIGHTER_INSTANCE_WORK_ID_INT_COLOR);
+        match color {
+            0 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            1 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("mewtwo_tail_attack_a_02"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            2 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("mewtwo_tail_attack_a_03"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            3 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("mewtwo_tail_attack_a_04"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            4 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("mewtwo_tail_attack_a_05"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            5 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("mewtwo_tail_attack_a_06"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            6 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("mewtwo_tail_attack_a_07"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            7 => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("mewtwo_tail_attack_a_08"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+            _ => EFFECT_FOLLOW_FLIP(agent, Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("mewtwo_tail_attack_a_01"), Hash40::new("top"), 2, 5, 6.5, 82, -85, -95.5, 1, true, *EF_FLIP_YZ),
+        };
+        LAST_EFFECT_SET_RATE(agent, 1.3);
+    }
+    frame(lua_state, 11.0);
+    if is_excute(agent) {
+        FOOT_EFFECT(agent, Hash40::new("sys_run_smoke"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1.5, 0, 0, 0, 0, 0, 0, false);
+    }
+}
+
 unsafe extern "C" fn game_attackhi3(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
@@ -204,10 +254,10 @@ pub fn install(agent: &mut Agent) {
 	agent.acmd("effect_attacks3", effect_attacks3, Priority::Low);
     agent.acmd("expression_attacks3", expression_attacks3, Priority::Low);
     agent.acmd("game_attacks3hi", game_attacks3, Priority::Low);
-	agent.acmd("effect_attacks3hi", effect_attacks3, Priority::Low);
+	agent.acmd("effect_attacks3hi", effect_attacks3hi, Priority::Low);
     agent.acmd("expression_attacks3hi", expression_attacks3, Priority::Low);
     agent.acmd("game_attacks3lw", game_attacks3, Priority::Low);
-	agent.acmd("effect_attacks3lw", effect_attacks3, Priority::Low);
+	agent.acmd("effect_attacks3lw", effect_attacks3lw, Priority::Low);
     agent.acmd("expression_attacks3lw", expression_attacks3, Priority::Low);
 
     agent.acmd("game_attackhi3", game_attackhi3, Priority::Low);

--- a/fighters/mewtwo/src/status/special_hi.rs
+++ b/fighters/mewtwo/src/status/special_hi.rs
@@ -30,6 +30,138 @@ unsafe extern "C" fn special_hi2_pre(fighter: &mut L2CFighterCommon) -> L2CValue
     return 0.into();
 }
 
+unsafe extern "C" fn special_hi_2_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let stick_x = ControlModule::get_stick_x(fighter.module_accessor);
+    let stick_y = ControlModule::get_stick_y(fighter.module_accessor);
+    let mut length = sv_math::vec2_length(stick_x, stick_y).min(1.0);
+
+    let wrap_stick = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("wrap_stick"));
+    let mut follow_stick = false;
+    if length <= wrap_stick {
+        if StatusModule::situation_kind(fighter.module_accessor) != *SITUATION_KIND_GROUND {
+            follow_stick = true;
+        }
+        else {
+            if GroundModule::is_touch(fighter.module_accessor, *GROUND_TOUCH_FLAG_ALL as u32) {
+                if GroundModule::is_passable_ground(fighter.module_accessor) {
+                    follow_stick = true;
+                }
+                else {
+                    let normal_x = GroundModule::get_touch_normal_x(fighter.module_accessor, *GROUND_TOUCH_FLAG_ALL as u32);
+                    let normal_y = GroundModule::get_touch_normal_y(fighter.module_accessor, *GROUND_TOUCH_FLAG_ALL as u32);
+                    let angle = sv_math::vec2_angle(normal_x, normal_y, stick_x, stick_y);
+                    if angle < 90.0_f32.to_radians() {
+                        follow_stick = true;
+                    }
+                }
+            }
+        }
+    }
+    else {
+        follow_stick = true;
+    }
+
+    if 0.00001 < stick_x {
+        PostureModule::set_lr(fighter.module_accessor, 1.0);
+    }
+    else if stick_x < -0.00001 {
+        PostureModule::set_lr(fighter.module_accessor, -1.0);
+    }
+    PostureModule::update_rot_y_lr(fighter.module_accessor);
+
+    let lr = PostureModule::lr(fighter.module_accessor);
+
+    let wrap_speed_multi = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("wrap_speed_multi"));
+    let wrap_speed_add = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_hi"), hash40("wrap_speed_add"));
+
+    let mut speed_x;
+    let mut speed_y = 0.0;
+    if !follow_stick {
+        let atan = stick_y.atan2(stick_x * lr);
+        let length_mul = wrap_speed_multi * length;
+
+        let speed = length_mul + wrap_speed_add;
+        let cos = atan.cos();
+        speed_x = speed * cos;
+        speed_x *= lr;
+    }
+    else {
+        let angle = if length < wrap_stick {
+            length = 1.0;
+            90.0_f32.to_radians()
+        }
+        else {
+            stick_y.atan2(stick_x * lr)
+        };
+
+        let length_mul = wrap_speed_multi * length;
+
+        let speed = length_mul + wrap_speed_add;
+        let cos = angle.cos();
+        speed_x = speed * cos;
+        speed_x *= lr;
+
+        let sin = angle.sin();
+        speed_y = speed * sin;
+
+        if angle != 0.0 && angle.to_degrees() != 180.0 { //previously would force airborne on horizontal angles..
+            fighter.set_situation(SITUATION_KIND_AIR.into());
+            GroundModule::set_attach_ground(fighter.module_accessor, false);
+            GroundModule::set_correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+        } 
+    }
+
+    KineticModule::unable_energy_all(fighter.module_accessor);
+
+    sv_kinetic_energy!(
+        reset_energy,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        ENERGY_STOP_RESET_TYPE_FREE,
+        speed_x,
+        speed_y,
+        0.0,
+        0.0,
+        0.0
+    );
+
+    sv_kinetic_energy!(
+        set_accel,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        0.0,
+        0.0
+    );
+
+    sv_kinetic_energy!(
+        set_stable_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        0.0,
+        0.0
+    );
+
+    sv_kinetic_energy!(
+        set_limit_speed,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP,
+        -1.0,
+        -1.0
+    );
+
+    sv_kinetic_energy!(
+        enable,
+        fighter,
+        FIGHTER_KINETIC_ENERGY_ID_STOP
+    );
+
+    HitModule::set_whole(fighter.module_accessor, HitStatus(*HIT_STATUS_XLU), 0);
+
+    GroundModule::clear_cliff_point(fighter.module_accessor);
+
+    0.into()
+}
+
 unsafe extern "C" fn special_hi2_exec(fighter: &mut L2CFighterCommon) -> L2CValue {
     return 0.into();
 }
@@ -143,6 +275,7 @@ unsafe extern "C" fn special_hi3_main_loop(fighter: &mut L2CFighterCommon) -> L2
 
 pub fn install(agent: &mut Agent) {
     agent.status(Pre, *FIGHTER_MEWTWO_STATUS_KIND_SPECIAL_HI_2, special_hi2_pre);
+    agent.status(Init, *FIGHTER_MEWTWO_STATUS_KIND_SPECIAL_HI_2, special_hi_2_init);
     agent.status(Exec, *FIGHTER_MEWTWO_STATUS_KIND_SPECIAL_HI_2, special_hi2_exec);
     
     agent.status(Pre, *FIGHTER_MEWTWO_STATUS_KIND_SPECIAL_HI_3, special_hi3_pre);

--- a/fighters/zelda/src/acmd/specials.rs
+++ b/fighters/zelda/src/acmd/specials.rs
@@ -271,10 +271,12 @@ unsafe extern "C" fn effect_specialhi(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         FLASH(agent, 0.62, 0.94, 0.9, 0.6);
         if VarModule::is_flag(agent.battle_object, vars::common::instance::IS_HEAVY_ATTACK) {
-            EFFECT_FOLLOW(agent, Hash40::new("zelda_atk"), Hash40::new("top"), 4.5 * lr, 10.0, -4.0, 0, 0, 0, 1.65, true);
-            LAST_EFFECT_SET_COLOR(agent, 0.95, 3.0, 0.6);
-            LAST_EFFECT_SET_ALPHA(agent, 0.75);
-            LAST_EFFECT_SET_RATE(agent, 1.15);
+            if boma.is_situation(*SITUATION_KIND_AIR) {
+                EFFECT_FOLLOW(agent, Hash40::new("zelda_atk"), Hash40::new("top"), 4.5 * lr, 10.0, -4.0, 0, 0, 0, 1.65, true);
+                LAST_EFFECT_SET_COLOR(agent, 0.95, 3.0, 0.6);
+                LAST_EFFECT_SET_ALPHA(agent, 0.75);
+                LAST_EFFECT_SET_RATE(agent, 1.15);
+            }
         } else {
             if lr < 0.0 {
                 EFFECT_FOLLOW(agent, Hash40::new("zelda_flor_end_l"), Hash40::new("top"), 0, 9, -0.75, 0, 0, 0, 1.0, false);
@@ -396,10 +398,6 @@ unsafe extern "C" fn effect_landingfallspecial(agent: &mut L2CAgentBase) {
         frame(lua_state, 3.0);
         if is_excute(agent) {
             FLASH(agent, 0.62, 0.94, 0.9, 0.6);
-            EFFECT_FOLLOW(agent, Hash40::new("zelda_atk"), Hash40::new("top"), 5.5 * lr, 8.0, -2.0, 0, 0, 0, 1.65, true);
-            LAST_EFFECT_SET_COLOR(agent, 0.95, 3.0, 0.6);
-            LAST_EFFECT_SET_ALPHA(agent, 0.75);
-            LAST_EFFECT_SET_RATE(agent, 1.10);
             if lr < 0.0 {
                 EFFECT_FOLLOW(agent, Hash40::new("sys_whirlwind_r"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 0.75, false);
             }

--- a/fighters/zelda/src/dein/acmd.rs
+++ b/fighters/zelda/src/dein/acmd.rs
@@ -22,13 +22,14 @@ unsafe extern "C" fn effect_tame(agent: &mut L2CAgentBase) {
 	for h in 21..=146 {
 		if is_excute(agent) {
 			let start_color = Vector3f { x: 0.85, y: 1.05, z: 1.15 };
-			let start_color_flame = Vector3f { x: 1.2, y: 4.5, z: 6.0 };
 			let end_color = Vector3f { x: 0.9, y: 0.044, z: 0.005 };
+			let start_color_flame = Vector3f { x: 1.55, y: 3.0, z: 9.0 };
+			let end_color_flame = Vector3f { x: 1.45, y: 0.5, z: 1.25 };
 			// Smoothly interpolate from starting to ending color
 			let flame_blend_vector = Vector3f {
-				x: end_color.x + (start_color_flame.x * ((h as f32) / 146.0)),
-				y: end_color.y + (start_color_flame.y * ((h as f32) / 146.0)),
-				z: end_color.z + (start_color_flame.z * ((h as f32) / 146.0))
+				x: start_color_flame.x + ((end_color_flame.x - start_color_flame.x) * ((h as f32) / 146.0)),
+				y: start_color_flame.y + ((end_color_flame.y - start_color_flame.y) * ((h as f32) / 146.0)),
+				z: start_color_flame.z + ((end_color_flame.z - start_color_flame.z) * ((h as f32) / 146.0))
 			};
 			let blend_vector = Vector3f {
 				x: start_color.x + ((end_color.x - start_color.x) * ((h as f32) / 146.0)),
@@ -46,12 +47,13 @@ unsafe extern "C" fn effect_tame(agent: &mut L2CAgentBase) {
 					//println!("aha! h is {}", h);
 					let tame_size = agent.get_float(*WEAPON_ZELDA_DEIN_STATUS_WORK_FLOAT_COUNT);
 					let flash_size = if h == 50 { 0.45 + 0.01 * tame_size * 0.95} else if h == 80 { 0.6 + 0.0145 * tame_size * 0.95} else if h == 112 { 0.75 + 0.019 * tame_size * 0.95} else { 0.9 + 0.023 * tame_size * 0.95};
-					let fire_size = if h == 146 { 0.8 + 0.037 * tame_size } else { 0.8 + 0.024 * tame_size };
+					let fire_size = if h == 146 { 1.2 + 0.036 * tame_size } else { 0.8 + 0.024 * tame_size };
 					let flash_handle = EffectModule::req_follow(boma, Hash40::new("sys_flash"), Hash40::new("top"), &Vector3f::zero(), &Vector3f::zero(), flash_size, false, 0, 0, 0, 0, 0, false, false);
 					let fire_handle = EffectModule::req_follow(boma, Hash40::new("zelda_appeal_s_fire"), Hash40::new("top"), &Vector3f::new(2.0, 0.0, 0.0), &Vector3f::zero(), fire_size, false, 0, 0, 0, 0, 0, false, false);
 					// Apply color blend
 					EffectModule::set_rgb(boma, flash_handle as u32, blend_vector.x, blend_vector.y, blend_vector.z);
 					EffectModule::set_rgb(boma, fire_handle as u32, flame_blend_vector.x, flame_blend_vector.y, flame_blend_vector.z);
+					EffectModule::set_alpha(boma, fire_handle as u32, 1.0 - ((146.0/h as f32) / 146.0)); 
 					VarModule::set_int64(zelda, vars::zelda::instance::SPECIAL_S_DEIN_FLASH_EFFECT_HANDLE, flash_handle as u64);
 					VarModule::set_int64(zelda, vars::zelda::instance::SPECIAL_S_DEIN_FIRE_EFFECT_HANDLE, fire_handle as u64);
 				}
@@ -59,6 +61,7 @@ unsafe extern "C" fn effect_tame(agent: &mut L2CAgentBase) {
 					// Apply color blend
 					EffectModule::set_rgb(boma, flash_handle as u32, blend_vector.x, blend_vector.y, blend_vector.z);
 					EffectModule::set_rgb(boma, fire_handle as u32, flame_blend_vector.x, flame_blend_vector.y, flame_blend_vector.z);
+					EffectModule::set_alpha(boma, fire_handle as u32, 1.0 - ((146.0/h as f32) / 146.0));
 				}
 			}
 		}

--- a/fighters/zelda/src/phantom/acmd.rs
+++ b/fighters/zelda/src/phantom/acmd.rs
@@ -506,15 +506,15 @@ unsafe extern "C" fn game_attackmax(agent: &mut L2CAgentBase) {
 	frame(lua_state, 3.0);
 	FT_MOTION_RATE(agent, 1.0);
 	if is_excute(agent) {
+		ATTACK(agent, 0, 0, Hash40::new("top"), 0.0, 368, 100, 50, 0, 6.0, 0.0, 8.0, 13.0, Some(0.0), Some(8.0), Some(8.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
 		ATTACK(agent, 1, 0, Hash40::new("top"), 0.0, 361, 100, 130, 0, 8.5, 0.0, 8.0, 13.0, Some(0.0), Some(8.0), Some(8.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 2, true, false, true, true, false, *COLLISION_SITUATION_MASK_G, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
-		ATTACK(agent, 0, 0, Hash40::new("top"), 0.0, 25, 100, 85, 0, 6.0, 0.0, 8.0, 13.0, Some(0.0), Some(8.0), Some(8.0), 1.0, 1.0, *ATTACK_SETOFF_KIND_OFF, *ATTACK_LR_CHECK_F, true, 0, 0.0, 2, true, false, false, false, false, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_NONE, *ATTACK_REGION_NONE);
+		let hit1 = Vector2f { x: 49.5, y: 14.5 };
+		AttackModule::set_vec_target_pos(boma, 0, smash::phx::Hash40::new("top"), &hit1, 10, false);
 		KineticModule::enable_energy(boma, *WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL);
 		agent.clear_lua_stack();
 		lua_args!(agent, WEAPON_ZELDA_PHANTOM_KINETIC_ENERGY_ID_NORMAL, rush_speed * PostureModule::lr(boma));
 		app::sv_kinetic_energy::set_speed(lua_state);
-		agent.clear_lua_stack();
-		let hit1 = Vector2f { x: 40.0, y: 15.0 };
-        AttackModule::set_vec_target_pos(boma, 0, smash::phx::Hash40::new("top"), &hit1, 9, false);
+		agent.clear_lua_stack();  
 	}
 	frame(lua_state, 11.0);
 	if is_excute(agent) {

--- a/fighters/zelda/src/status/special_hi.rs
+++ b/fighters/zelda/src/status/special_hi.rs
@@ -126,10 +126,42 @@ unsafe extern "C" fn special_hi2_end(fighter: &mut L2CFighterCommon) -> L2CValue
                 let stop_energy = KineticModule::get_energy(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_STOP) as *mut app::KineticEnergy;
                 let speed = Vector2f{ x: lua_bind::KineticEnergy::get_speed_x(stop_energy), y: lua_bind::KineticEnergy::get_speed_y(stop_energy)};
                 sv_kinetic_energy!(set_speed, fighter, *FIGHTER_KINETIC_ENERGY_ID_STOP, speed.x.abs() * lr * 1.05, speed.y); //b-reverse telecancel reverses momentum on ground
+                EFFECT_FOLLOW(fighter, Hash40::new("zelda_atk"), Hash40::new("top"), 5.5 * lr, 8.0, -2.0, 0, 0, 0, 1.65, true);
+                LAST_EFFECT_SET_COLOR(fighter, 0.95, 3.0, 0.6);
+                LAST_EFFECT_SET_ALPHA(fighter, 0.75);
+                LAST_EFFECT_SET_RATE(fighter, 1.10); //spawn gr cancel eff frame 0
             }
         }
     }
     0.into()
+}
+
+unsafe extern "C" fn special_hi3_pre(fighter: &mut L2CFighterCommon) -> L2CValue {
+    StatusModule::init_settings(
+        fighter.module_accessor,
+        app::SituationKind(*SITUATION_KIND_NONE),
+        *FIGHTER_KINETIC_TYPE_UNIQ,
+        *GROUND_CORRECT_KIND_KEEP as u32,
+        app::GroundCliffCheckKind(*GROUND_CLIFF_CHECK_KIND_NONE),
+        true,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_FLAG,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_INT,
+        *FIGHTER_STATUS_WORK_KEEP_FLAG_ALL_FLOAT,
+        (*FS_SUCCEEDS_KEEP_ATTACK | *FS_SUCCEEDS_KEEP_EFFECT) as i32 //allow effect to spawn on ledge cancel
+    );
+    FighterStatusModuleImpl::set_fighter_status_data(
+        fighter.module_accessor,
+        false,
+        *FIGHTER_TREADED_KIND_NO_REAC,
+        false,
+        false,
+        false,
+        (*FIGHTER_LOG_MASK_FLAG_ATTACK_KIND_SPECIAL_HI | *FIGHTER_LOG_MASK_FLAG_ACTION_CATEGORY_ATTACK) as u64,
+        0,
+        *FIGHTER_POWER_UP_ATTACK_BIT_SPECIAL_HI as u32,
+        0
+    );
+    return 0.into();
 }
 
 unsafe extern "C" fn special_hi3_main(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -230,5 +262,6 @@ pub fn install(agent: &mut Agent) {
     agent.status(Pre, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2, special_hi2_pre);
     agent.status(Main, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2, special_hi2_main);
     agent.status(End, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_2, special_hi2_end);
+    agent.status(Pre, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_3, special_hi3_pre);
     agent.status(Main, *FIGHTER_ZELDA_STATUS_KIND_SPECIAL_HI_3, special_hi3_main);
 }


### PR DESCRIPTION
Fixes a few bugs/unintended things on both Zelda and Mewtwo, and slight polish on last Zelda changes.
### Zelda
### Side Special:
- [$] Dins color gradient of red -> yellow reverted to yellow -> red, size and color adj
### Up Special:
- [$] Telecancel effect appears frame 0 (slightly more reactable but not really)
### Down Special:
- [*] Attempt? to fix bug where it registers an attack input frame 0 and buffers phantom instantly (idk how to test)
- [*] Movement on 368 adjusted to be less deadly upon trades
- [R] Launch input reverted to vanilla, but after shield cancelling it requires a down special input like any other time you launch Phantom. 
### Mewtwo
- [$] Fixes angled ftilt graphics being deleted as part of previous consolidation of Sound/Expression scripts.
- [*] Fixes grounded-reappearance momentum bugs by using Zelda's (mostly) vanilla angling logic. Ex holding down doing grounded teleport makes you slide backwards, teleporting forwards has no momentum on reappearance, etc.
