### PR TITLE
DPit Orbitar Touchups

### DIFF
--- a/dynamic/src/consts.rs
+++ b/dynamic/src/consts.rs
@@ -1610,8 +1610,11 @@ pub mod vars {
 
     pub mod pitb {
         pub mod instance {
+            // ints
+            pub const SPECIAL_LW_SITUATION_START: i32 = 0x0100;
+
             // flags
-            pub const SPECIAL_LW_DISABLE_LC: i32 = 0x0100;
+            pub const SPECIAL_LW_ENABLE_CANCEL: i32 = 0x0100;
             pub const SPECIAL_LW_DISABLE_STALL: i32 = 0x0101;
         }
     }

--- a/fighters/pitb/src/acmd/ground.rs
+++ b/fighters/pitb/src/acmd/ground.rs
@@ -8,9 +8,9 @@ unsafe extern "C" fn game_attack11(agent: &mut L2CAgentBase) {
     frame(lua_state, 5.0);
     FT_MOTION_RATE_RANGE(agent, 5.0, 5.5, 1.0);
     if is_excute(agent) {
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 0, bone: "armr", dmg: 3.0, angle: 80, kbg: 40, bkb: 10, size: 3.0, x: 2.0, y: 0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 1, bone: "bowr", dmg: 3.0, angle: 80, kbg: 40, bkb: 10, size: 3.0, x: 0.0, y: 2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 2, bone: "bowr", dmg: 3.0, angle: 80, kbg: 40, bkb: 10, size: 3.0, x: 0.0, y: 7.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 0, bone: "armr", dmg: 3.0, angle: 74, kbg: 60, bkb: 20, size: 3.0, x: 2.0, y: 0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 1, bone: "bowr", dmg: 3.0, angle: 74, kbg: 60, bkb: 20, size: 3.0, x: 0.0, y: 2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 2, bone: "bowr", dmg: 3.0, angle: 74, kbg: 60, bkb: 20, size: 3.0, x: 0.0, y: 7.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
         // Jab lock hitboxes
         hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 3, bone: "armr", dmg: 3.0, angle: 361, kbg: 15, bkb: 30, size: 3.0, x: 2.0, y: 0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::G, });
         hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 4, bone: "bowr", dmg: 3.0, angle: 361, kbg: 15, bkb: 30, size: 3.0, x: 0.0, y: 2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::G, });
