### PR TITLE
F1 Grab Tech

### DIFF
--- a/fighters/bayonetta/src/acmd/throws.rs
+++ b/fighters/bayonetta/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/brave/src/acmd/throws.rs
+++ b/fighters/brave/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/buddy/src/acmd/throws.rs
+++ b/fighters/buddy/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/captain/src/acmd/throws.rs
+++ b/fighters/captain/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/chrom/src/acmd/throws.rs
+++ b/fighters/chrom/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/cloud/src/acmd/throws.rs
+++ b/fighters/cloud/src/acmd/throws.rs
@@ -5,12 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.5);
-    frame(lua_state, 3.0);
-    FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 8.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 3.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 9.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 3.8, 0.0, 7.1, 0.0, Some(0.0), Some(7.1), Some(8.1), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/daisy/src/acmd/throws.rs
+++ b/fighters/daisy/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/dedede/src/acmd/throws.rs
+++ b/fighters/dedede/src/acmd/throws.rs
@@ -5,11 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 5.0/(7.0-1.0));
-    frame(lua_state, 7.0);
-    FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 7.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 8.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 5.5, 0.0, 7.0, 0.0, Some(0.0), Some(7.0), Some(10.5), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/demon/src/acmd/throws.rs
+++ b/fighters/demon/src/acmd/throws.rs
@@ -4,7 +4,7 @@ use smash2;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/diddy/src/acmd/throws.rs
+++ b/fighters/diddy/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/dolly/src/acmd/throws.rs
+++ b/fighters/dolly/src/acmd/throws.rs
@@ -5,11 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 5.0, 6.0);
-    frame(lua_state, 5.0);
-    FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 6.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.0, 0.0, 8.0, 4.0, Some(0.0), Some(8.0), Some(9.5), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/donkey/src/acmd/throws.rs
+++ b/fighters/donkey/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/duckhunt/src/acmd/throws.rs
+++ b/fighters/duckhunt/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 5.0/(5.0-1.0));
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/edge/src/acmd/throws.rs
+++ b/fighters/edge/src/acmd/throws.rs
@@ -5,11 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 6.0);
-    frame(lua_state, 6.0);
-    FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 6.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 7.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.2, 0.0, 8.5, 4.7, Some(0.0), Some(8.5), Some(9.2), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/eflame/src/acmd/throws.rs
+++ b/fighters/eflame/src/acmd/throws.rs
@@ -5,12 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 2.0);
-    frame(lua_state, 2.0);
-    FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 2.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 7.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 3.8, 0.0, 8.5, 4.0, Some(0.0), Some(8.5), Some(8.4), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/elight/src/acmd/throws.rs
+++ b/fighters/elight/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 5.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/falco/src/acmd/throws.rs
+++ b/fighters/falco/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/fox/src/acmd/throws.rs
+++ b/fighters/fox/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/gamewatch/src/acmd/throws.rs
+++ b/fighters/gamewatch/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/ganon/src/acmd/throws.rs
+++ b/fighters/ganon/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/gekkouga/src/acmd/throws.rs
+++ b/fighters/gekkouga/src/acmd/throws.rs
@@ -5,12 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.5);
-    frame(lua_state, 3.0);
-    FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 9.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 3.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 10.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 3.6, 0.0, 6.0, 0.0, Some(0.0), Some(6.0), Some(17.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/iceclimber/src/acmd/throws.rs
+++ b/fighters/iceclimber/src/acmd/throws.rs
@@ -5,11 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
-    FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 6.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 3.75, 0.0, 5.75, 3.5, Some(0.0), Some(5.75), Some(6.75), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/ike/src/acmd/throws.rs
+++ b/fighters/ike/src/acmd/throws.rs
@@ -5,11 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 5.0/(7.0-1.0));
-    frame(lua_state, 7.0);
-    FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 7.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 8.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.1, 0.0, 8.0, 0.0, Some(0.0), Some(8.0), Some(11.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/inkling/src/acmd/throws.rs
+++ b/fighters/inkling/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/jack/src/acmd/throws.rs
+++ b/fighters/jack/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/kamui/src/acmd/throws.rs
+++ b/fighters/kamui/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/ken/src/acmd/throws.rs
+++ b/fighters/ken/src/acmd/throws.rs
@@ -21,7 +21,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/kirby/src/acmd/throws.rs
+++ b/fighters/kirby/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/koopa/src/acmd/throws.rs
+++ b/fighters/koopa/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/koopajr/src/acmd/throws.rs
+++ b/fighters/koopajr/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
 	FT_MOTION_RATE_RANGE(agent, 1.0, 13.0, 7.0);
-    frame(lua_state, 12.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/krool/src/acmd/throws.rs
+++ b/fighters/krool/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/link/src/acmd/throws.rs
+++ b/fighters/link/src/acmd/throws.rs
@@ -4,10 +4,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     frame(lua_state, 1.0);
-    if is_excute(agent) {
-        FT_MOTION_RATE(agent, 1.2);
-    }
-    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.2);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/littlemac/src/acmd/throws.rs
+++ b/fighters/littlemac/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.667);
-    frame(lua_state, 8.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/lucario/src/acmd/throws.rs
+++ b/fighters/lucario/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/lucina/src/acmd/throws.rs
+++ b/fighters/lucina/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/luigi/src/acmd/throws.rs
+++ b/fighters/luigi/src/acmd/throws.rs
@@ -5,6 +5,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     FT_MOTION_RATE_RANGE(agent, 1.0, 13.0, 5.0);
     if is_excute(agent) {
+        GrabModule::set_rebound(boma, true);
         if ArticleModule::is_exist(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_OBAKYUMU) {
             ArticleModule::remove_exist(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_OBAKYUMU, app::ArticleOperationTarget(*ARTICLE_OPE_TARGET_ALL));
         }
@@ -22,7 +23,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {
         ArticleModule::set_rate(boma, *FIGHTER_LUIGI_GENERATE_ARTICLE_OBAKYUMU, 1.0);
-        GrabModule::set_rebound(boma, true);
         SEARCH(agent, 0, 0, Hash40::new("throw"), 3.0, 0.0, 0.0, -1.5, None, None, None, *COLLISION_KIND_MASK_HIT, *HIT_STATUS_MASK_NORMAL, 1, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_FIGHTER, *COLLISION_PART_MASK_BODY_HEAD, false);
     }
     frame(lua_state, 14.0);

--- a/fighters/mario/src/acmd/throws.rs
+++ b/fighters/mario/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/mariod/src/acmd/throws.rs
+++ b/fighters/mariod/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/marth/src/acmd/throws.rs
+++ b/fighters/marth/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/master/src/acmd/throws.rs
+++ b/fighters/master/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/metaknight/src/acmd/throws.rs
+++ b/fighters/metaknight/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/mewtwo/src/acmd/throws.rs
+++ b/fighters/mewtwo/src/acmd/throws.rs
@@ -3,11 +3,12 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
-    FT_MOTION_RATE_RANGE(agent, 6.0, 8.0, 1.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 6.0);
+    FT_MOTION_RATE_RANGE(agent, 6.0, 8.0, 1.0);
     frame(lua_state, 8.0);
     FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {

--- a/fighters/miifighter/src/acmd/throws.rs
+++ b/fighters/miifighter/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/miigunner/src/acmd/throws.rs
+++ b/fighters/miigunner/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
 	frame(lua_state, 1.0);
 	FT_MOTION_RATE(agent, 1.2);
-	frame(lua_state, 5.0);
 	if is_excute(agent) {
 		GrabModule::set_rebound(boma, true);
 	}

--- a/fighters/miiswordsman/src/acmd/throws.rs
+++ b/fighters/miiswordsman/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/ness/src/acmd/throws.rs
+++ b/fighters/ness/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/packun/src/acmd/throws.rs
+++ b/fighters/packun/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/palutena/src/acmd/throws.rs
+++ b/fighters/palutena/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/peach/src/acmd/throws.rs
+++ b/fighters/peach/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/pichu/src/acmd/throws.rs
+++ b/fighters/pichu/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/pikachu/src/acmd/throws.rs
+++ b/fighters/pikachu/src/acmd/throws.rs
@@ -7,7 +7,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 4.5, 3.5);
     }
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/pit/src/acmd/throws.rs
+++ b/fighters/pit/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/pitb/src/acmd/throws.rs
+++ b/fighters/pitb/src/acmd/throws.rs
@@ -4,10 +4,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     frame(lua_state, 1.0);
-    if is_excute(agent) {
-        FT_MOTION_RATE(agent, 1.200);
-    }
-    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.2);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/plizardon/src/acmd/throws.rs
+++ b/fighters/plizardon/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/purin/src/acmd/throws.rs
+++ b/fighters/purin/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/pzenigame/src/acmd/throws.rs
+++ b/fighters/pzenigame/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/reflet/src/acmd/throws.rs
+++ b/fighters/reflet/src/acmd/throws.rs
@@ -5,12 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 2.0);
-    frame(lua_state, 2.0);
-    FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 6.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 2.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 7.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.0, 0.0, 8.0, 0.0, Some(0.0), Some(8.0), Some(9.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/richter/src/acmd/throws.rs
+++ b/fighters/richter/src/acmd/throws.rs
@@ -6,12 +6,10 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.7);
     if is_excute(agent) {
+        GrabModule::set_rebound(boma, true);
         FighterAreaModuleImpl::enable_fix_jostle_area(boma, 4.0, 6.0);
     }
     frame(lua_state, 9.0);
