### PR TITLE
Richter Divekick Cancels

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -327,6 +327,12 @@ pub mod vars {
             pub const NO_POCKET: i32 = 0x1052;
 
             pub const IS_DASH_CANCEL: i32 = 0x1055;
+            
+            pub const CAN_EMPTY_CANCEL: i32 = 0x1056;
+            
+            pub const ON_HIT_SHIELD: i32 = 0x1057;
+            
+            pub const ON_HIT_DAMAGE: i32 = 0x1058;
 
             // ints
 

--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -550,6 +550,8 @@ pub trait BomaExt {
     unsafe fn sub_check_command_parry(&mut self) -> L2CValue;
     // Checks for situation kind and transitions to heavy landing
     unsafe fn check_land_cancel(&mut self, landing_lag: Option<f32>) -> bool;
+    // Checks for empty cancel
+    unsafe fn check_empty_cancel(&mut self) -> bool;
 
     /// check for hitfall (should be called once per frame)
     unsafe fn check_hitfall(&mut self) -> bool;
@@ -1283,6 +1285,16 @@ impl BomaExt for BattleObjectModuleAccessor {
 
         false
     }
+    
+    // Checks conditions for empty cancel.
+    unsafe fn check_empty_cancel(&mut self) -> bool {
+        if !AttackModule::is_infliction_status(self, *COLLISION_KIND_MASK_HIT)
+        && !self.is_in_hitlag() 
+        && VarModule::is_flag(self.object(), vars::common::status::CAN_EMPTY_CANCEL) {
+            return true;
+        }
+        false
+    }
 
     /// Sets the position of the front/red ledge-grab box (see [`set_center_cliff_hangdata`](BomaExt::set_center_cliff_hangdata) for more information)
     ///
@@ -1464,7 +1476,7 @@ impl BomaExt for BattleObjectModuleAccessor {
             fighter.sub_air_check_fall_common();
         }
     }
-
+    
     unsafe fn check_magicseries(&mut self) {
         // Dont use magic series if we're already in cancel frames, if we're in hitlag, or if we didn't connect
         if CancelModule::is_enable_cancel(self) 
@@ -1481,15 +1493,20 @@ impl BomaExt for BattleObjectModuleAccessor {
             *FIGHTER_STATUS_KIND_ATTACK, 
             *FIGHTER_STATUS_KIND_ATTACK_DASH,
         ].contains(&status_kind) {
-            if self.is_cat_flag(Cat1::AttackS3) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_S3,false);
-            }
-            if self.is_cat_flag(Cat1::AttackHi3) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_HI3,false);
-            }
-            if self.is_cat_flag(Cat1::AttackLw3) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW3,false);
-            }
+            check_input_trans!(self, [
+                *FIGHTER_STATUS_KIND_ATTACK_S3,
+                *FIGHTER_STATUS_KIND_ATTACK_HI3,
+                *FIGHTER_STATUS_KIND_ATTACK_LW3,
+            ]);
+            // if self.is_cat_flag(Cat1::AttackS3) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_S3,false);
+            // }
+            // if self.is_cat_flag(Cat1::AttackHi3) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_HI3,false);
+            // }
+            // if self.is_cat_flag(Cat1::AttackLw3) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW3,false);
+            // }
         }
     
         // Smash cancels
@@ -1500,15 +1517,20 @@ impl BomaExt for BattleObjectModuleAccessor {
             *FIGHTER_STATUS_KIND_ATTACK_HI3,
             *FIGHTER_STATUS_KIND_ATTACK_LW3,
         ].contains(&status_kind) {
-            if self.is_cat_flag(Cat1::AttackS4) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_S4_START,true);
-            }
-            if self.is_cat_flag(Cat1::AttackHi4) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_HI4_START,true);
-            }
-            if self.is_cat_flag(Cat1::AttackLw4) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW4_START,true);
-            }
+            check_input_trans!(self, [
+                *FIGHTER_STATUS_KIND_ATTACK_S4_START,
+                *FIGHTER_STATUS_KIND_ATTACK_HI4_START,
+                *FIGHTER_STATUS_KIND_ATTACK_LW4_START,
+            ]);
+            // if self.is_cat_flag(Cat1::AttackS4) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_S4_START,true);
+            // }
+            // if self.is_cat_flag(Cat1::AttackHi4) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_HI4_START,true);
+            // }
+            // if self.is_cat_flag(Cat1::AttackLw4) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW4_START,true);
+            // }
         }
     
         // Special cancels