@@ -49,12 +49,16 @@ unsafe extern "C" fn effect_attack11(agent: &mut L2CAgentBase) {
 unsafe extern "C" fn game_attack12(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
+    frame(lua_state, 1.0);
+    FT_MOTION_RATE_RANGE(agent, 1.0, 4.0, 1.0);
+    frame(lua_state, 4.0);
+    FT_MOTION_RATE(agent, 1.0);
     frame(lua_state, 5.0);
     FT_MOTION_RATE_RANGE(agent, 5.0, 5.5, 1.0);
     if is_excute(agent) {
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 0, bone: "arml", dmg: 3.0, angle:  60, kbg: 40, fkb: 70, bkb: 0, size: 3.0, x: 2.0, y:  0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 1, bone: "bowl", dmg: 3.0, angle:  90, kbg: 40, fkb: 70, bkb: 0, size: 3.2, x: 0.0, y: -2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
-        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 2, bone: "bowl", dmg: 3.0, angle: 145, kbg: 40, fkb: 85, bkb: 0, size: 3.2, x: 0.0, y: -7.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 0, bone: "arml", dmg: 3.0, angle: 80, kbg: 60, bkb: 20, size: 3.0, x: 2.0, y:  0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 1, bone: "bowl", dmg: 3.0, angle: 80, kbg: 60, bkb: 20, size: 3.2, x: 0.0, y: -2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
+        hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 2, bone: "bowl", dmg: 3.0, angle: 80, kbg: 60, bkb: 20, size: 3.2, x: 0.0, y: -7.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::GA_d, });
         // Jab lock hitboxes
         hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 3, bone: "arml", dmg: 3.0, angle: 361, kbg: 15, bkb: 30, size: 3.0, x: 2.0, y:  0.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::G, });
         hitbox!(agent, { extends: PITB_SWORD_HITBOX_S, id: 4, bone: "bowl", dmg: 3.0, angle: 361, kbg: 15, bkb: 30, size: 3.2, x: 0.0, y: -2.0, z: 0.0, facing: LrCheck::F, situation: CollisionSituation::G, });

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -154,11 +154,15 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     frame(lua_state, 6.9);
     FT_MOTION_RATE_RANGE(agent, 6.9, 7.0, 3.0);
     if is_excute(agent) {
-        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 24, kbg: 100, fkb: 40, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
+        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 24, kbg: 100, fkb: 60, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, situation: CollisionSituation::G, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
+        hitbox!(agent, { extends: BASE_HITBOX, id: 1, bone: "top", dmg: 5.0, angle: 44, kbg: 100, fkb: 60, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, situation: CollisionSituation::A, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
     }
     frame(lua_state, 6.933);
     if is_excute(agent) {
         AttackModule::clear_all(boma);
+        // enables slideoff
+        VarModule::on_flag(agent.battle_object, vars::pitb::instance::SPECIAL_LW_ENABLE_CANCEL);
+        agent.ground_correct_by_situation(*GROUND_CORRECT_KIND_GROUND, *GROUND_CORRECT_KIND_AIR);
     }
     frame(lua_state, 7.0);
     FT_MOTION_RATE(agent, 1.0);
@@ -198,6 +202,10 @@ unsafe extern "C" fn game_speciallwhold(agent: &mut L2CAgentBase) {
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 0, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 1, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
         VarModule::on_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
+        // enables slideoff
+        if agent.is_situation(*SITUATION_KIND_GROUND) {
+            CORRECT(agent, *GROUND_CORRECT_KIND_GROUND);
+        }
     }
 }
 

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -152,8 +152,7 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     frame(lua_state, 6.9);
     FT_MOTION_RATE_RANGE(agent, 6.9, 7.0, 3.0);
     if is_excute(agent) {
-        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 24, kbg: 100, fkb: 60, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, situation: CollisionSituation::G, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
-        hitbox!(agent, { extends: BASE_HITBOX, id: 1, bone: "top", dmg: 5.0, angle: 44, kbg: 100, fkb: 60, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, situation: CollisionSituation::A, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
+        hitbox!(agent, { extends: BASE_HITBOX, id: 0, bone: "top", dmg: 5.0, angle: 361, kbg: 100, fkb: 80, bkb: 0, set_weight: true, size: 7.5, x: 0.0, y: 7.0, z: -1.5, x2: 0.0, y2: 7.0, z2: 1.5, hitlag: 1.0, sdi: 1.15, clank: SetOff::Off, effect: "collision_attr_magic", sound_level: SoundLevel::M, hit_sound: CollisionSound::Magic, region: AttackRegion::None, });
     }
     frame(lua_state, 6.933);
     if is_excute(agent) {

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -203,9 +203,7 @@ unsafe extern "C" fn game_speciallwhold(agent: &mut L2CAgentBase) {
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 1, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
         VarModule::on_flag(agent.battle_object, vars::common::status::DISABLE_ECB_SHIFT);
         // enables slideoff
-        if agent.is_situation(*SITUATION_KIND_GROUND) {
-            CORRECT(agent, *GROUND_CORRECT_KIND_GROUND);
-        }
+        agent.ground_correct_by_situation(*GROUND_CORRECT_KIND_GROUND, *GROUND_CORRECT_KIND_AIR);
     }
 }
 

--- a/fighters/pitb/src/acmd/specials.rs
+++ b/fighters/pitb/src/acmd/specials.rs
@@ -144,13 +144,11 @@ unsafe extern "C" fn game_speciallwstart(agent: &mut L2CAgentBase) {
     let lua_state = agent.lua_state_agent;
     let boma = agent.boma();
     frame(lua_state, 1.0);
-    FT_MOTION_RATE_RANGE(agent, 1.0, 6.0, 3.0);
-    frame(lua_state, 6.0);
-    FT_MOTION_RATE_RANGE(agent, 6.0, 6.9, 1.0);
     if is_excute(agent) {
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 0, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
         shield!(agent, *MA_MSC_CMD_SHIELD_ON, *COLLISION_KIND_REFLECTOR, 1, *FIGHTER_PIT_REFLECTOR_GROUP_SPECIAL_LW);
     }
+    FT_MOTION_RATE_RANGE(agent, 1.0, 6.9, 1.0);
     frame(lua_state, 6.9);
     FT_MOTION_RATE_RANGE(agent, 6.9, 7.0, 3.0);
     if is_excute(agent) {

--- a/fighters/pitb/src/opff.rs
+++ b/fighters/pitb/src/opff.rs
@@ -10,48 +10,37 @@ unsafe fn bow_lc(boma: &mut BattleObjectModuleAccessor) {
     }
 }
 
-unsafe fn guardian_orbitar(fighter: &mut L2CFighterCommon) {
-    // happens on init
-    if fighter.is_status_one_of(&[
-        *FIGHTER_STATUS_KIND_SPECIAL_LW,
-    ])
-    && StatusModule::is_changing(fighter.module_accessor) {
-        if !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL) {
-            sv_kinetic_energy!(
-                set_speed,
-                fighter,
-                FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                0.0
-            );
-            sv_kinetic_energy!(
-                set_accel,
-                fighter,
-                FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
-                0.0
-            );
-        }
-        VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC);
-        VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL);
-    }
-
+unsafe fn dspecial_cancel(fighter: &mut L2CFighterCommon) {
     // happens on main for all statuses
     if fighter.is_status_one_of(&[
         *FIGHTER_STATUS_KIND_SPECIAL_LW,
         *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_HOLD,
         *FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END,
     ]) {
+        let situation_kind = fighter.global_table[SITUATION_KIND].get_i32();
+    
         // disable land cancel on parry
         if AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_PARRY) {
-            VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC);
+            // prevents slideoffs
+            VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_ENABLE_CANCEL);
+            fighter.ground_correct_by_situation(*GROUND_CORRECT_KIND_GROUND_CLIFF_STOP_ATTACK, *GROUND_CORRECT_KIND_AIR);
+
+            // ends the attack early
             if !fighter.is_status(*FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END)
             && !fighter.is_in_hitlag() {
                 fighter.change_status(FIGHTER_PIT_STATUS_KIND_SPECIAL_LW_END.into(), false.into());
             }
         }
 
-        // land cancel
-        if !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_LC) {
-            fighter.check_land_cancel(None);
+        // cancel the attack when situation changes
+        if situation_kind != VarModule::get_int(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_SITUATION_START)
+        && VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_ENABLE_CANCEL) {
+            if situation_kind == *SITUATION_KIND_GROUND {
+                // we don't use check_land_cancel because the transition is defered until the hitbox comes out
+                fighter.change_status(FIGHTER_STATUS_KIND_LANDING.into(), false.into());
+            } else {
+                fighter.change_status(FIGHTER_STATUS_KIND_FALL.into(), false.into());
+            }
         }
     }
 }
