### PR TITLE
Add dashback out of squat (aka dashback out of crouch (aka dbooc))

### DIFF
--- a/fighters/common/src/general_statuses/dash.rs
+++ b/fighters/common/src/general_statuses/dash.rs
@@ -485,8 +485,6 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
     }
 
     let is_dash_input: bool = fighter.global_table[CMD_CAT1].get_i32() & *FIGHTER_PAD_CMD_CAT1_FLAG_DASH != 0;
-    let is_backdash_input: bool = fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor) <= ParamModule::get_float(fighter.object(), ParamType::Common, "dashback_stick_x")
-                                && fighter.global_table[FLICK_X].get_i32() <= WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dash_flick_x"));
 
     if VarModule::is_flag(fighter.battle_object, vars::common::status::IS_AFTER_DASH_TO_RUN_FRAME)  // if after dash-to-run transition frame
     && WorkModule::get_param_float(fighter.module_accessor, hash40("common"), hash40("run_stick_x")) <= fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor)  // AND stick_x is >= run threshold
@@ -502,14 +500,22 @@ unsafe extern "C" fn status_dash_main_common(fighter: &mut L2CFighterCommon, arg
 
     // Disables dashbacks when stick falls below threshold
     // For ease of moonwalking
-    let moonwalk_disable_dashback_stick_y = ParamModule::get_float(fighter.battle_object, ParamType::Common, "moonwalk_disable_dashback_stick_y");
-    if fighter.global_table[STICK_Y].get_f32() <= moonwalk_disable_dashback_stick_y
-    && WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) {
-        WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
-    }
+    let stick_y_should_disable_dashback: bool = fighter.global_table[STICK_Y].get_f32() <= ParamModule::get_float(fighter.battle_object, ParamType::Common, "moonwalk_disable_dashback_stick_y");
+    let is_backdash_input: bool = fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor) <= ParamModule::get_float(fighter.object(), ParamType::Common, "dashback_stick_x")
+                                && fighter.global_table[FLICK_X].get_i32() <= WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dash_flick_x"));
 
