### PR TITLE
ECB Snap Fixes

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -239,6 +239,7 @@ pub mod vars {
             pub const PREV_STATUS_TRANSITION_FRAME: i32 = 0x0013;
 
             pub const ATTACK_LR_CHECK: i32 = 0x0014;
+            pub const PREVIOUS_FRAME_FRAMES_IN_AIR: i32 = 0x0015;
 
             // floats
 

--- a/fighters/common/src/general_statuses/damage.rs
+++ b/fighters/common/src/general_statuses/damage.rs
@@ -6,6 +6,9 @@ use utils::game_modes::CustomMode;
 
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+    // NOPs fighter_handle_damage setting the airtime counter to 0 frames on hit in air.
+    // This is so the ECB diamond will not reset when getting hit in the air (same as melee)
+    skyline::patching::Patch::in_text(0x63251c).nop();
 }
 
 fn nro_hook(info: &skyline::nro::NroInfo) {

--- a/fighters/common/src/lib.rs
+++ b/fighters/common/src/lib.rs
@@ -37,6 +37,7 @@ pub static mut LAST_ATTACK_TEAM_COLOR: i32 = 0;
 
 extern "C" fn common_init(fighter: &mut L2CFighterCommon) {
     VarModule::set_int(fighter.battle_object, vars::common::instance::LEDGE_ID, -1);
+    VarModule::set_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR, -1);
     VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_INIT);
 }
 