@@ -75,7 +64,7 @@ extern "Rust" {
 
 pub unsafe fn moveset(fighter: &mut L2CFighterCommon, boma: &mut BattleObjectModuleAccessor, id: usize, cat: [i32 ; 4], status_kind: i32, situation_kind: i32, motion_kind: u64, stick_x: f32, stick_y: f32, facing: f32, frame: f32) {
     bow_lc(boma);
-    guardian_orbitar(fighter);
+    dspecial_cancel(fighter);
     electroshock_land_cancel_on_hit(fighter);
     pits_common(fighter, boma, status_kind);
 }

--- a/fighters/pitb/src/status/mod.rs
+++ b/fighters/pitb/src/status/mod.rs
@@ -3,6 +3,7 @@ use globals::*;
 // status script import
 
 mod special_hi;
+mod special_lw;
 mod special_n;
 
 unsafe extern "C" fn change_status_callback(fighter: &mut L2CFighterCommon) -> L2CValue {
@@ -21,5 +22,6 @@ unsafe extern "C" fn on_start(fighter: &mut L2CFighterCommon) {
 pub fn install(agent: &mut Agent) {
     agent.on_start(on_start);
     special_hi::install(agent);
+    special_lw::install(agent);
     special_n::install(agent);
 }

--- a/fighters/pitb/src/status/special_lw.rs
+++ b/fighters/pitb/src/status/special_lw.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+// FIGHTER_STATUS_KIND_SPECIAL_LW
+
+unsafe extern "C" fn special_lw_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+
+    let ret = smashline::original_status(Main, fighter, *FIGHTER_STATUS_KIND_SPECIAL_LW)(fighter);
+
+    let situation_kind = fighter.global_table[SITUATION_KIND].get_i32();
+    VarModule::set_int(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_SITUATION_START, situation_kind);
+    VarModule::off_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_ENABLE_CANCEL);
+    if !VarModule::is_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL) {
+        sv_kinetic_energy!(
+            set_speed,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+            0.0
+        );
+        sv_kinetic_energy!(
+            set_accel,
+            fighter,
+            FIGHTER_KINETIC_ENERGY_ID_GRAVITY,
+            0.0
+        );
+    }
+    VarModule::on_flag(fighter.battle_object, vars::pitb::instance::SPECIAL_LW_DISABLE_STALL);
+
+    ret
+}
+
+pub fn install(agent: &mut Agent) {
+    agent.status(Main, *FIGHTER_STATUS_KIND_SPECIAL_LW, special_lw_main);
+}


### PR DESCRIPTION
## Dark Pit
### Jab 1

Adjusted the knockback of Jab 1/2 and the startup of Jab 2 to make the basic Jab string more reliable at mid to high percents

```diff
- [-] Angle: 80 -> 74
+ [+] KBG: 40 -> 60
+ [+] BKB: 10 -> 20
```
### Jab 2
```diff
+ [+] Active: F5-F6 -> F3-F4
- [-] Angle: 60/90/145 -> 80
~ [/] KBG: 40 -> 60
~ [/] FKB: 70/70/85 -> 0
~ [/] BKB: 0 -> 20
```

### Guardian Orbitars (Down Special)
```diff
! (!) Can now slide off of ledges, and ledgecancels when done so
~ (*) Fixed an issue where the attack could be land cancelled during the startup

+ [+] Startup (reflector): F4 -> F1
+ [+] Startup (attack): F5 -> F2

~ [/] Angle: 24 -> 361
# Less potent off-stage, but provides better combo potential on-stage

+ [+] FKB: 40 -> 80
# Now +10F on ASDI-down and +8F on true CC
```