-    if is_excute(agent) {
-        GrabModule::set_rebound(boma, true);
-    }
     frame(lua_state, 10.0);
     FT_MOTION_RATE(agent, 1.0);
     if is_excute(agent) {

--- a/fighters/ridley/src/acmd/throws.rs
+++ b/fighters/ridley/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 7.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/robot/src/acmd/throws.rs
+++ b/fighters/robot/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/rockman/src/acmd/throws.rs
+++ b/fighters/rockman/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 6.0);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/rosetta/src/acmd/throws.rs
+++ b/fighters/rosetta/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/roy/src/acmd/throws.rs
+++ b/fighters/roy/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/ryu/src/acmd/throws.rs
+++ b/fighters/ryu/src/acmd/throws.rs
@@ -20,10 +20,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     frame(lua_state, 1.0);
-    if is_excute(agent) {
-        FT_MOTION_RATE(agent, 1.200);
-    }
-    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.2);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/sheik/src/acmd/throws.rs
+++ b/fighters/sheik/src/acmd/throws.rs
@@ -3,7 +3,7 @@ use super::*;
 unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/shulk/src/acmd/throws.rs
+++ b/fighters/shulk/src/acmd/throws.rs
@@ -7,7 +7,7 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     FT_MOTION_RATE(agent, 2.0);
     frame(lua_state, 2.0);
     FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 6.0);
