### PR TITLE
Positive Pika PR (alliteration makes him happy)

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1425,6 +1425,7 @@ pub mod vars {
 
             // flags
             pub const ATTACK_AIR_LANDING_HIT: i32 = 0x0100;
+            pub const DISABLE_SPECIAL_S: i32 = 0x0101;
         }
         pub mod status {
             // ints

--- a/fighters/pikachu/src/acmd/aerials.rs
+++ b/fighters/pikachu/src/acmd/aerials.rs
@@ -215,6 +215,7 @@ unsafe extern "C" fn game_attackairhi(agent: &mut L2CAgentBase) {
     FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 11.0);
     FT_MOTION_RATE_RANGE(agent, 11.0, 27.0, 20.0);
+    frame(lua_state, 11.5);
     if is_excute(agent) {
         AttackModule::clear_all(boma);
     }

--- a/fighters/pikachu/src/acmd/aerials.rs
+++ b/fighters/pikachu/src/acmd/aerials.rs
@@ -198,8 +198,8 @@ unsafe extern "C" fn game_attackairhi(agent: &mut L2CAgentBase) {
     frame(lua_state, 4.0);
     FT_MOTION_RATE_RANGE(agent, 4.0, 10.0, 4.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("tail2"), 4.0, 80, 60, 0, 100, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-        ATTACK(agent, 1, 0, Hash40::new("tail4"), 4.0, 80, 60, 0, 100, 5.0, 0.0, 0.0, 2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+        ATTACK(agent, 0, 0, Hash40::new("tail2"), 4.0, 80, 60, 0, 90, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+        ATTACK(agent, 1, 0, Hash40::new("tail4"), 4.0, 80, 60, 0, 90, 5.0, 0.0, 0.0, 2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_B, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
     }
     frame(lua_state, 5.0);
     if is_excute(agent) {

--- a/fighters/pikachu/src/acmd/aerials.rs
+++ b/fighters/pikachu/src/acmd/aerials.rs
@@ -198,8 +198,8 @@ unsafe extern "C" fn game_attackairhi(agent: &mut L2CAgentBase) {
     frame(lua_state, 4.0);
     FT_MOTION_RATE_RANGE(agent, 4.0, 10.0, 4.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("tail2"), 5.0, 100, 60, 0, 90, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
-        ATTACK(agent, 1, 0, Hash40::new("tail4"), 5.0, 100, 60, 0, 90, 5.0, 0.0, 0.0, 2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+        ATTACK(agent, 0, 0, Hash40::new("tail2"), 4.0, 80, 60, 0, 100, 3.0, 0.0, 0.0, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
+        ATTACK(agent, 1, 0, Hash40::new("tail4"), 4.0, 80, 60, 0, 100, 5.0, 0.0, 0.0, 2.5, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_S, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_TAIL);
     }
     frame(lua_state, 5.0);
     if is_excute(agent) {

--- a/fighters/pikachu/src/acmd/mod.rs
+++ b/fighters/pikachu/src/acmd/mod.rs
@@ -8,7 +8,32 @@ mod specials;
 mod throws;
 mod other;
 
+// Prevents sideB from being used again if it has already been used once in the current airtime
+unsafe extern "C" fn should_use_special_s_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_AIR) && VarModule::is_flag(fighter.battle_object, vars::pikachu::instance::DISABLE_SPECIAL_S) {
+        false.into()
+    } else {
+        true.into()
+    }
+}
+
+// Re-enables the ability to use sideB when connecting to ground or cliff
+unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.is_situation(*SITUATION_KIND_GROUND) || fighter.is_situation(*SITUATION_KIND_CLIFF)
+    || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING, *FIGHTER_STATUS_KIND_GIMMICK_SPRING_JUMP]) {
+        VarModule::off_flag(fighter.battle_object, vars::pikachu::instance::DISABLE_SPECIAL_S);
+    }
+    true.into()
+}
+
+unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
+    fighter.global_table[globals::USE_SPECIAL_S_CALLBACK].assign(&L2CValue::Ptr(should_use_special_s_callback as *const () as _));
+    fighter.global_table[globals::STATUS_CHANGE_CALLBACK].assign(&L2CValue::Ptr(change_status_callback as *const () as _));   
+}
+
 pub fn install(agent: &mut Agent) {
+    agent.on_start(on_start);
+    
     ground::install(agent);
     tilts::install(agent);
     smashes::install(agent);

--- a/fighters/pikachu/src/acmd/specials.rs
+++ b/fighters/pikachu/src/acmd/specials.rs
@@ -20,6 +20,10 @@ unsafe extern "C" fn game_specials(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         AttackModule::set_size(boma, 0, 3.0);
     }
+    frame(lua_state, 23.0);
+    if is_excute(agent) {
+        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP);
+    }
     wait(lua_state, 27.0);
     if is_excute(agent) {
         WorkModule::on_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_BRAKE_TRIGGER);

--- a/fighters/pikachu/src/acmd/specials.rs
+++ b/fighters/pikachu/src/acmd/specials.rs
@@ -5,24 +5,33 @@ unsafe extern "C" fn game_specials(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     if is_excute(agent) {
+        VarModule::on_flag(agent.battle_object, vars::pikachu::instance::DISABLE_SPECIAL_S);
         boma.select_cliff_hangdata_from_name("special_s");
         notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_NONE);
     }
     frame(lua_state, 5.0);
     if is_excute(agent) {
+        let min_power = WorkModule::get_param_float(boma, hash40("param_special_s"), hash40("special_s_power_min_"));
+        let max_power = WorkModule::get_param_float(boma, hash40("param_special_s"), hash40("special_s_power_tame_"));
+        let max_charge = WorkModule::get_param_float(boma, hash40("param_special_s"), hash40("special_s_tame_time_"));
+
+        let mut charge_frames = WorkModule::get_int(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_INT_SKULL_BASH_HOLD_COUNT).to_f32();
+        if charge_frames == 20.0 {
+            charge_frames = 8.0;
+        }
+        let range = max_power - min_power;
+        let power_per_frame = range / max_charge;
+        let real_power = min_power + (power_per_frame * charge_frames);
+
         JostleModule::set_status(boma, false);
         WorkModule::on_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_ATTACK_TRIGGER);
-        ATTACK(agent, 0, 0, Hash40::new("rot"), 1.0, 361, 78, 0, 40, 3.0, 0.0, -0.7, 2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HEAD);
+        ATTACK(agent, 0, 0, Hash40::new("rot"), real_power, 361, 78, 0, 40, 3.0, 0.0, -0.7, 2.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_NO_FLOOR, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_HEAD);
         WorkModule::on_flag(boma, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_CALC_ATTACK_POWER);
         AttackModule::set_attack_keep_rumble(boma, 0, true);
     }
     frame(lua_state, 13.0);
     if is_excute(agent) {
         AttackModule::set_size(boma, 0, 3.0);
-    }
-    frame(lua_state, 23.0);
-    if is_excute(agent) {
-        notify_event_msc_cmd!(agent, Hash40::new_raw(0x2127e37c07), *GROUND_CLIFF_CHECK_KIND_ON_DROP);
     }
     wait(lua_state, 27.0);
     if is_excute(agent) {

--- a/fighters/pikachu/src/opff.rs
+++ b/fighters/pikachu/src/opff.rs
@@ -27,19 +27,9 @@ unsafe fn skull_bash_edge_cancel(fighter: &mut L2CFighterCommon) {
     }
 }
 
-unsafe fn up_b_edge_cancel(fighter: &mut L2CFighterCommon) {
-    if fighter.is_status(*FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END) {
-        if fighter.global_table[PREV_SITUATION_KIND] == SITUATION_KIND_GROUND
-        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
-            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
-        }
-    }
-}
-
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     fastfall_specials(fighter);
     skull_bash_edge_cancel(fighter);
-    up_b_edge_cancel(fighter);
 }
 
 pub extern "C" fn pikachu_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {

--- a/fighters/pikachu/src/opff.rs
+++ b/fighters/pikachu/src/opff.rs
@@ -27,9 +27,19 @@ unsafe fn skull_bash_edge_cancel(fighter: &mut L2CFighterCommon) {
     }
 }
 
+unsafe fn up_b_edge_cancel(fighter: &mut L2CFighterCommon) {
+    if fighter.is_status(*FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_HI_END) {
+        if fighter.global_table[PREV_SITUATION_KIND] == SITUATION_KIND_GROUND
+        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+        }
+    }
+}
+
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
     fastfall_specials(fighter);
     skull_bash_edge_cancel(fighter);