@@ -1523,18 +1545,24 @@ impl BomaExt for BattleObjectModuleAccessor {
             *FIGHTER_STATUS_KIND_ATTACK_LW4,
             *FIGHTER_STATUS_KIND_ATTACK_AIR
         ].contains(&status_kind) {
-            if self.is_cat_flag(Cat1::SpecialN) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_N,false);
-            }
-            if self.is_cat_flag(Cat1::SpecialS) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_S,false);
-            }
-            if self.is_cat_flag(Cat1::SpecialHi) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_HI,false);
-            }
-            if self.is_cat_flag(Cat1::SpecialLw) {
-                StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_LW,false);
-            }
+            check_input_trans!(self, [
+                *FIGHTER_STATUS_KIND_SPECIAL_N,
+                *FIGHTER_STATUS_KIND_SPECIAL_S,
+                *FIGHTER_STATUS_KIND_SPECIAL_HI,
+                *FIGHTER_STATUS_KIND_SPECIAL_LW,
+            ]);
+            // if self.is_cat_flag(Cat1::SpecialN) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_N,false);
+            // }
+            // if self.is_cat_flag(Cat1::SpecialS) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_S,false);
+            // }
+            // if self.is_cat_flag(Cat1::SpecialHi) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_HI,false);
+            // }
+            // if self.is_cat_flag(Cat1::SpecialLw) {
+            //     StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_SPECIAL_LW,false);
+            // }
         }
     }
 

--- a/dynamic/src/lib.rs
+++ b/dynamic/src/lib.rs
@@ -4,12 +4,15 @@ pub mod offsets;
 pub mod util;
 pub mod singletons;
 pub mod consts;
+#[macro_use]
+pub mod trans_helper;
 pub mod ext;
 mod modules;
 pub mod frame_info;
 pub mod game_modes;
 pub mod ui;
 pub mod se;
+
 
 #[macro_use]
 extern crate modular_bitfield;

