### PR TITLE
Allow Backwards Crouch Dash

### DIFF
--- a/dynamic/src/ext.rs
+++ b/dynamic/src/ext.rs
@@ -799,12 +799,12 @@ impl BomaExt for BattleObjectModuleAccessor {
     }
 
     /// Checks if a given input is held and turns off the check if released
-    /// 
+    ///
     /// # Arguments
     /// * `start_frame` - the status frame to start checking for the held input
     /// * `end_frame` - the status frame which to stop checking
     /// * `input` - a Button input (ie Buttons::Special)
-    /// 
+    ///
     /// Returns true if the end of the hold check has completed, if the end frame has been specified
     unsafe fn check_hold_input(&mut self, start_frame: i32, end_frame: i32, input: Buttons) -> bool {
         // if out of range, return early
@@ -1175,7 +1175,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         if self.is_prev_status(*FIGHTER_STATUS_KIND_JUMP_SQUAT) {
             return false;
         }
-    
+
         // The distance from your ECB center to your base position is your waveland snap threshold
         let pos = *PostureModule::pos(self);
         let upper_bound_offset_y = if StatusModule::is_changing(self) && !self.is_prev_status(*FIGHTER_STATUS_KIND_PASS) {
@@ -1197,7 +1197,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         let ground_pos_stage = &mut Vector2f::zero();
         let is_touch_any = GroundModule::line_segment_check(self, &Vector2f::new(pos.x, upper_bound_y), &lower_bound, &Vector2f::zero(), ground_pos_any, true);
         let is_touch_stage = GroundModule::line_segment_check(self, &Vector2f::new(pos.x, upper_bound_y), &lower_bound, &Vector2f::zero(), ground_pos_stage, false);
-        let can_snap = !( 
+        let can_snap = !(
             is_touch_any == 0 as *const *const u64
             || (is_touch_stage != 0 as *const *const u64
                 && WorkModule::get_float(self, *FIGHTER_STATUS_ESCAPE_AIR_SLIDE_WORK_FLOAT_DIR_Y) > 0.0)
@@ -1526,7 +1526,7 @@ impl BomaExt for BattleObjectModuleAccessor {
         }
 
         // if you have an escape_air_dash motion, change into it
-        if MotionModule::is_anim_resource(self, Hash40::new("escape_air_dash")) 
+        if MotionModule::is_anim_resource(self, Hash40::new("escape_air_dash"))
         && !self.is_motion(Hash40::new("escape_air_dash"))
         && self.motion_frame() >= 1.0 {
             MotionModule::change_motion(
@@ -1554,18 +1554,18 @@ impl BomaExt for BattleObjectModuleAccessor {
 
     unsafe fn check_magicseries(&mut self) {
         // Dont use magic series if we're already in cancel frames, if we're in hitlag, or if we didn't connect
-        if CancelModule::is_enable_cancel(self) 
-        || self.is_in_hitlag() 
+        if CancelModule::is_enable_cancel(self)
+        || self.is_in_hitlag()
         || !AttackModule::is_infliction_status(self, *COLLISION_KIND_MASK_HIT | *COLLISION_KIND_MASK_SHIELD)
         || AttackModule::is_infliction_status(self, *crate::consts::COLLISION_KIND_MASK_PARRY) {
             return;
         }
 
         let status_kind = StatusModule::status_kind(self);
-        
+
         // Tilt cancels
         if [
-            *FIGHTER_STATUS_KIND_ATTACK, 
+            *FIGHTER_STATUS_KIND_ATTACK,
             *FIGHTER_STATUS_KIND_ATTACK_DASH,
         ].contains(&status_kind) {
             if self.is_cat_flag(Cat1::AttackS3) {
@@ -1578,11 +1578,11 @@ impl BomaExt for BattleObjectModuleAccessor {
                 StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW3,false);
             }
         }
-    
+
         // Smash cancels
         if [
-            *FIGHTER_STATUS_KIND_ATTACK, 
-            *FIGHTER_STATUS_KIND_ATTACK_DASH, 
+            *FIGHTER_STATUS_KIND_ATTACK,
+            *FIGHTER_STATUS_KIND_ATTACK_DASH,
             *FIGHTER_STATUS_KIND_ATTACK_S3,
             *FIGHTER_STATUS_KIND_ATTACK_HI3,
             *FIGHTER_STATUS_KIND_ATTACK_LW3,
@@ -1597,11 +1597,11 @@ impl BomaExt for BattleObjectModuleAccessor {
                 StatusModule::change_status_request_from_script(self, *FIGHTER_STATUS_KIND_ATTACK_LW4_START,true);
             }
         }
-    
+
         // Special cancels
         if [
-            *FIGHTER_STATUS_KIND_ATTACK, 
-            *FIGHTER_STATUS_KIND_ATTACK_DASH, 
+            *FIGHTER_STATUS_KIND_ATTACK,
+            *FIGHTER_STATUS_KIND_ATTACK_DASH,
             *FIGHTER_STATUS_KIND_ATTACK_S3,
             *FIGHTER_STATUS_KIND_ATTACK_HI3,
             *FIGHTER_STATUS_KIND_ATTACK_LW3,
@@ -1651,7 +1651,7 @@ impl BomaExt for BattleObjectModuleAccessor {
             let item_boma = &mut (*item_module_accessor).battle_object_module_accessor;
             return Some(item_boma);
         }
-        
+
         // get the global position of the bone, defaulting to "top"
         let fighter_pos = &mut Vector3f{x: 0.0, y: 0.0, z: 0.0};
         let bone_hash = bone.unwrap_or(Hash40::new("top"));
@@ -1665,7 +1665,7 @@ impl BomaExt for BattleObjectModuleAccessor {
             },
             None => {}
         }
-        
+
         let total = item_manager.get_num_of_active_item_all();
         for id in 0..total {
             // pointer to the item
@@ -2043,8 +2043,137 @@ pub struct CommandInputState {
     pub command_timer: u8,
     pub state: u8,
     pub unk2: u8,
-    pub input_allow: u8,
+    pub input_allow: InputAllow,
     pub max_timer: u8,
     pub enable_timer: u8,
     pub lr: i8,
+}
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    pub struct CommandInputFlags: u32 {
+        const UP = 0b10;
+        const DOWN = 0b100;
+        const LEFT = 0b1000;
+        const RIGHT = 0b10000;
+
+        const UP_LEFT = 0b100000;
+        const DOWN_LEFT = 0b1000000;
+        const UP_RIGHT = 0b10000000;
+        const DOWN_RIGHT = 0b100000000;
+
+        const ATTACK_EDGE = 0b1000000000;
+        const SPECIAL_EDGE = 0b10000000000;
+        const GRAB_EDGE = 0b100000000000;
+
+        const ATTACK_PRESSING = 0b1000000000000;
+        const SPECIAL_PRESSING = 0b10000000000000;
+        const ATTACK_RAW_PRESSING = 0b100000000000000; // IDK CHIEF
+
+        const ANY_DIRECTION = 0x1FE;
+    }
+
+    #[derive(Debug, Copy, Clone)]
+    pub struct InputAllow: u8 {
+        const ATTACK = 0x1;
+        const SPECIAL = 0x2;
+        const UNK = 0x3;
+    }
+}
+
+impl CommandInputFlags {
+    pub fn back(&self, lr: f32) -> bool {
+        if lr < 0.0 {
+            self.intersects(Self::RIGHT)
+        } else {
+            self.intersects(Self::LEFT)
+        }
+    }
+
+    pub fn back_down(&self, lr: f32) -> bool {
+        if lr < 0.0 {
+            self.intersects(Self::DOWN_RIGHT)
+        } else {
+            self.intersects(Self::DOWN_LEFT)
+        }
+    }
+
+    pub fn back_up(&self, lr: f32) -> bool {
+        if lr < 0.0 {
+            self.intersects(Self::UP_RIGHT)
+        } else {
+            self.intersects(Self::UP_LEFT)
+        }
+    }
+
+    pub fn front(&self, lr: f32) -> bool {
+        if lr > 0.0 {
+            self.intersects(Self::RIGHT)
+        } else {
+            self.intersects(Self::LEFT)
+        }
+    }
+
+    pub fn front_down(&self, lr: f32) -> bool {
+        if lr > 0.0 {
+            self.intersects(Self::DOWN_RIGHT)
+        } else {
+            self.intersects(Self::DOWN_LEFT)
+        }
+    }
+
+    pub fn front_up(&self, lr: f32) -> bool {
+        if lr > 0.0 {
+            self.intersects(Self::UP_RIGHT)
+        } else {
+            self.intersects(Self::UP_LEFT)
+        }
+    }
+
+    pub fn up(&self) -> bool {
+        self.intersects(Self::UP)
+    }
+
+    pub fn down(&self) -> bool {
+        self.intersects(Self::DOWN)
+    }
+
+    pub fn left(&self) -> bool {
+        self.intersects(Self::LEFT)
+    }
+
+    pub fn right(&self) -> bool {
+        self.intersects(Self::RIGHT)
+    }
+
+    pub fn up_right(&self) -> bool {
+        self.intersects(Self::UP_RIGHT)
+    }
+
+    pub fn up_left(&self) -> bool {
+        self.intersects(Self::UP_LEFT)
+    }
+
+    pub fn down_right(&self) -> bool {
+        self.intersects(Self::DOWN_RIGHT)
+    }
+
+    pub fn down_left(&self) -> bool {
+        self.intersects(Self::DOWN_LEFT)
+    }
+}
+
+impl InputAllow {
+    pub fn check(&self, inputs: &CommandInputFlags) -> bool {
+        let mut input = false;
+        if self.intersects(Self::ATTACK) && inputs.intersects(CommandInputFlags::ATTACK_EDGE) {
+            input |= true;
+        }
+
+        if self.intersects(Self::SPECIAL) && inputs.intersects(CommandInputFlags::SPECIAL_EDGE) {
+            input |= true;
+        }
+
+        input
+    }
 }

--- a/fighters/common/src/function_hooks/command/c_323_catch.rs
+++ b/fighters/common/src/function_hooks/command/c_323_catch.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[skyline::hook(offset = 0x6c0df0)]
+unsafe extern "C" fn c_323_catch(
+    class: &mut CommandInputState,
+    args: *const CommandInputFlags,
+    lr: f32
+) -> bool {
+    let data = *args.add(2);
+    if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+        if class.state != 0 {
+            if class.unk2 != 0 {
+                class.command_timer = 0;
+                class.state = 0;
+                return false;
+            }
+        }
+    }
+
+    match class.state {
+        0 => {
+            if data.front_down(lr) {
+                class.state = 1;
+                class.lr = lr as i8;
+            }
+            else if data.back_down(lr) {
+                class.state = 1;
+                class.lr = -lr as i8;
+            }
+            false
+        }
+        1 => {
+            if data.down() {
+                class.state = 2;
+                class.command_timer = 0;
+            }
+            false
+        }
+        2 => {
+            if data.front_down(class.lr as f32) {
+                class.state = 3;
+                class.command_timer = 0;
+            }
+
+            false
+        }
+        3 => {
+            if data.intersects(CommandInputFlags::GRAB_EDGE) {
+                println!("grab");
+                return true;
+            }
+
+            false
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        c_323_catch
+    );
+}

--- a/fighters/common/src/function_hooks/command/c_623_a.rs
+++ b/fighters/common/src/function_hooks/command/c_623_a.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+#[skyline::hook(offset = 0x6bf210)]
+unsafe extern "C" fn c_623_a(
+    class: &mut CommandInputState,
+    args: *const CommandInputFlags,
+    lr: f32
+) -> bool {
+    let data = *args.add(2);
+    if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+        if class.state != 0 {
+            if class.unk2 != 0 {
+                class.command_timer = 0;
+                class.state = 0;
+                return false;
+            }
+        }
+    }
+
+    match class.state {
+        0 => {
+            if data.front_down(lr) || data.front(lr) {
+                class.state = 2;
+                class.lr = lr as i8;
+            }
+            else if data.back_down(lr) || data.back(lr) {
+                class.state = 2;
+                class.lr = -lr as i8;
+            }
+            false
+        }
+        1 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+            if data.front_down(class.lr as f32) || data.front(class.lr as f32) {
+                class.state = 2;
+                class.command_timer = 0;
+            }
+            false
+        }
+        2 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            // impossible check?
+            if data.back_down(class.lr as f32) {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+                class.state = 1;
+            }
+
+            false
+        }
+        3 => {
+            if data.front(class.lr as f32) || data.front_down(class.lr as f32) || data.front_up(class.lr as f32) {
+                class.command_timer = 0;
+                class.state = 4;
+            }
+
+            false
+        }
+        4 => {
+            let check_flag = if !class.input_allow.bits() & 3 == 0 {
+                CommandInputFlags::ATTACK_EDGE | CommandInputFlags::SPECIAL_EDGE
+            }
+            else {
+                if class.input_allow.intersects(InputAllow::ATTACK) {
+                    CommandInputFlags::ATTACK_EDGE
+                }
+                else {
+                    CommandInputFlags::SPECIAL_EDGE
+                }
+            };
+            if data.intersects(check_flag) {
+                return true;
+            }
+
+            false
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        c_623_a
+    );
+}

--- a/fighters/common/src/function_hooks/command/c_623_ab_long.rs
+++ b/fighters/common/src/function_hooks/command/c_623_ab_long.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+#[skyline::hook(offset = 0x6c0480)]
+unsafe extern "C" fn c_623_ab_long(
+    class: &mut CommandInputState,
+    args: *const CommandInputFlags,
+    lr: f32
+) -> bool {
+    let data = *args.add(2);
+    if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+        if class.state != 0 {
+            if class.unk2 != 0 {
+                class.command_timer = 0;
+                class.state = 0;
+                return false;
+            }
+        }
+    }
+
+    match class.state {
+        0 => {
+            if data.front_down(lr) || data.front(lr) {
+                class.state = 2;
+                class.lr = lr as i8;
+            }
+            else if data.back_down(lr) || data.back(lr) {
+                class.state = 2;
+                class.lr = -lr as i8;
+            }
+            false
+        }
+        1 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+            if data.front_down(class.lr as f32) || data.front(class.lr as f32) {
+                class.state = 2;
+                class.command_timer = 0;
+            }
+            false
+        }
+        2 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            // impossible check?
+            if data.back_down(class.lr as f32) {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+                class.state = 1;
+            }
+            false
+        }
+        3 => {
+            if data.front_down(class.lr as f32) || data.front_up(class.lr as f32) || data.front(class.lr as f32) {
+                class.state = 4;
+                class.command_timer = 0;
+            }
+
+            false
+        }
+        4 => {
+            let check_flag = if !class.input_allow.bits() & 3 == 0 {
+                CommandInputFlags::ATTACK_EDGE | CommandInputFlags::SPECIAL_EDGE
+            }
+            else {
+                if class.input_allow.intersects(InputAllow::ATTACK) {
+                    CommandInputFlags::ATTACK_EDGE
+                }
+                else {
+                    CommandInputFlags::SPECIAL_EDGE
+                }
+            };
+            if data.intersects(check_flag) {
+                class.state = 5;
+                class.command_timer = 0;
+                class.enable_timer = 1;
+                class.lr = (data.bits() >> 10 & 1) as i8; // it just reuses this???
+            }
+
+            false
+        }
+        5 => {
+            let check = if class.lr == 0 {
+                0xc
+            }
+            else {
+                0xd
+            };
+            if data.bits() >> check & 1 == 0 {
+                class.state = 0;
+                class.command_timer = 0;
+                return false;
+            }
+
+            let count = class.enable_timer;
+            class.enable_timer = count + 1;
+            class.command_timer = 0;
+
+            if class.unk2 <= count {
+                return true;
+            }
+
+            false
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        c_623_ab_long
+    );
+}

--- a/fighters/common/src/function_hooks/command/c_623_nb.rs
+++ b/fighters/common/src/function_hooks/command/c_623_nb.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+#[skyline::hook(offset = 0x6c0120)]
+unsafe extern "C" fn c_623_nb(
+    class: &mut CommandInputState,
+    args: *const CommandInputFlags,
+    lr: f32
+) -> bool {
+    let data = *args.add(2);
+    if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+        if class.state != 0 {
+            if class.unk2 != 0 {
+                class.command_timer = 0;
+                class.state = 0;
+                return false;
+            }
+        }
+    }
+
+    match class.state {
+        0 => {
+            if data.front_down(lr) || data.front(lr) {
+                class.state = 2;
+                class.lr = lr as i8;
+            }
+            else if data.back_down(lr) || data.back(lr) {
+                class.state = 2;
+                class.lr = -lr as i8;
+            }
+            false
+        }
+        1 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+            if data.front_down(class.lr as f32) || data.front(class.lr as f32) {
+                class.state = 2;
+                class.command_timer = 0;
+            }
+            false
+        }
+        2 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            // impossible check?
+            if data.back_down(class.lr as f32) {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+                class.state = 1;
+            }
+            false
+        }
+        3 => data.front(class.lr as f32) || data.front_up(class.lr as f32) || data.front_down(class.lr as f32),
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        c_623_nb
+    );
+}

--- a/fighters/common/src/function_hooks/command/c_623_strict.rs
+++ b/fighters/common/src/function_hooks/command/c_623_strict.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+#[skyline::hook(offset = 0x6c0270)]
+unsafe extern "C" fn c_623_strict(
+    class: &mut CommandInputState,
+    args: *const CommandInputFlags,
+    lr: f32
+) -> bool {
+    let data = *args.add(2);
+    if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+        if class.state != 0 {
+            if class.unk2 != 0 {
+                class.command_timer = 0;
+                class.state = 0;
+                return false;
+            }
+        }
+    }
+
+    match class.state {
+        0 => {
+            if data.front_down(lr) || data.front(lr) {
+                class.state = 2;
+                class.lr = lr as i8;
+            }
+            else if data.back_down(lr) || data.back(lr) {
+                class.state = 2;
+                class.lr = -lr as i8;
+            }
+            false
+        }
+        1 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+            if data.front_down(class.lr as f32) || data.front(class.lr as f32) {
+                class.state = 2;
+                class.command_timer = 0;
+            }
+            false
+        }
+        2 => {
+            if data.down() {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            // impossible check?
+            if data.back_down(class.lr as f32) {
+                class.state = 3;
+                class.command_timer = 0;
+                return false;
+            }
+
+            if data.bits() & 1 == 0 {
+                if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+                    class.state = 1;
+                }
+            }
+            false
+        }
+        3 => {
+            if data.front_down(class.lr as f32) {
+                let mut check_flag = CommandInputFlags::SPECIAL_EDGE;
+                if class.input_allow.intersects(InputAllow::ATTACK) {
+                    check_flag = CommandInputFlags::ATTACK_EDGE;
+                }
+                let mut check_flag2 = CommandInputFlags::ATTACK_EDGE | CommandInputFlags::SPECIAL_EDGE;
+                if !class.input_allow.bits() & 3 != 0 {
+                    check_flag2 = check_flag;
+                }
+                if !data.intersects(check_flag2) {
+                    class.state = 4;
+                    class.command_timer = 0;
+                    return false;
+                }
+                return true;
+            }
+
+            if !data.intersects(CommandInputFlags::ANY_DIRECTION) {
+                return false;
+            }
+
+            if data.bits() >> 2 & 1 != 0 {
+                return false;
+            }
+
+            if data.back_down(class.lr as f32) {
+                return false;
+            }
+
+            class.command_timer = 0;
+            class.state = 0;
+            false
+        }
+        4 => {
+            if data.front_down(class.lr as f32) {
+                let mut check_flag = CommandInputFlags::SPECIAL_EDGE;
+                if class.input_allow.intersects(InputAllow::ATTACK) {
+                    check_flag = CommandInputFlags::ATTACK_EDGE;
+                }
+                let mut check_flag2 = CommandInputFlags::ATTACK_EDGE | CommandInputFlags::SPECIAL_EDGE;
+                if !class.input_allow.bits() & 3 != 0 {
+                    check_flag2 = check_flag;
+                }
+                if !data.intersects(check_flag2) {
+                    class.state = 4;
+                    class.command_timer = 0;
+                    return false;
+                }
+                return true;
+            }
+
+            class.command_timer = 0;
+            class.state = 0;
+            false
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        c_623_strict
+    );
+}