+    up_b_edge_cancel(fighter);
 }
 
 pub extern "C" fn pikachu_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {

--- a/fighters/pikachu/src/status/mod.rs
+++ b/fighters/pikachu/src/status/mod.rs
@@ -2,7 +2,9 @@ use super::*;
 use globals::*;
 // status script import
 mod special_hi;
+mod special_s;
 
 pub fn install(agent: &mut Agent) {
     special_hi::install(agent);
+    special_s::install(agent);
 }

--- a/fighters/pikachu/src/status/special_hi.rs
+++ b/fighters/pikachu/src/status/special_hi.rs
@@ -80,7 +80,7 @@ unsafe extern "C" fn special_hi_end_main_loop(fighter: &mut L2CFighterCommon) ->
             CancelModule::enable_cancel(fighter.module_accessor);
             // disable gravity and place pikachu in the air
             KineticModule::clear_speed_energy_id(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            PostureModule::add_pos(fighter.module_accessor, &Vector3f::new(0.0, 1.5, 0.0));
+            PostureModule::add_pos(fighter.module_accessor, &Vector3f::new(0.0, 3.5, 0.0));
             StatusModule::set_situation_kind(fighter.module_accessor, smash::app::SituationKind(*SITUATION_KIND_AIR), false);
             fighter.global_table[PREV_SITUATION_KIND].assign(&L2CValue::I32(situation_kind));
             fighter.global_table[SITUATION_KIND].assign(&L2CValue::I32(*SITUATION_KIND_AIR));

--- a/fighters/pikachu/src/status/special_hi.rs
+++ b/fighters/pikachu/src/status/special_hi.rs
@@ -45,6 +45,11 @@ unsafe extern "C" fn special_hi_end_main_loop(fighter: &mut L2CFighterCommon) ->
         return true.into();
     }
 
+    if fighter.global_table[PREV_SITUATION_KIND] == SITUATION_KIND_GROUND
+        && fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+            fighter.change_status_req(*FIGHTER_STATUS_KIND_FALL, false);
+    }
+
     if CancelModule::is_enable_cancel(fighter.module_accessor) {
         if VarModule::is_flag(fighter.battle_object, vars::pikachu::status::SPECIAL_HI_QUICK_ATTACK_CANCEL)
         && fighter.is_cat_flag(Cat1::AirEscape) {
@@ -80,7 +85,7 @@ unsafe extern "C" fn special_hi_end_main_loop(fighter: &mut L2CFighterCommon) ->
             CancelModule::enable_cancel(fighter.module_accessor);
             // disable gravity and place pikachu in the air
             KineticModule::clear_speed_energy_id(fighter.module_accessor, *FIGHTER_KINETIC_ENERGY_ID_GRAVITY);
-            PostureModule::add_pos(fighter.module_accessor, &Vector3f::new(0.0, 3.5, 0.0));
+            PostureModule::add_pos(fighter.module_accessor, &Vector3f::new(0.0, 2.5, 0.0));
             StatusModule::set_situation_kind(fighter.module_accessor, smash::app::SituationKind(*SITUATION_KIND_AIR), false);
             fighter.global_table[PREV_SITUATION_KIND].assign(&L2CValue::I32(situation_kind));
             fighter.global_table[SITUATION_KIND].assign(&L2CValue::I32(*SITUATION_KIND_AIR));

--- a/fighters/pikachu/src/status/special_s.rs
+++ b/fighters/pikachu/src/status/special_s.rs
@@ -1,0 +1,105 @@
+use super::*;
+use globals::*;
+// status script import
+
+unsafe extern "C" fn special_s_hold_init(fighter: &mut L2CFighterCommon) -> L2CValue {
+    WorkModule::set_int(fighter.module_accessor, 0, *FIGHTER_PIKACHU_STATUS_WORK_ID_INT_SKULL_BASH_HOLD_COUNT);
+
+    return smashline::original_status(Init, fighter, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_HOLD)(fighter);
+}
+
+unsafe extern "C" fn special_s_attack(fighter: &mut L2CFighterCommon) -> L2CValue {
+
+    if fighter.is_situation(*SITUATION_KIND_AIR) {
+        VarModule::on_flag(fighter.battle_object, vars::pikachu::instance::DISABLE_SPECIAL_S);
+    }
+
+    WorkModule::off_flag(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_HIT);
+
+    GroundModule::correct(fighter.module_accessor, GroundCorrectKind(*GROUND_CORRECT_KIND_AIR));
+    StatusModule::set_situation_kind(fighter.module_accessor, app::SituationKind(*SITUATION_KIND_AIR), false);
+
+    MotionModule::change_motion(fighter.module_accessor, Hash40::new("special_s"), 0.0, 1.0, false, 0.0, false, false);
+    GroundModule::select_cliff_hangdata(fighter.module_accessor, *FIGHTER_PICHU_CLIFF_HANG_DATA_SPECIAL_S as u32);
+
+    fighter.sub_shift_status_main(L2CValue::Ptr(special_s_attack_main_loop as *const () as _))
+
+    //return smashline::original_status(Main, fighter, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_ATTACK)(fighter);
+}
+
+unsafe extern "C" fn special_s_attack_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    if fighter.sub_transition_group_check_air_cliff().get_bool() {
+        return true.into();
+    }
+
+    if !WorkModule::is_flag(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_ATTACK_POWER_MODIFY) {
+        /*let min_power = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("special_s_power_min_"));
+        let max_power = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("special_s_power_tame_"));
+        let max_charge = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_s"), hash40("special_s_tame_time_"));
+
+        let charge_frames = WorkModule::get_int(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_INT_SKULL_BASH_HOLD_COUNT);
+        let range = max_power - min_power;
+        let power_per_frame = range / max_charge;
+        let real_power = min_power + (power_per_frame * charge_frames.to_f32());
+        AttackModule::set_power(fighter.module_accessor, 0, real_power, false);*/
+
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_ATTACK_POWER_MODIFY);
+    }
+
+    let mut touch_wall = false;
+    let bounce = Vector3f::new(2.5, 1.2, 0.0);
+    let gravity = WorkModule::get_param_float(fighter.module_accessor, hash40("param_special_lw"), hash40("special_lw_air_yaccel_"));
+    if PostureModule::lr(fighter.module_accessor) > 0.0 {
+        touch_wall = GroundModule::is_wall_touch_line(fighter.module_accessor, *GROUND_TOUCH_FLAG_RIGHT as u32);
+    } else {
+        touch_wall = GroundModule::is_wall_touch_line(fighter.module_accessor, *GROUND_TOUCH_FLAG_LEFT as u32);
+    }
+
+    if touch_wall {
+        /*KineticModule::clear_speed_all(fighter.module_accessor);
+        sv_kinetic_energy!(set_speed, fighter, FIGHTER_KINETIC_ENERGY_ID_GRAVITY, gravity);
+        KineticModule::add_speed(fighter.module_accessor, &bounce);*/
+
+        WorkModule::on_flag(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_HIT);
+        
+        EFFECT_FOLLOW(fighter, Hash40::new("sys_spin_wind"), Hash40::new("head"), 0, 0, 0, 0, 0, 0, 0.8, true);
+        LAST_EFFECT_SET_RATE(fighter, 5.0);
+        EffectModule::set_scale_last(fighter.module_accessor, &Vector3f::new(1.75, 1.75, 1.0));
+
+        SoundModule::play_se(fighter.module_accessor, Hash40::new("se_common_down_m_01"), true, false, false, false, enSEType(0));
+        fighter.change_status(FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_END.into(), false.into());
+    }
+
+    if MotionModule::is_end(fighter.module_accessor) {
+        fighter.change_status(FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_END.into(), false.into());
+    }
+
+    let x_speed = KineticModule::get_sum_speed_x(fighter.module_accessor, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+    let direction = PostureModule::lr(fighter.module_accessor);
+    let mut stop = false;
+    
+    if (direction > 0.0) {
+        if x_speed < 0.0 {
+            stop = true;
+        }
+    } else {
+        if x_speed > 0.0 {
+            stop = true;
+        }
+    }
+
+    if (stop == true) {
+        lua_args!(fighter, FIGHTER_KINETIC_ENERGY_ID_STOP, 0.0, 0.0);
+        app::sv_kinetic_energy::set_speed(fighter.lua_state_agent);
+
+        lua_args!(fighter,FIGHTER_KINETIC_ENERGY_ID_STOP, 0.0, 0.0);
+        app::sv_kinetic_energy::set_accel(fighter.lua_state_agent);
+    }
+
+    return false.into();
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Init, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_HOLD, special_s_hold_init);
+    agent.status(Main, *FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_ATTACK, special_s_attack);
+}

