### PR TITLE
Boomerang Effects Cleanup

### DIFF
--- a/fighters/link/src/boomerang/acmd.rs
+++ b/fighters/link/src/boomerang/acmd.rs
@@ -17,6 +17,24 @@ unsafe extern "C" fn game_fly(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn effect_fly(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("link_boomerang"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+        EFFECT_FOLLOW(agent, Hash40::new("link_boomerang_t_hdr"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+    }
+}
+
+unsafe extern "C" fn effect_haved(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_OFF_KIND(agent, Hash40::new("link_boomerang"), false, false);
+        EFFECT_OFF_KIND(agent, Hash40::new("link_boomerang_t_hdr"), false, false);
+    }
+}
+
 unsafe extern "C" fn game_turn(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
@@ -27,5 +45,7 @@ unsafe extern "C" fn game_turn(agent: &mut L2CAgentBase) {
 
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_fly", game_fly, Priority::Low);
+    agent.acmd("effect_fly", effect_fly, Priority::Low);
+    agent.acmd("effect_haved", effect_haved, Priority::Low);
     agent.acmd("game_turn", game_turn, Priority::Low);
 }

--- a/fighters/toonlink/src/boomerang/acmd.rs
+++ b/fighters/toonlink/src/boomerang/acmd.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+unsafe extern "C" fn effect_fly(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("toonlink_boomerang_t_hdr"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+        EFFECT_FOLLOW(agent, Hash40::new("toonlink_boomerang"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+    }
+}
+
+unsafe extern "C" fn effect_haved(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_OFF_KIND(agent, Hash40::new("toonlink_boomerang_t_hdr"), false, false);
+        EFFECT_OFF_KIND(agent, Hash40::new("toonlink_boomerang"), false, false);
+    }
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.acmd("effect_fly", effect_fly, Priority::Low);
+    agent.acmd("effect_haved", effect_haved, Priority::Low);
+}

--- a/fighters/toonlink/src/boomerang/mod.rs
+++ b/fighters/toonlink/src/boomerang/mod.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+mod acmd;
+
+pub fn install() {
+    let agent = &mut Agent::new("toonlink_boomerang");
+    acmd::install(agent);
+    agent.install();
+}

--- a/fighters/toonlink/src/lib.rs
+++ b/fighters/toonlink/src/lib.rs
@@ -7,6 +7,10 @@ pub mod acmd;
 pub mod opff;
 pub mod status;
 
+// articles
+
+mod boomerang;
+
 use smash::{
     lib::{
         L2CValue,
@@ -45,4 +49,6 @@ pub fn install() {
     opff::install(agent);
     status::install(agent);
     agent.install();
+
+    boomerang::install();
 }

--- a/fighters/younglink/src/boomerang/acmd.rs
+++ b/fighters/younglink/src/boomerang/acmd.rs
@@ -13,6 +13,26 @@ unsafe extern "C" fn game_fly(agent: &mut L2CAgentBase) {
     }
 }
 
+unsafe extern "C" fn effect_fly(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_FOLLOW(agent, Hash40::new("younglink_boomerang_t_hdr"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+        EFFECT_FOLLOW(agent, Hash40::new("younglink_boomerang"), Hash40::new("all"), 0, 0, 0, 0, 0, 0, 1, false);
+    }
+}
+
+unsafe extern "C" fn effect_haved(agent: &mut L2CAgentBase) {
+    let lua_state = agent.lua_state_agent;
+    let boma = agent.boma();
+    if is_excute(agent) {
+        EFFECT_OFF_KIND(agent, Hash40::new("younglink_boomerang_t_hdr"), false, false);
+        EFFECT_OFF_KIND(agent, Hash40::new("younglink_boomerang"), false, false);
+    }
+}
+
 pub fn install(agent: &mut Agent) {
     agent.acmd("game_fly", game_fly, Priority::Low);
+    agent.acmd("effect_fly", effect_fly, Priority::Low);
+    agent.acmd("effect_haved", effect_haved, Priority::Low);
 }


### PR DESCRIPTION
HDR Assets: [boomerang_effects_cleanup.zip](https://github.com/user-attachments/files/22972693/boomerang_effects_cleanup.zip)

PR adjusts the trail follow-up of Link, Toon Link, and Young Link's Boomerang to be less cluttered and easier to see where the boomerang is.

<video src=https://github.com/user-attachments/assets/f5d7b836-febe-4b5e-b46b-90e89a1bc01c></video>

Link
[$] Boomerang trail adjusted

Toon Link
[$] Boomerang trail adjusted
Old:
<img width="1920" height="1080" alt="HDR - yink boomerang_2025-10-06_14-59-52" src="https://github.com/user-attachments/assets/af9947eb-cd01-4496-8cb5-30c4947347e9" />
New:
<img width="1920" height="1080" alt="HDR - yink boomerang_2025-10-06_15-06-09" src="https://github.com/user-attachments/assets/dc2499a1-9c96-4dd7-8c3d-2aa794c8de81" />

Young Link
[$] Boomerang trail adjusted
Old:
<img width="1920" height="1080" alt="HDR - yink boomerang_2025-10-06_14-59-10" src="https://github.com/user-attachments/assets/6a52ae38-2023-4b2e-98b2-d0a75a895852" />
New:
<img width="1920" height="1080" alt="HDR - yink boomerang_2025-10-06_15-05-34" src="https://github.com/user-attachments/assets/76bc47e9-3a46-400f-8eda-a938939734e1" />