+    frame(lua_state, 1.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/simon/src/acmd/throws.rs
+++ b/fighters/simon/src/acmd/throws.rs
@@ -6,11 +6,8 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.7);
     if is_excute(agent) {
-        FighterAreaModuleImpl::enable_fix_jostle_area(boma, 4.0, 6.0);
-    }
-    frame(lua_state, 9.0);
-    if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
+        FighterAreaModuleImpl::enable_fix_jostle_area(boma, 4.0, 6.0);
     }
     frame(lua_state, 10.0);
     FT_MOTION_RATE(agent, 1.0);

--- a/fighters/snake/src/acmd/throws.rs
+++ b/fighters/snake/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 0.875);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/sonic/src/acmd/throws.rs
+++ b/fighters/sonic/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 6.0);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/szerosuit/src/acmd/throws.rs
+++ b/fighters/szerosuit/src/acmd/throws.rs
@@ -5,12 +5,11 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.0/(3.0-1.0));
-    frame(lua_state, 3.0);
-    FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 7.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 3.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 8.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.3, 0.0, 9.0, 5.0, Some(0.0), Some(9.0), Some(7.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/trail/src/acmd/throws.rs
+++ b/fighters/trail/src/acmd/throws.rs
@@ -4,13 +4,12 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     frame(lua_state, 1.0);
-        FT_MOTION_RATE(agent, 0.5);
-    frame(lua_state, 5.0);
-        FT_MOTION_RATE(agent, 1.0);
-    frame(lua_state, 8.0);
+    FT_MOTION_RATE(agent, 0.5);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }
+    frame(lua_state, 5.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 9.0);
     if is_excute(agent) {
         CATCH(agent, 0, Hash40::new("top"), 4.0, 0.0, 7.0, 0.0, Some(0.0), Some(7.0), Some(9.0), *FIGHTER_STATUS_KIND_CAPTURE_PULLED, *COLLISION_SITUATION_MASK_GA);

--- a/fighters/wiifit/src/acmd/throws.rs
+++ b/fighters/wiifit/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/wolf/src/acmd/throws.rs
+++ b/fighters/wolf/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE(agent, 1.2);
-    frame(lua_state, 5.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }

--- a/fighters/zelda/src/acmd/throws.rs
+++ b/fighters/zelda/src/acmd/throws.rs
@@ -5,7 +5,6 @@ unsafe extern "C" fn game_catch(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
 	FT_MOTION_RATE(agent, 0.7);
-    frame(lua_state, 9.0);
     if is_excute(agent) {
         GrabModule::set_rebound(boma, true);
     }


### PR DESCRIPTION
# Experimental!
Grab Tech / Grab Clank:
- Grab Techs are now enabled on the first frame of **standing grabs**
  - *Previously, they were enabled 1F before the grab hitbox*
  - *This change does not apply to non-standard grabs, like tether grabs, or slow direct grabs*
  - *Intended to provide a new defensive option in some scenarios*