--- a/fighters/pikachu/src/status/special_s.rs
+++ b/fighters/pikachu/src/status/special_s.rs
@@ -62,9 +62,8 @@ unsafe extern "C" fn special_s_attack_main_loop(fighter: &mut L2CFighterCommon) 
 
         WorkModule::on_flag(fighter.module_accessor, *FIGHTER_PIKACHU_STATUS_WORK_ID_FLAG_SKULL_BASH_HIT);
         
-        EFFECT_FOLLOW(fighter, Hash40::new("sys_spin_wind"), Hash40::new("head"), 0, 0, 0, 0, 0, 0, 0.8, true);
-        LAST_EFFECT_SET_RATE(fighter, 5.0);
-        EffectModule::set_scale_last(fighter.module_accessor, &Vector3f::new(1.75, 1.75, 1.0));
+        EFFECT(fighter, Hash40::new("sys_crown"), Hash40::new("top"), 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, false);
+        EffectModule::set_scale_last(fighter.module_accessor, &Vector3f::new(1.25, 1.25, 1.0));
 
         SoundModule::play_se(fighter.module_accessor, Hash40::new("se_common_down_m_01"), true, false, false, false, enSEType(0));
         fighter.change_status(FIGHTER_PIKACHU_STATUS_KIND_SPECIAL_S_END.into(), false.into());

