### PR TITLE
Fix warnings picked up by properly configured rust-analyzer

### DIFF
--- a/fighters/common/src/function_hooks/vtables/demon.rs
+++ b/fighters/common/src/function_hooks/vtables/demon.rs
@@ -11,7 +11,7 @@ pub unsafe extern "C" fn demon_on_attack(vtable: u64, fighter: &mut Fighter, log
         *FIGHTER_DEMON_STATUS_KIND_ATTACK_STEP_2S,
     ].contains(&status)
     && VarModule::is_flag(battle_object, vars::demon::status::CHECK_STEP_CANCEL) {
-        let collision_log: &mut CollisionLog = std::mem::transmute(log);
+        let collision_log: &CollisionLog = &*std::ptr::with_exposed_provenance::<CollisionLog>(log as usize);
         if [
             *COLLISION_KIND_ATTACK as u8,
             *COLLISION_KIND_HIT as u8,

--- a/src/matchup/containers.rs
+++ b/src/matchup/containers.rs
@@ -81,11 +81,11 @@ impl<T> CppVector<T> {
         }
     }
 
-    pub fn iter(&self) -> CppVectorIterator<T> {
+    pub fn iter(&self) -> CppVectorIterator<'_, T> {
         self.into_iter()
     }
 
-    pub fn iter_mut(&mut self) -> CppVectorIteratorMut<T> {
+    pub fn iter_mut(&mut self) -> CppVectorIteratorMut<'_, T> {
         self.into_iter()
     }
 
@@ -326,7 +326,7 @@ impl ResList {
         }
     }
 
-    pub fn node_iter(&self) -> NodeIter {
+    pub fn node_iter(&self) -> NodeIter<'_> {
         NodeIter {
             list: self,
             count: 0,


### PR DESCRIPTION
While making [HDR Development Environment Setup for WSL](https://github.com/Savestate2A03/hdr-wsl-dev-env-setup), I figured out how to properly set up `rust-analyzer`.

These were the two warnings that were presented to me after doing so:

```rust
// ---------------------------------------------------------------
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/matchup/containers.rs:88:21
   |
88 |     pub fn iter_mut(&mut self) -> CppVectorIteratorMut<T> {
   |                     ^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                     |
   |                     the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
88 |     pub fn iter_mut(&mut self) -> CppVectorIteratorMut<'_, T> {
   |                                                        +++
// ---------------------------------------------------------------
warning: transmuting an integer to a pointer creates a pointer without provenance
  --> fighters/common/src/function_hooks/vtables/demon.rs:14:48
   |
14 |         let collision_log: &mut CollisionLog = std::mem::transmute(log);
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
   = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
   = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
   = note: `#[warn(integer_to_ptr_transmutes)]` on by default
help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
   |
14 -         let collision_log: &mut CollisionLog = std::mem::transmute(log);
14 +         let collision_log: &mut CollisionLog = &mut *std::ptr::with_exposed_provenance_mut::<dynamic::ext::CollisionLog>(log);
   |
// ---------------------------------------------------------------
```

This fixes them