### PR TITLE
Robin Float and Elwind Additions

### DIFF
--- a/fighters/common/src/function_hooks/get_param.rs
+++ b/fighters/common/src/function_hooks/get_param.rs
@@ -278,6 +278,24 @@ pub unsafe fn get_param_float_hook(x0 /*boma*/: u64, x1 /*param_type*/: u64, x2 
             }
         }
         
+        else if fighter_kind == *FIGHTER_KIND_REFLET {
+            // Increased Elwind Angle out of run
+            if x1 == hash40("param_special_hi") {
+            if (StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_RUN || 
+                StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_TURN_RUN ||
+                StatusModule::prev_status_kind(boma, 0) == *FIGHTER_STATUS_KIND_RUN_BRAKE) {
+                if x2 == hash40("special_hi_shoot_store_x_initial_velocity_mul"){
+                    return ParamModule::get_float(boma_reference.object(), ParamType::Agent, "param_special_hi.run_angle_mul_x");
+                }
+                if x2 == hash40("special_hi_shoot_store_y_initial_velocity_mul"){
+                    return ParamModule::get_float(boma_reference.object(), ParamType::Agent, "param_special_hi.run_angle_mul_y");
+                }
+            } else {
+                return original!()(x0, x1, x2);
+                }
+            }
+        }
+        
         else if fighter_kind == *FIGHTER_KIND_MIIGUNNER {
             if x1 == hash40("param_special_hi") && x2 == hash40("hi1_first_jump_y_speed") {
                 return 3.5 + (2.7 * VarModule::get_float(boma_reference.object(), vars::miigunner::status::ATTACK_CHARGE)) / 29.0;

--- a/fighters/reflet/src/opff.rs
+++ b/fighters/reflet/src/opff.rs
@@ -1,9 +1,10 @@
 // opff import
 utils::import_noreturn!(common::opff::fighter_common_opff);
 use super::*;
+use super::status::*;
 use globals::*;
  
-unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor) {
+unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor, fighter: &mut L2CFighterCommon) {
     //PM-like neutral-b canceling
     if boma.is_status(*FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_CANCEL) {
         if boma.is_situation(*SITUATION_KIND_AIR) {
@@ -16,8 +17,14 @@ unsafe fn nspecial_cancels(boma: &mut BattleObjectModuleAccessor) {
     // Allow charge jump cancel even when left stick is down
     if boma.is_status(*FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_HOLD) {
         if boma.is_input_jump() && boma.get_num_used_jumps() < boma.get_jump_count_max() {
-            StatusModule::change_status_request_from_script(boma, *FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_JUMP_CANCEL, false);
-            WorkModule::set_int(boma, *FIGHTER_STATUS_KIND_JUMP_AERIAL, *FIGHTER_REFLET_STATUS_SPECIAL_N_HOLD_INT_NEXT_STATUS);
+            let mut float_check = 0.into();
+            if WorkModule::get_int(fighter.module_accessor, *FIGHTER_REFLET_INSTANCE_WORK_ID_INT_SPECIAL_HI_CURRENT_POINT) > 0 {
+                float_check = float_check_air_jump(fighter, statuses::reflet::FLOAT.into());
+            }
+            if float_check != 1 {
+                StatusModule::change_status_request_from_script(boma, *FIGHTER_REFLET_STATUS_KIND_SPECIAL_N_JUMP_CANCEL, false);
+                WorkModule::set_int(boma, *FIGHTER_STATUS_KIND_JUMP_AERIAL, *FIGHTER_REFLET_STATUS_SPECIAL_N_HOLD_INT_NEXT_STATUS);
+            }
         }
     }
 }
@@ -103,7 +110,7 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
 }
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
-    nspecial_cancels(boma);
+    nspecial_cancels(boma, fighter);
     elwind_cost(fighter);
     levin_leniency(fighter, boma);
     sword_length(boma);

--- a/fighters/reflet/src/status/mod.rs
+++ b/fighters/reflet/src/status/mod.rs
@@ -10,7 +10,7 @@ mod float;
 
 extern "Rust" {
     #[link_name = "float_check_air_jump"]
-    fn float_check_air_jump(fighter: &mut L2CFighterCommon, float_status: L2CValue) -> L2CValue;
+    pub fn float_check_air_jump(fighter: &mut L2CFighterCommon, float_status: L2CValue) -> L2CValue;
     #[link_name = "float_check_air_jump_aerial"]
     fn float_check_air_jump_aerial(fighter: &mut L2CFighterCommon, float_status: L2CValue) -> L2CValue;
 }

--- a/romfs/source/fighter/reflet/param/hdr.xml
+++ b/romfs/source/fighter/reflet/param/hdr.xml
@@ -5,4 +5,8 @@
       <float hash="float_accel_add">0.01</float>
       <float hash="float_accel_mul">0.04</float>
     </struct>
+        <struct hash="param_special_hi">
+        <float hash="run_angle_mul_x">1.25</float>
+        <float hash="run_angle_mul_y">1.1</float>
+    </struct>
 </struct>


### PR DESCRIPTION
Small Robin Mobility Improvements.

**Neutral Special**
```diff
+ (+) Charging can be cancelled directly into float without losing double jump

# This is in line with quality of life adjustments previously made to Dark Samus
# Ultimately if accepted the intent is to standardize this feature
```

**Up Special (Elwind)**
```diff
+ (+) Grounded Elwind has increased angle multipliers when done out of the following states:

> Run
> Run Turn
> Run Brake

# This gives grounded elwind increased utility without buffing Robin's recovery
```