--- a/romfs/source/fighter/pikachu/param/vl.prcxml
+++ b/romfs/source/fighter/pikachu/param/vl.prcxml
@@ -34,4 +34,20 @@
     <hash40 index="2">dummy</hash40>
     <hash40 index="3">dummy</hash40>
   </list>
+  <list hash="param_special_lw">
+    <struct index="0">
+      <float hash="special_lw_offset_y_">17.0</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
+  <list hash="param_kaminari">
+    <struct index="0">
+      <float hash="speed_">-6.48</float>
+    </struct>
+    <hash40 index="1">dummy</hash40>
+    <hash40 index="2">dummy</hash40>
+    <hash40 index="3">dummy</hash40>
+  </list>
 </struct>

--- a/romfs/source/fighter/pikachu/param/vl.prcxml
+++ b/romfs/source/fighter/pikachu/param/vl.prcxml
@@ -17,6 +17,8 @@
   <list hash="param_special_s">
     <struct index="0">
       <float hash="special_s_tame_time_">60</float>
+      <float hash="special_s_power_min_">4.0</float>
+      <float hash="special_s_power_tame_">29.0</float>
       <float hash="special_s_move_spd_x_">1.4</float>
       <float hash="special_s_tame_spd_x_">2.25</float>
     </struct>