--- a/fighters/common/src/opff/mod.rs
+++ b/fighters/common/src/opff/mod.rs
@@ -127,6 +127,8 @@ pub unsafe fn moveset_edits(fighter: &mut L2CFighterCommon, info: &FrameInfo) {
 pub unsafe fn sys_line_system_control_fighter_hook(fighter: &mut L2CFighterCommon) -> L2CValue {
     // Reserved for common OPFF to be placed on exec status
     // rather than main status (default behavior)
+    other::fighter_frame_in_air_inc_ensure(fighter); // fighter_common_opff runs multiple times per frame when
+                                                     // transitioning between states, so this is placed here instead.
     decrease_knockdown_bounce_heights(fighter);
     left_stick_flick_counter(fighter);
     right_stick_flick_counter(fighter);

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -17,6 +17,10 @@ use crate::misc::*;
 use globals::*;
 use crate::util::get_fighter_common_from_accessor;
 
+use std::sync::LazyLock;
+use std::sync::RwLock;
+use std::collections::HashMap;
+
 unsafe fn hitstun_overlay_orange(boma: &mut BattleObjectModuleAccessor, id: usize) {
     let cmb_vec1 = Vector4f{x: 0.949, y: 0.5137, z: 0.08643, w: 0.69};
     let cmb_vec2 = Vector4f{x: 0.949, y: 0.5137, z: 0.08643, w: 0.0};
@@ -112,6 +116,40 @@ pub unsafe fn cliff_xlu_frame_counter(fighter: &mut L2CFighterCommon) {
             VarModule::set_int(fighter.battle_object, vars::common::instance::CLIFF_XLU_FRAME, 0);
         }
     }
+}
+
+static mut PREVIOUS_FRAME_AIRTIME_COUNT: LazyLock<RwLock<HashMap<i32, i32>>> = LazyLock::new(||
+    RwLock::new(HashMap::<i32, i32>::new())
+);
+
+pub unsafe fn fighter_frame_in_air_inc_ensure(fighter: &mut L2CFighterCommon) {
+    let player_idx: i32 = (*fighter.module_accessor).get_player_idx_from_boma();
+    let mut current_air_frames: i32 = WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
+    let previous_air_frames: i32 = PREVIOUS_FRAME_AIRTIME_COUNT.read().unwrap().get(&player_idx).copied().unwrap_or(-1);
+    // println!("[{}] AIRTIME: {}", player_idx, current_air_frames);
+    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
+        // see: fighters/common/src/function_hooks/lua_bind_hook/status.rs
+        if !(*fighter.module_accessor).is_prev_status_one_of(&[
+            *FIGHTER_STATUS_KIND_DEMO,
+            *FIGHTER_STATUS_KIND_ENTRY,
+            *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
+            *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
+            *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
+            *FIGHTER_STATUS_KIND_THROWN,
+            *FIGHTER_STATUS_KIND_CATCHED_GANON,
+            *FIGHTER_STATUS_KIND_CATCHED_AIR_GANON,
+            *FIGHTER_STATUS_KIND_CATCHED_REFLET,
+            *FIGHTER_STATUS_KIND_CATCHED_RIDLEY,
+            *FIGHTER_STATUS_KIND_CAPTURE_JACK_WIRE,
+            *FIGHTER_STATUS_KIND_CAPTURE_MASTER_SWORD]) {
+            if (previous_air_frames == current_air_frames) {
+                current_air_frames += 1;
+                // println!("[{}] INCREMENTING MISSED AIRTIME! NEW AIRTIME: {}", player_idx, current_air_frames);
+                WorkModule::set_int(fighter.module_accessor, current_air_frames, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
+            }
+        }
+    }
+    PREVIOUS_FRAME_AIRTIME_COUNT.write().unwrap().insert(player_idx, current_air_frames);
 }
 
 pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {

--- a/fighters/common/src/opff/other.rs
+++ b/fighters/common/src/opff/other.rs
@@ -17,10 +17,6 @@ use crate::misc::*;
 use globals::*;
 use crate::util::get_fighter_common_from_accessor;
 
-use std::sync::LazyLock;
-use std::sync::RwLock;
-use std::collections::HashMap;
-
 unsafe fn hitstun_overlay_orange(boma: &mut BattleObjectModuleAccessor, id: usize) {
     let cmb_vec1 = Vector4f{x: 0.949, y: 0.5137, z: 0.08643, w: 0.69};
     let cmb_vec2 = Vector4f{x: 0.949, y: 0.5137, z: 0.08643, w: 0.0};
@@ -118,15 +114,11 @@ pub unsafe fn cliff_xlu_frame_counter(fighter: &mut L2CFighterCommon) {
     }
 }
 
-static mut PREVIOUS_FRAME_AIRTIME_COUNT: LazyLock<RwLock<HashMap<i32, i32>>> = LazyLock::new(||
-    RwLock::new(HashMap::<i32, i32>::new())
-);
-
 pub unsafe fn fighter_frame_in_air_inc_ensure(fighter: &mut L2CFighterCommon) {
-    let player_idx: i32 = (*fighter.module_accessor).get_player_idx_from_boma();
     let mut current_air_frames: i32 = WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
-    let previous_air_frames: i32 = PREVIOUS_FRAME_AIRTIME_COUNT.read().unwrap().get(&player_idx).copied().unwrap_or(-1);
-    // println!("[{}] AIRTIME: {}", player_idx, current_air_frames);
+    let previous_air_frames: i32 = VarModule::get_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR);
+    // println!("[{}] AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), current_air_frames);
+    // println!("[{}] PREV AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), previous_air_frames);
     if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
         // see: fighters/common/src/function_hooks/lua_bind_hook/status.rs
         if !(*fighter.module_accessor).is_prev_status_one_of(&[
@@ -144,12 +136,12 @@ pub unsafe fn fighter_frame_in_air_inc_ensure(fighter: &mut L2CFighterCommon) {
             *FIGHTER_STATUS_KIND_CAPTURE_MASTER_SWORD]) {
             if (previous_air_frames == current_air_frames) {
                 current_air_frames += 1;
-                // println!("[{}] INCREMENTING MISSED AIRTIME! NEW AIRTIME: {}", player_idx, current_air_frames);
+                // println!("[{}] INCREMENTING MISSED AIRTIME! NEW AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), current_air_frames);
                 WorkModule::set_int(fighter.module_accessor, current_air_frames, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
             }
         }
     }
-    PREVIOUS_FRAME_AIRTIME_COUNT.write().unwrap().insert(player_idx, current_air_frames);
+    VarModule::set_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR, current_air_frames);
 }
 
 pub unsafe fn ecb_shift_disabled_motions(fighter: &mut L2CFighterCommon) {

--- a/utils/src/modules/meter.rs
+++ b/utils/src/modules/meter.rs
@@ -420,6 +420,9 @@ unsafe fn shield_module_send_shield_attack_collision_event(shield_module: *mut u
     VarModule::set_vec3(battle_object, vars::common::instance::LAST_ATTACK_HIT_LOCATION, Vector3f { x: loc_x, y: loc_y, z: loc_z });
 }
 
+// This should probably be in fighters/common/src/general_statuses/damage.rs but the only thing we currently do is meter-related
+// But now we are nopping an instruction in it, which can be found in damage.rs. If the scope widens, it will likely be a good idea
+// to decomp the entire function and/or consoliate things there as it makes more sense.
 #[skyline::hook(offset = offsets::fighter_handle_damage())]
 unsafe fn fighter_handle_damage_hook(fighter: *mut smash::app::BattleObject, arg: *const u8) {
     let module_accessor = (*fighter).module_accessor;


### PR DESCRIPTION
# Overview

In HDR / Ultimate, the number of frames you have been in the air gets reset on hit. Given how HDR is designed, this is not desired behaviour. Additionally, the way the game calculates attacker ECB unsnapping can vary with particular moves and states. For example, while Fox back air will unsnap correctly after 9 frames including hitlag, this does not occur during forward air as some frames are not counted towards airtime for some unknown reason. This also fixes that. 

Defender hitlag additionally did not count any of its airtime towards the airtime counter. This fixes that as well.

# Changes

## `fighters\common\src\general_statuses\damage.rs`

A `nop` is patched into the function that sets airtime to 0 on hit to prevent this from happening.

```diff
 pub fn install() {
     skyline::nro::add_hook(nro_hook);
+    // NOPs fighter_handle_damage setting the airtime counter to 0 frames on hit in air.
+    // This is so the ECB diamond will not reset when getting hit in the air (same as melee)
+    skyline::patching::Patch::in_text(0x63251c).nop();
}
```
## `fighters\common\src\opff\other.rs`

A new function `fighter_frame_in_air_inc_ensure` has been added. It checks to see if the airtime was correctly increased the previous frame. If this is not the case, increment it. This is a global catch-all and should avoid a series of small patches anywhere this might apply.

~~A hashmap to keep track of the previous frame airtime was added: `PREVIOUS_FRAME_AIRTIME_COUNT`. It is indexed by `player_idx` from the fighter's battle object module accessor.~~ This has now been replaced by `VarModule` usage.

```rs
pub unsafe fn fighter_frame_in_air_inc_ensure(fighter: &mut L2CFighterCommon) {
    let mut current_air_frames: i32 = WorkModule::get_int(fighter.module_accessor, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
    let previous_air_frames: i32 = VarModule::get_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR);
    // println!("[{}] AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), current_air_frames);
    // println!("[{}] PREV AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), previous_air_frames);
    if fighter.global_table[SITUATION_KIND] == SITUATION_KIND_AIR {
        // see: fighters/common/src/function_hooks/lua_bind_hook/status.rs
        if !(*fighter.module_accessor).is_prev_status_one_of(&[
            *FIGHTER_STATUS_KIND_DEMO,
            *FIGHTER_STATUS_KIND_ENTRY,
            *FIGHTER_STATUS_KIND_CAPTURE_PULLED,
            *FIGHTER_STATUS_KIND_CAPTURE_WAIT,
            *FIGHTER_STATUS_KIND_CAPTURE_DAMAGE,
            *FIGHTER_STATUS_KIND_THROWN,
            *FIGHTER_STATUS_KIND_CATCHED_GANON,
            *FIGHTER_STATUS_KIND_CATCHED_AIR_GANON,
            *FIGHTER_STATUS_KIND_CATCHED_REFLET,
            *FIGHTER_STATUS_KIND_CATCHED_RIDLEY,
            *FIGHTER_STATUS_KIND_CAPTURE_JACK_WIRE,
            *FIGHTER_STATUS_KIND_CAPTURE_MASTER_SWORD]) {
            if (previous_air_frames == current_air_frames) {
                current_air_frames += 1;
                // println!("[{}] INCREMENTING MISSED AIRTIME! NEW AIRTIME: {}", (*fighter.battle_object).get_player_idx_from_boma(), current_air_frames);
                WorkModule::set_int(fighter.module_accessor, current_air_frames, *FIGHTER_INSTANCE_WORK_ID_INT_FRAME_IN_AIR);
            }
        }
    }
    VarModule::set_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR, current_air_frames);
}
```

## `dynamic\src\consts.rs`

New `VarModule` variable added for keeping track of the previous frame's airtime.

```diff
             pub const PREV_STATUS_TRANSITION_FRAME: i32 = 0x0013;

             pub const ATTACK_LR_CHECK: i32 = 0x0014;
+            pub const PREVIOUS_FRAME_FRAMES_IN_AIR: i32 = 0x0015;

             // floats
```

## `fighters\common\src\lib.rs`

Initialization for the `VarModule` variable included in common fighter init.

```diff
 extern "C" fn common_init(fighter: &mut L2CFighterCommon) {
     VarModule::set_int(fighter.battle_object, vars::common::instance::LEDGE_ID, -1);
+    VarModule::set_int(fighter.battle_object, vars::common::instance::PREVIOUS_FRAME_FRAMES_IN_AIR, -1);
     VarModule::off_flag(fighter.battle_object, vars::common::instance::IS_INIT);
 }
```

## `fighters\common\src\opff\mod.rs`

A call to `other::figher_frame_in_air_inc_ensure` is made in `sys_line_system_control_fighter_hook` as opposed to adding it to `other::run` due to `fighter_common_opff` running more than one time per frame in certain states (transitional states usually. ex. going from ground to air while also inputting back air will run this 3 times)

```diff
 #[skyline::hook(replace = smash::lua2cpp::L2CFighterCommon_sys_line_system_control_fighter)]
 pub unsafe fn sys_line_system_control_fighter_hook(fighter: &mut L2CFighterCommon) -> L2CValue {
     // Reserved for common OPFF to be placed on exec status
     // rather than main status (default behavior)
+    other::fighter_frame_in_air_inc_ensure(fighter); // fighter_common_opff runs multiple times per frame when
+                                                     // transitioning between states, so this is placed here instead.
     decrease_knockdown_bounce_heights(fighter);
     left_stick_flick_counter(fighter);
     right_stick_flick_counter(fighter);

     original!()(fighter)
 }
```

## `utils\src\modules\meter.rs`

A comment was added to `fighter_handle_damage_hook` to be helpful information in the future.

```rs 
// This should probably be in fighters/common/src/general_statuses/damage.rs but the only thing we currently do is meter-related
// But now we are nopping an instruction in it, which can be found in damage.rs. If the scope widens, it will likely be a good idea
// to decomp the entire function and/or consoliate things there as it makes more sense.
```

# Examples

## ECB reset

Airtime previously was reset in the air, re-snapping ECB, which then unsnapped after 9 frames.

https://github.com/user-attachments/assets/b4f5a6f3-a85e-4a4f-ac84-311f4bddbadf

After this fix, it correctly never resets airtime.

https://github.com/user-attachments/assets/5ed24262-5d65-4dd5-9f48-fa5a08ab0ea7

## SDI into the ground

Previously, attempting to SDI into the ground allowed you to be grounded (if ASDI was strong enough to do so afterwards) due to airtime being reset. Forbidden SDI was applied, but it did not matter because forbidden SDI by nature will push you up to your ECB root, which due to being reset, allowed you to be grounded after being hit in this way.

https://github.com/user-attachments/assets/e9ecb32c-2d54-42c9-90b4-a43026a918d7

With airtime not being reset, you will no longer have this happen as the ECB position that is used to check the ground after forbidden SDI pushing you up will keep you off the ground.

https://github.com/user-attachments/assets/5446380d-dc53-4478-aaf3-2176d677af54

## ECB grounding on animation change

Previously, if you were hit in a part of your animation where the ECB shift would hit the ground, you would be able to be grounded if ASDI was enough afterwards despite forbidden SDI applying due to the above.

https://github.com/user-attachments/assets/52f5f588-8d14-43a3-84fb-b269a1d596a7

This will no longer happen, for the reasons we have already outlined.

https://github.com/user-attachments/assets/149572b0-1eb6-4cd9-bf3d-064b67099068

## Demonstrating airtime compensation

Here is a demonstration of the airtime fix being applied to both the unusual fair hitlag for fox as well as defender hitlag now counting for airtime.

https://github.com/user-attachments/assets/42c52c02-d12f-4040-80be-3de65a0b71e6

# Additional Notes

There are cases where you can still ASDI into the ground after being hit in the air despite your airtime not being reset. For example:

- You SDI down towards the ground so that your ECB diamond is barely above the ground, but not actually touching, so forbidden SDI never applies. ASDI then grounds you after hitlag. This happens in melee as well, and is rare. 
- You are hit very early after entering the air, SDI into the ground, and exit hitlag before your ECB unsnaps, allowing the behaviour seen before this fix. This happens in melee as well, and is rare. 

The (Ultimate vanilla) bug that allows the other forbidden SDI, SDI up off the ground when grounded if done frame 2 of hitlag, still exists as well but is out of scope for this PR and can be handled some other time if felt to be necessary. 