--- a/dynamic/src/trans_helper.rs
+++ b/dynamic/src/trans_helper.rs
@@ -1,0 +1,85 @@
+use crate::consts::{globals::*, vars};
+use smash::app::*;
+use smash::lib::{lua_const::*, *};
+use smash::lua2cpp::*;
+use smash::phx::*;
+use crate::{InputModule, VarModule};
+
+#[macro_export]
+macro_rules! define_trans_map {
+        (
+            $(
+                $to:ident => ($input:path, $from_script:expr)
+            ),* $(,)?
+        ) => {
+            #[macro_export]
+            macro_rules! trans_to {
+                $(
+                    ($f:expr, $to) => {{
+                        if $f.is_cat_flag($input) {
+                            StatusModule::change_status_request_from_script(
+                                $f,
+                                *$to,
+                                $from_script
+                            );
+                        }
+                    }};
+                )*
+    
+                ($f:expr, $other:ident) => {{
+                    compile_error!(concat!(
+                        "trans_to!: no mapping for target status ",
+                        stringify!($other)
+                    ));
+                }};
+            }
+        };
+    }
+    
+    #[macro_export]
+    macro_rules! check_input_trans {
+    
+        ($f:expr, [$($tokens:tt)*]) => {{
+            check_input_trans!(@munch $f; $($tokens)*);
+        }};
+    
+        (@munch $f:expr; ) => {{}};
+    
+        (@munch $f:expr; , $($rest:tt)*) => {{
+            check_input_trans!(@munch $f; $($rest)*);
+        }};
+    
+        (@munch $f:expr; *$to:ident $($rest:tt)*) => {{
+            trans_to!($f, $to);
+            check_input_trans!(@munch $f; $($rest)*);
+        }};
+    
+        (@munch $f:expr; $to:ident $($rest:tt)*) => {{
+            trans_to!($f, $to);
+            check_input_trans!(@munch $f; $($rest)*);
+        }};
+    }
+    
+    define_trans_map! {
+        
+        // Takes a status and checks for the corresponding input before transitioning
+        
+        // Tilts
+        FIGHTER_STATUS_KIND_ATTACK_LW3 => (Cat1::AttackLw3, false),
+        FIGHTER_STATUS_KIND_ATTACK_HI3 => (Cat1::AttackHi3, false),
+        FIGHTER_STATUS_KIND_ATTACK_S3 => (Cat1::AttackS3, false),
+        
+        // Smashes
+        FIGHTER_STATUS_KIND_ATTACK_LW4_START => (Cat1::AttackLw4, true),
+        FIGHTER_STATUS_KIND_ATTACK_HI4_START => (Cat1::AttackHi4, true),
+        FIGHTER_STATUS_KIND_ATTACK_S4_START => (Cat1::AttackS4, true),
+    
+        // Specials
+        FIGHTER_STATUS_KIND_SPECIAL_N  => (Cat1::SpecialN,  false),
+        FIGHTER_STATUS_KIND_SPECIAL_S  => (Cat1::SpecialS,  false),
+        FIGHTER_STATUS_KIND_SPECIAL_HI => (Cat1::SpecialHi, false),
+        FIGHTER_STATUS_KIND_SPECIAL_LW => (Cat1::SpecialLw, false),
+    
+        // TODO: Add more Input -> Status pairs
+    }
+