### PR DESCRIPTION
https://github.com/user-attachments/assets/e15ba040-bdb4-40a3-9382-408e55ba1956

### Skull Bash (Side Special)
```diff 
! (!) Move will now bounce off of walls
! (!) Move now is only usable once per airtime. 
- (-) Minimum Damage: 6.2 > 4
+ (+) Maximum Damage: 21.4 > 29

# Currently, Sideb can only grab ledge after the move ends, which takes much longer than similar 
# horizontally-moving moves in the air. To fix this, a 'bonk' effect was added, which allows you to end 
# the move early upon hitting a wall, making it much better for recovery. To compensate for this, the move
# is now only usable once per airtime. The damage range was also changed to match melee, because
# it being his optimal rest punish is objectively what we (collectively) want as a society.
```

### Thunder (Down Special)
```diff 
+ (+) Thunder Height: 10.5 > 17
+ (+) Thunder Speed: -4 > -6.48

# Thunder height is increased to allow better killing potential off the top due to the thundercloud change 
# last patch. This should allow him to secure stocks without needing platforms to get the height required, 
# which is too slow in most cases. The speed increase is proportional to ensure that it reaches Pikachu at the
# same time it used to at the old height.
```

### Quick Attack (Up Special)
```diff 
! (!) Edge cancelling added
+ (+) Height on Quick Attack Cancel: 1.5 > 2.5

# There was a change in Smash 4 to remove ledge cancelling from this attack, it has been restored. The 
# additional height is meant to make doing aerials out of QAC more consistent, while not changing the 
# intended interactions from the developers noted in the last PR (namely, the ability to choose between
# weak/strong hit of nair based on fastfalling, being able to waveland, and fair/bair not having time to come out).
```

### Up Air
```diff 
+ (+) Activity: 4-8 > 4-9
- (-) Damage: 5.0 > 4.0
~ (/) Angle: 100 > 80

# These changes are only to the first (initial) hitbox of Uair, the other 2 later hitboxes are unchanged. 
# This is intended to give stronger followups on most of the cast at lower %s, but will be worse against 
# fastfallers as they will land before Pikachu.
```