### PR TITLE
Young Link Side Taunt Fix

### DIFF
--- a/fighters/younglink/src/acmd/other.rs
+++ b/fighters/younglink/src/acmd/other.rs
@@ -45,8 +45,11 @@ unsafe extern "C" fn game_appeallw(agent: &mut L2CAgentBase) {
     FT_MOTION_RATE(agent, 2.5);
     frame(lua_state, 61.0);
     if is_excute(agent) {
-        if DamageModule::damage(boma, 0) > 2.5 {
+        let damage = DamageModule::damage(boma, 0);
+        if damage >= 2.5 {
             DamageModule::add_damage(boma, -2.5, 0);
+        } else {
+            DamageModule::add_damage(boma, -damage, 0);
         }
     }
     frame(lua_state, 71.0);

--- a/fighters/younglink/src/acmd/other.rs
+++ b/fighters/younglink/src/acmd/other.rs
@@ -45,12 +45,7 @@ unsafe extern "C" fn game_appeallw(agent: &mut L2CAgentBase) {
     FT_MOTION_RATE(agent, 2.5);
     frame(lua_state, 61.0);
     if is_excute(agent) {
-        let damage = DamageModule::damage(boma, 0);
-        if damage >= 2.5 {
-            DamageModule::add_damage(boma, -2.5, 0);
-        } else {
-            DamageModule::add_damage(boma, -damage, 0);
-        }
+        DamageModule::heal(boma, -2.5, 0);
     }
     frame(lua_state, 71.0);
     FT_MOTION_RATE(agent, 1.0);


### PR DESCRIPTION
Fixes a critical game breaking oversight where Young Link's side taunt would not heal him if he was at or under 2.5%.

# Changelog

## Young Link

### Side Taunt
```diff
~ (*) Will now properly heal Young Link to 0% if he has less than or equal to 2.5% damage taken
```