-    if WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH)  // if backdash transition term is enabled (it is by default)
-    && is_backdash_input {  // AND is a backdash input
+    // Note: Previously the moonwalk helper disabled dashback entirely for
+    //       the rest of the dash. Changed only check whether or not it
+    //       should apply as needed - rei wolf 2025-12-07
+
+    if (
+        WorkModule::is_enable_transition_term(
+            fighter.module_accessor,
+            *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH // Turn dashes are allowed / enabled
+        )
+        && !stick_y_should_disable_dashback // AND the y stick is not implicating a moonwalk
+        && is_backdash_input // AND is a backdash input
+    ) {
         //println!("transition to backdash");
         let perfect_pivot_window = ParamModule::get_int(fighter.object(), ParamType::Common, "dash_perfect_pivot_window");
         if fighter.global_table[CURRENT_FRAME].get_i32() <= perfect_pivot_window {

--- a/fighters/common/src/general_statuses/squat.rs
+++ b/fighters/common/src/general_statuses/squat.rs
@@ -9,8 +9,79 @@ fn nro_hook(info: &skyline::nro::NroInfo) {
     if info.name == "common" {
         skyline::install_hooks!(
             fl_get_squat_walk_max_speed_hook,
+            fightercommon_status_squatwait_main,
+            fightercommon_status_squatrv_main,
         );
     }
+}
+
+// Note: Changes were made to the moonwalk check in status_dash_main_common at the same time as
+//       the dashback out of squat modifications made here as to allow dashback when coming out
+//       of crouch with a dash sometimes (depending on your y value when you started dash). It 
+//       was a thing previously actually for dash forward too but I only noticied it when
+//       looking into how to add dashback into HDR) - rei wolf 2025-12-07
+
+// This runs for both SquatWait and SquatRv. SquatRv actually naturally allows you to cancel it with
+// dashback, but the window for it is limited to the latter portion. This covers dashback both while
+// squatting and getting up from it while utilizing the same thresholds normal dashback checks that
+// are defined in dash.rs.
+pub unsafe fn dashback_in_squat_check(fighter: &mut L2CFighterCommon) -> bool {
+    // Stick positions
+    let stick_x: f32 = fighter.global_table[STICK_X].get_f32();
+    let stick_y: f32 = fighter.global_table[STICK_Y].get_f32();
+    let flick_x: i32 = fighter.global_table[FLICK_X].get_i32();
+    // Returns -1 or 1, to align the backdash check against the input
+    let left_right_modifier: f32 = PostureModule::lr(fighter.module_accessor);
+    // Parameters from common.xml
+    let dashback_x_threshold: f32 = ParamModule::get_float(fighter.object(), ParamType::Common, "dashback_stick_x");
+    let disable_y_threshold: f32 = ParamModule::get_float(fighter.object(), ParamType::Common, "squat_disable_dashback_crouch_threshold_stick_y");
+    let flick_x_threshold: i32 = WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dash_flick_x"));
+
+    // Perform checks on input conditions
+    let is_smash_back_input: bool = (stick_x * left_right_modifier <= dashback_x_threshold) && (flick_x <= flick_x_threshold);
+    let is_y_position_invalid: bool = stick_y <= disable_y_threshold;
+
+    let conditions: bool = is_smash_back_input && !is_y_position_invalid;
+
+    /*
+     * useful for debugging/testing
+     */
+
+    // println!("({}): stick_x: {}, stick_y: {}, flick_x: {}, left_right_modifier: {}, dashback_x_threshold: {}, disable_y_threshold: {}, flick_x_threshold: {}",
+    //     conditions,
+    //     stick_x,
+    //     stick_y,
+    //     flick_x,
+    //     left_right_modifier,
+    //     dashback_x_threshold,
+    //     disable_y_threshold,
+    //     flick_x_threshold,
+    // );
+    //
+    // println!("is_smash_back_input: .......... {} --> (stick_x * left_right_modifier <= dashback_x_threshold) && (flick_x <= flick_x_threshold)", is_smash_back_input);
+    // println!("is_y_position_invalid: ........ {} --> stick_y <= disable_y_threshold", is_y_position_invalid);
+
+    conditions
+}
+
+// Skyline hooks
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_SquatRv_Main)]
+pub unsafe fn fightercommon_status_squatrv_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if (dashback_in_squat_check(fighter)) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_SMASH_TURN);
+        interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
+    }
+    call_original!(fighter)
+}
+
+#[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_status_SquatWait_Main)]
+pub unsafe fn fightercommon_status_squatwait_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if (dashback_in_squat_check(fighter)) {
+        VarModule::on_flag(fighter.battle_object, vars::common::instance::IS_SMASH_TURN);
+        interrupt!(fighter, FIGHTER_STATUS_KIND_TURN, true);
+    }
+    call_original!(fighter)
 }
 
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_FL_get_squat_walk_max_speed)]

--- a/romfs/source/fighter/common/hdr/param/common.xml
+++ b/romfs/source/fighter/common/hdr/param/common.xml
@@ -32,6 +32,7 @@
     </struct>
     <float hash="pass_stick_x">0.3</float>
     <float hash="moonwalk_disable_dashback_stick_y">-0.5</float>
+    <float hash="squat_disable_dashback_crouch_threshold_stick_y">-0.6</float> <!-- standard threshold from game for squat -->
     <float hash="wavedash_speed_mul">0.8945</float>
     <float hash="dashback_stick_x">-0.5673</float>
     <float hash="dash_end_speed_mul">0.225</float>