--- a/fighters/common/src/function_hooks/command/mod.rs
+++ b/fighters/common/src/function_hooks/command/mod.rs
@@ -4,10 +4,12 @@ mod c_623_nb;
 mod c_623_strict;
 mod c_623_ab_long;
 mod c_623_a;
+mod c_323_catch;
 
 pub fn install() {
     c_623_nb::install();
     c_623_strict::install();
     c_623_ab_long::install();
     c_623_a::install();
+    c_323_catch::install();
 }

--- a/fighters/common/src/function_hooks/command/mod.rs
+++ b/fighters/common/src/function_hooks/command/mod.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+mod c_623_nb;
+mod c_623_strict;
+mod c_623_ab_long;
+mod c_623_a;
+
+pub fn install() {
+    c_623_nb::install();
+    c_623_strict::install();
+    c_623_ab_long::install();
+    c_623_a::install();
+}

--- a/fighters/common/src/function_hooks/mod.rs
+++ b/fighters/common/src/function_hooks/mod.rs
@@ -27,6 +27,7 @@ mod fighterspecializer;
 mod fighter_util;
 mod vtables;
 mod item;
+mod command;
 
 #[repr(C)]
 pub struct TempModule {
@@ -878,6 +879,7 @@ pub fn install() {
     fighter_util::install();
     vtables::install();
     item::install();
+    command::install();
 
     unsafe {
         // Handles getting rid of the kill zoom

--- a/fighters/demon/src/opff.rs
+++ b/fighters/demon/src/opff.rs
@@ -43,7 +43,7 @@ unsafe fn fastfall_specials(fighter: &mut L2CFighterCommon) {
         *FIGHTER_DEMON_STATUS_KIND_SPECIAL_S_AIR_END,
         *FIGHTER_DEMON_STATUS_KIND_SPECIAL_HI_RISE,
         *FIGHTER_DEMON_STATUS_KIND_SPECIAL_HI_FALL,
-        ]) 
+        ])
     && fighter.is_situation(*SITUATION_KIND_AIR) {
         fighter.sub_air_check_dive();
     }
