### PR TITLE
Kirby Up Special Adjustment

### DIFF
--- a/fighters/kirby/src/acmd/specials.rs
+++ b/fighters/kirby/src/acmd/specials.rs
@@ -338,7 +338,7 @@ unsafe extern "C" fn game_specialairhi2(agent: &mut L2CAgentBase) {
     }
     frame(lua_state, 19.0);
     if is_excute(agent) {
-        ATTACK(agent, 0, 0, Hash40::new("haver"), 2.0, 275, 102, 0, 40, 6.0, 0.0, 8.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
+        ATTACK(agent, 0, 0, Hash40::new("haver"), 7.0, 55, 115, 0, 55, 6.0, 0.0, 8.5, 0.0, None, None, None, 1.0, 1.0, *ATTACK_SETOFF_KIND_ON, *ATTACK_LR_CHECK_POS, true, 0, 0.0, 0, false, false, false, false, true, *COLLISION_SITUATION_MASK_GA, *COLLISION_CATEGORY_MASK_ALL, *COLLISION_PART_MASK_ALL, false, Hash40::new("collision_attr_cutup"), *ATTACK_SOUND_LEVEL_L, *COLLISION_SOUND_ATTR_CUTUP, *ATTACK_REGION_SWORD);
     }
     frame(lua_state, 28.0);
     if is_excute(agent) {


### PR DESCRIPTION
Per Suddy in Kirby chat, makes Kirby's second Up B hit function like Chrom and Ike's instead of spiking.


### Up Special (Final Cutter)
```diff

Hit 2:

! [R] Angle: 275 > 55

+ [+] Damage: 2% > 7%

~ [/] BKB: 40 > 55

~ [/] KBG: 102 > 115

# Slightly weaker version of Ike Up Special. 