--- a/fighters/richter/src/acmd/aerials.rs
+++ b/fighters/richter/src/acmd/aerials.rs
@@ -395,10 +395,12 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         VarModule::off_flag(agent.battle_object, vars::richter::instance::ATTACK_AIR_LW_REBOUND);
+        VarModule::on_flag(agent.battle_object, vars::common::status::CAN_EMPTY_CANCEL);
     }
     frame(lua_state, 4.0);
     if is_excute(agent) {
         WorkModule::on_flag(boma, *FIGHTER_STATUS_ATTACK_AIR_FLAG_ENABLE_LANDING);
+        VarModule::on_flag(agent.battle_object, vars::common::status::ENABLE_SPECIAL_WALLJUMP);
     }
     frame(lua_state, 15.0);
     if is_excute(agent) {
@@ -409,6 +411,7 @@ unsafe extern "C" fn game_attackairlw(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 16.0);
     if is_excute(agent) {
+        VarModule::off_flag(agent.battle_object, vars::common::status::CAN_EMPTY_CANCEL);
         ATTACK(agent, 0, 0, Hash40::new("top"), 12.0, 80, 46, 0, 88, 5.5, 0.0, 1.0, 0.0, None, None, None, 1.1, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_F, false, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_normal"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_KICK, *ATTACK_REGION_KICK);
     }
     wait(lua_state, 2.0);
@@ -434,6 +437,7 @@ unsafe extern "C" fn game_attackairlw2(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     if is_excute(agent) {
         AttackModule::clear_all(boma);
+        VarModule::on_flag(agent.battle_object, vars::common::status::ENABLE_SPECIAL_WALLJUMP);
         if VarModule::is_flag(agent.battle_object, vars::richter::instance::ATTACK_AIR_LW_REBOUND) {
             SET_SPEED_EX(agent, 0.0, 0.0, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
         } else {

--- a/fighters/richter/src/opff.rs
+++ b/fighters/richter/src/opff.rs
@@ -35,9 +35,36 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
     }
 }
 
+unsafe fn walljump_cancel(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    let boma_obj = boma.object();
+    if boma.is_situation(*SITUATION_KIND_AIR) &&
+       VarModule::is_flag(boma_obj, vars::common::status::ENABLE_SPECIAL_WALLJUMP) &&
+       !crate::VarModule::is_flag(boma_obj, vars::common::instance::SPECIAL_WALL_JUMP) {
+           if fighter.sub_transition_group_check_air_wall_jump().get_bool() {
+               crate::VarModule::on_flag(boma_obj, vars::common::instance::SPECIAL_WALL_JUMP);
+           }
+     }
+}
+
+unsafe fn kara_divekick(fighter: &mut smash::lua2cpp::L2CFighterCommon, boma: &mut BattleObjectModuleAccessor) {
+    if  fighter.is_motion(Hash40::new("attack_air_lw")) {    
+        if fighter.check_empty_cancel() {
+            check_input_trans!(boma, [
+                *FIGHTER_STATUS_KIND_SPECIAL_N,
+                *FIGHTER_STATUS_KIND_SPECIAL_S,
+                *FIGHTER_STATUS_KIND_SPECIAL_HI,
+                *FIGHTER_STATUS_KIND_SPECIAL_LW,
+            ]);
+        }
+    }
+}
+
+
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     whip_angling(fighter, boma, frame, stick_y);
     fastfall_specials(fighter);
+    walljump_cancel(fighter, boma);
+    kara_divekick(fighter, boma);
 }
 
 pub extern "C" fn richter_frame_wrapper(fighter: &mut smash::lua2cpp::L2CFighterCommon) {

--- a/fighters/richter/src/status/special_s.rs
+++ b/fighters/richter/src/status/special_s.rs
@@ -28,6 +28,12 @@ unsafe extern "C" fn special_s_main_loop(fighter: &mut L2CFighterCommon) -> L2CV
     if fighter.sub_transition_group_check_air_cliff().get_bool() {
         return 1.into();
     }
+    if AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_SHIELD) {
+        if !VarModule::is_flag(fighter.battle_object, vars::common::status::ON_HIT_SHIELD) {
+            KineticModule::mul_speed(fighter.module_accessor, &Vector3f::new(0.75, 1.0, 1.0), *KINETIC_ENERGY_RESERVE_ATTRIBUTE_ALL);
+            VarModule::on_flag(fighter.battle_object, vars::common::status::ON_HIT_SHIELD);
+        }
+    }
     if StatusModule::is_situation_changed(fighter.module_accessor) {
         if fighter.is_situation(*SITUATION_KIND_GROUND) {
             GroundModule::correct(fighter.module_accessor, app::GroundCorrectKind(*GROUND_CORRECT_KIND_GROUND));

--- a/romfs/source/fighter/richter/motion/body/motion_patch.yaml
+++ b/romfs/source/fighter/richter/motion/body/motion_patch.yaml
@@ -250,12 +250,12 @@ special_s1:
   flags:
     move: true
   extra:
-    cancel_frame: 42
+    cancel_frame: 44
 special_air_s1:
   flags:
     move: true
   extra:
-    cancel_frame: 42
+    cancel_frame: 44
 special_lw:
   flags:
     move: true


### PR DESCRIPTION
Adjustments for yassified Simon.

```diff

Down Air
+ (+) Empty cancellable into specials until first hitbox frame
# Exactly 1 frame window to retain momentum

+ (+) Special walljump cancellable

Side Special
- (-) FAF: 42 -> 44
- (-) 25% Speed Reduction on Shield Hit

```
Divekick now empty cancellable into specials. 

This may or may not have useful applications.

https://github.com/user-attachments/assets/13212e67-b203-4635-b08b-6dd3a9335125

Also included in this PR is a rust macro for easily checking input transitions.

This may or may not have useful applications.