### PR TITLE
64 Inspired Assault Orbitars

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1608,7 +1608,8 @@ pub mod vars {
     pub mod pitb {
         pub mod instance {
             // flags
-            pub const SPECIAL_LW_DISABLE_JC: i32 = 0x0100;
+            pub const SPECIAL_LW_DISABLE_LC: i32 = 0x0100;
+            pub const SPECIAL_LW_DISABLE_STALL: i32 = 0x0101;
         }
     }
 

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -144,6 +144,9 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 3.0);
+    if is_excute(agent) {
+        VarModule::on_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
+    }
     frame(lua_state, 6.0);
     FT_MOTION_RATE_RANGE(agent, 6.0, 6.9, 1.0);
     if is_excute(agent) {
@@ -153,7 +156,7 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     frame(lua_state, 6.9);
     FT_MOTION_RATE_RANGE(agent, 6.9, 7.0, 3.0);
     if is_excute(agent) {
-        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 70, kbg: 85, bkb: 77, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 0.72, clank: SetOff::Off, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
+        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 24, kbg: 100, fkb: 40, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
     }
     frame(lua_state, 6.933);
     if is_excute(agent) {
@@ -196,6 +199,7 @@ unsafe extern "C" fn game_speciallwhold(agent: &mut L2CAgentBase) {
     if is_excute(agent) {
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 0, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 1, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
+        VarModule::on_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
     }
 }
 
@@ -208,6 +212,7 @@ unsafe extern "C" fn effect_speciallwend(agent: &mut L2CAgentBase) {
         let rot2 = if facing > 0.0 { 120 } else { 60 };
         EFFECT(agent, Hash40::new("pitb_guardian_shield_end"), Hash40::new("virtualguardianf"), 2.0 * facing, 3, -2, 0, rot1, 0, 1, 0, 0, 0, 0, 0, 0, true);
         EFFECT(agent, Hash40::new("pitb_guardian_shield_end"), Hash40::new("virtualguardianb"), 2.0 * facing, 3, 2, 0, rot2, 0, 1, 0, 0, 0, 0, 0, 0, true);
+        VarModule::off_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
     }
     frame(lua_state, 3.0);
     if is_excute(agent) {

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -144,9 +144,6 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     let boma = agent.boma();
     frame(lua_state, 1.0);
     FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 3.0);
-    if is_excute(agent) {
-        VarModule::on_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
-    }
     frame(lua_state, 6.0);
     FT_MOTION_RATE_RANGE(agent, 6.0, 6.9, 1.0);
     if is_excute(agent) {

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -10,38 +10,49 @@ unsafe fn bow_lc(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
-// Dark Pit Guardian Orbitar Jump Cancels
-unsafe fn guardian_orbitar_jc(fighter: &mut L2CFighterCommon) {
-
-    // resets the disable jump cancel flag
+unsafe fn guardian_orbitar(fighter: &mut L2CFighterCommon) {
+    // happens on init
     if fighter.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_SPECIAL_LW,
     ])
     && StatusModule::is_changing(fighter.module_accessor) {
-        VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_JC);
+        if !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL) {
+            sv_kinetic_energy!(
+                set_speed,
+                fighter,
+                FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+                0.0
+            );
+            sv_kinetic_energy!(
+                set_accel,
+                fighter,
+                FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+                0.0
+            );
+        }
+        VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC);
+        VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL);
     }
 
-    // disables jump cancels when parried between statuses
+    // happens on main for all statuses
     if fighter.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_SPECIAL_LW,
         *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_HOLD,
         *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END,
-    ])
-    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_PARRY) {
-        VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_JC);
-        if !fighter.is_status(*FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END)
-        && !fighter.is_in_hitlag() {
-            fighter.change_status(FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END.into(), false.into());
+    ]) {
+        // disable land cancel on parry
+        if AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_PARRY) {
+            VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC);
+            if !fighter.is_status(*FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END)
+            && !fighter.is_in_hitlag() {
+                fighter.change_status(FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END.into(), false.into());
+            }
         }
-    }
 