@@ -57,7 +57,8 @@ unsafe fn camera_lockout(fighter: &mut L2CFighterCommon) {
 unsafe fn check_step_cancel(fighter: &mut L2CFighterCommon) {
     if VarModule::is_flag(fighter.battle_object, vars::demon::status::ENABLE_STEP_CANCEL)
     && !fighter.global_table[IS_STOPPING].get_bool() {
-        if fighter.is_cat_flag(Cat4::Command623NB) {
+        if fighter.is_cat_flag(Cat4::Command623NB)
+        && ControlModule::get_special_command_lr(fighter.module_accessor, *FIGHTER_PAD_CMD_CAT4_COMMAND_623NB) == PostureModule::lr(fighter.module_accessor) {
             fighter.change_status(statuses::demon::CANCEL_STEP.into(), false.into());
         }
     }


### PR DESCRIPTION
# Changelog

## Kazuya

- The following inputs can now be performed *backwards* to make Kazuya immediately turn around before performing them:
  - Crouch Dash (623)
  - Wind God Fist / Electric Wind God Fist (623A)
  - Dragon Uppercut (623[A])
  - Spinning Demon to Left Hook (623B)
  - Hell's Gate (323 Grab)

After removing autoturn, it seemed necessary to allow these inputs instead of forcing the player to turn around manually first.

Step Cancel still must be performed in the same direction as Kazuya is currently facing.