--- a/src/chara_select/random.rs
+++ b/src/chara_select/random.rs
@@ -74,7 +74,7 @@ unsafe fn decide_random(ctx: &mut skyline::hooks::InlineCtx) {
 
 unsafe fn generate_random(player_id: usize, main_data: u64, sub_data: u64) {
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let mut rng_seed = StdRng::seed_from_u64((now.as_millis() as u64 + 1) * rand::thread_rng().gen::<u64>());
+    let mut rng_seed = StdRng::seed_from_u64((now.as_millis() as u64 + 1).overflowing_mul(rand::thread_rng().gen::<u64>()).0);
     let mut chara_string = decide_fighter_from_id(player_id, &mut rng_seed);
     let mut chara_hash = hash40(&format!("ui_chara_{}", chara_string)).0;
 


### PR DESCRIPTION
# Dashback Out of Squat

https://github.com/user-attachments/assets/d7e05a7b-db74-4771-9a9a-5fd65dc3a85f

## Preface
This is a first attempt at making changes to HDR so feedback, opinions, ideas, and questions would be appreciated. I can not confidently say that this code is steadfast and will be testing it over the coming days and others testing it would be appreciated. Obvious blunders or mistakes being made apparent would help as well. Getting acquainted with a new codebase and way-of-working is always a process.

## Primary Changes
Added two new functions to the install list of `squat.rs`:
- `fightercommon_status_squatwait_main`
- `fightercommon_status_squatrv_main`

Created a dashback out of squat checking function, `dashback_in_squat_check`, that runs during SquatWait (resting in squat) and SquatRV (standing up from squat), both of which are run each frame during the animation. The logic is mostly based on the backdash logic already present in `dash.rs`, although I separated things out a bit for readability since I have a bit of trouble following rust sometimes. 

Added a new param to `common.xml`:
```xml
    <float hash="squat_disable_dashback_crouch_threshold_stick_y">-0.6</float> <!-- standard threshold from game for squat -->
```
This is referenced in `squat.rs` to know whether or not to allow cancelling crouch with dashback. I do not know where I would find this threshold to reference it in-game however. As that would be preferred, do let me know where to find this if you yourself know where.

## Secondary Changes
Previously, the moonwalk helper code disabled dashback for the entirety of the dash if your stick's Y coordinate was below `-0.5` at _any_ point during the dash. This meant that dash forward out of crouch (which already existed) was sometimes entirely locked out of being able to dash back after starting the dash if your stick's y position happened to be below the threshold when starting dash while you were making the quarter-circle motion upwards.

https://github.com/user-attachments/assets/96806c3b-6687-4d92-89de-e619c5a4ce61

```rust
// Disables dashbacks when stick falls below threshold
// For ease of moonwalking
let moonwalk_disable_dashback_stick_y = ParamModule::get_float(fighter.battle_object, ParamType::Common, "moonwalk_disable_dashback_stick_y");
if fighter.global_table[STICK_Y].get_f32() <= moonwalk_disable_dashback_stick_y
&& WorkModule::is_enable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH) {
    WorkModule::unable_transition_term(fighter.module_accessor, *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH);
}
```

The core logic after the change disregards the concept of unabling `FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH` for the entirety of dash to begin with, rather moving the threshold check of the _current frame_ in time to the comparison later on that checks to see if a backdash input has been made.

```rust
    let stick_y_should_disable_dashback: bool = fighter.global_table[STICK_Y].get_f32() <= ParamModule::get_float(fighter.battle_object, ParamType::Common, "moonwalk_disable_dashback_stick_y");
    let is_backdash_input: bool = fighter.global_table[STICK_X].get_f32() * PostureModule::lr(fighter.module_accessor) <= ParamModule::get_float(fighter.object(), ParamType::Common, "dashback_stick_x")
                                && fighter.global_table[FLICK_X].get_i32() <= WorkModule::get_param_int(fighter.module_accessor, hash40("common"), hash40("dash_flick_x"));

    // Note: Previously the moonwalk helper disabled dashback entirely for
    //       the rest of the dash. Changed only check whether or not it
    //       should apply as needed - rei wolf 2025-12-07

    if (
        WorkModule::is_enable_transition_term(
            fighter.module_accessor,
            *FIGHTER_STATUS_TRANSITION_TERM_ID_CONT_TURN_DASH // Turn dashes are allowed / enabled
        )
        && !stick_y_should_disable_dashback // AND the y stick is not implicating a moonwalk
        && is_backdash_input // AND is a backdash input
    ) {
        // do backdash stuff
        // ...
```

## Tertiary Changes
Minor bugfix regarding a runtime Rust panic that I encountered due to two u64s being multiplied and triggering an unhandled overflow. I changed the line that panicked to use [u64::overflowing_mul](https://doc.rust-lang.org/std/primitive.u64.html#method.overflowing_mul) instead to avoid this happening in the future.

```Rust
let mut rng_seed = StdRng::seed_from_u64((now.as_millis() as u64 + 1).overflowing_mul(rand::thread_rng().gen::<u64>()).0);
```