-    if fighter.is_status_one_of(&[
-        *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_HOLD,
-        *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END
-    ])
-    && !fighter.is_in_hitlag()
-    && !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_JC) {
-        fighter.check_jump_cancel(false, false, false);
+        // land cancel
+        if !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC) {
+            fighter.check_land_cancel(None);
+        }
     }
 }
 
@@ -64,7 +75,7 @@ extern "Rust" {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_lc(boma);
-    guardian_orbitar_jc(fighter);
+    guardian_orbitar(fighter);
     electroshock_land_cancel_on_hit(fighter);
     pits_common(fighter, boma, status_kind);
 }

--- a/fighters/pitb/src/status/mod.rs
+++ b/fighters/pitb/src/status/mod.rs
@@ -5,7 +5,21 @@ use globals::*;
 mod special_hi;
 mod special_n;
 
+unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
+    // Reset shine stall flag on landing or ledgegrab
+    if [*SITUATION_KIND_GROUND, *SITUATION_KIND_CLIFF].contains(&fighter.global_table[SITUATION_KIND].get_i32())
+    || fighter.is_status_one_of(&[*FIGHTER_STATUS_KIND_REBIRTH, *FIGHTER_STATUS_KIND_DEAD, *FIGHTER_STATUS_KIND_LANDING, *FIGHTER_STATUS_KIND_GIMMICK_SPRING_JUMP]) {
+        VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL);
+    }
+    true.into()
+}
+
+unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
+    fighter.global_table[globals::STATUS_CHANGE_CALLBACK].assign(&L2CValue::Ptr(change_status_callback as *const () as _));
+}
+
 pub fn install(agent: &mut Agent) {
+    agent.on_start(on_start);
     special_hi::install(agent);
     special_n::install(agent);
 }

--- a/romfs/source/fighter/pitb/param/vl.prcxml
+++ b/romfs/source/fighter/pitb/param/vl.prcxml
@@ -68,7 +68,7 @@
   </list>
   <list hash="param_special_lw">
     <struct index="0">
-      <int hash="frame_min">20</int>
+      <int hash="frame_min">12</int>
       <float hash="end_scale">0.8</float>
       <float hash="end_offset_z">7</float>
       <float hash="shield_max">2</float>


### PR DESCRIPTION
## Dark Pit
### Assault Orbitars
Reworked, inspired by Fox's reflector in Smash 64:

```diff
! (!) Removed the ability to jump cancel the attack
! (!) Dark Pit can now land cancel the attack
! (!) Dark Pit's vertical momentum is stalled the first time he uses the attack each airtime
~ Gravity start frame: F8

+ [+] Minimum hold time: 20F -> 12F
# Other framedata is unchanged, including the startup

Attack:
! [R] The attack now uses set weight
! [R] Angle: 70 -> 24
! [R] KBG: 85 -> 100
! [R] FKB: 0 -> 40
! [R] BKB: 77 -> 0
~ [/] Hitlag: 0.72x -> 1.0x
- [-] SDI: 1.0x -> 1.15x
# It now sends the opponent horizontally, but no longer defeats CC
# With perfect timing, Dark Pit is +11F on hit, +2F on ASDI-down, +0F on true CC, and -2F on shield
```

This PR is public because I'm not confident enough in it to go ahead without a lot of open feedback. I've always loved Fox's design in Smash 64, and his land-cancel shine in that game is a very special tool that deserves to be represented. I think that such a change to Dark Pit's shine would help distinguish him mechanically from spacies, in a way that's still true to his identity. In order to keep it in check, I've designed it with ASDI and CC in mind. Hopefully it's still mechanically deep and fun to use! If you playtest this, please provide footage and feedback in the Dark Pit channel of our discord server.

https://github.com/user-attachments/assets/8be8bf97-b97e-484d-bcc5-fb631cc56901

https://github.com/user-attachments/assets/9214dda8-6ef0-4ab1-91b0-107d46d8d887

https://github.com/user-attachments/assets/98864725-f0cf-486b-9544-83b51c2e5247

https://github.com/user-attachments/assets/b634c79f-caa7-4af4-92c7-16ddbd072410

